### PR TITLE
Bind mount all of /dev in the devcontainer.

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -28,8 +28,7 @@
         }
     },
     "mounts": [
-        "type=bind,source=/dev/bus/usb,target=/dev/bus/usb",
-        "type=bind,source=/dev/ttyUSB0,target=/dev/ttyUSB0"
+        "type=bind,source=/dev,target=/dev"
     ],
     "privileged": true,
     "remoteUser": "vscode",


### PR DESCRIPTION
This way the devcontainer will start without error even if there is no
 /dev/ttyUSB0 device present, but it will still detect the device once
 it's plugged in.