### PR TITLE
Fix compatibility problems with python 3.12

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -1,6 +1,6 @@
 {
     "name": "Python 3",
-    "image": "mcr.microsoft.com/devcontainers/python:0-3.10-bullseye",
+    "image": "mcr.microsoft.com/devcontainers/python:3.12",
     "postCreateCommand": "scripts/setup",
     "customizations": {
         "vscode": {
@@ -37,6 +37,8 @@
         "dialout"
     ],
     "features": {
-        "ghcr.io/devcontainers/features/docker-in-docker:2": {}
+        "ghcr.io/devcontainers/features/docker-in-docker:2": {
+            "moby": false
+        }
     }
 }

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10"]
+        python-version: ["3.10", "3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v4

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,5 @@
 {
     "python.formatting.provider": "black",
-    "python.linting.pylintEnabled": true,
-    "python.linting.enabled": true,
     "python.pythonPath": "/usr/local/bin/python",
     "python.testing.pytestEnabled": true,
     "mos.port": "/dev/ttyUSB0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,11 +5,11 @@ build-backend = "setuptools.build_meta"
 [project]
 name            = "pytboss"
 # version         = "2023.4.0"
-description     = "Python library for interacting with Pitboss grills and smokers."
+description     = "Python library for interacting with PitBoss grills and smokers."
 authors         = [
     {name = "David Knowles", email = "dknowles2@gmail.com"},
 ]
-dependencies    = ["bleak", "bleak_retry_connector", "js2py"]
+dependencies    = ["bleak", "bleak_retry_connector", "dukpy"]
 requires-python = ">=3.10"
 dynamic         = ["readme", "version"]
 license         = {text = "Apache License 2.0"}
@@ -20,9 +20,9 @@ classifiers     = [
 ]
 
 [project.urls]
-"Homepage"      = "https://github.com/dknowles2/pyschlage"
-"Source Code"   = "https://github.com/dknowles2/pyschlage"
-"Bug Reports"   = "https://github.com/dknowles2/pyschlage/issues"
+"Homepage"      = "https://github.com/dknowles2/pytboss"
+"Source Code"   = "https://github.com/dknowles2/pytboss"
+"Bug Reports"   = "https://github.com/dknowles2/pytboss/issues"
 
 [tool.setuptools]
 platforms            = ["any"]

--- a/pytboss/api.py
+++ b/pytboss/api.py
@@ -194,7 +194,7 @@ class PitBoss:
             return
 
         async with self._lock:
-            self._state.update(state.to_dict())
+            self._state.update(state)
             # TODO: Run callbacks concurrently
             # TODO: Send copies of state so subscribers can't modify it
             for callback in self._state_callbacks:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 bleak==0.21.1
 bleak_retry_connector==3.4.0
-js2py==0.74
+dukpy==0.3.0

--- a/tests/test_ble.py
+++ b/tests/test_ble.py
@@ -2,6 +2,7 @@ import asyncio
 import json
 from unittest import mock
 
+import bleak
 from bleak_retry_connector import BleakClientWithServiceCache
 
 from pytboss import ble
@@ -29,19 +30,13 @@ async def test_connect_disconnect(
 
 
 @mock.patch("bleak_retry_connector.establish_connection")
-@mock.patch("bleak.BleakClient", spec=True)
-@mock.patch("bleak.BleakClient", spec=True)
-@mock.patch("bleak.BLEDevice", spec=True)
-@mock.patch("bleak.BLEDevice", spec=True)
-async def test_reset_device(
-    mock_old_device,
-    mock_new_device,
-    mock_old_bleak_client,
-    mock_new_bleak_client,
-    mock_establish_connection,
-):
+async def test_reset_device(mock_establish_connection):
+    mock_old_device = mock.create_autospec(bleak.BLEDevice)
+    mock_new_device = mock.create_autospec(bleak.BLEDevice)
     mock_old_device.name = "OLD DEVICE NAME"
     mock_new_device.name = "NEW DEVICE NAME"
+    mock_old_bleak_client = mock.create_autospec(bleak.BleakClient)
+    mock_new_bleak_client = mock.create_autospec(bleak.BleakClient)
     mock_establish_connection.return_value = mock_old_bleak_client
 
     conn = ble.BleConnection(mock_old_device)
@@ -75,19 +70,13 @@ async def test_reset_device(
 
 
 @mock.patch("bleak_retry_connector.establish_connection")
-@mock.patch("bleak.BleakClient", spec=True)
-@mock.patch("bleak.BleakClient", spec=True)
-@mock.patch("bleak.BLEDevice", spec=True)
-@mock.patch("bleak.BLEDevice", spec=True)
-async def test_reset_device_with_debug_log_subscription(
-    mock_old_device,
-    mock_new_device,
-    mock_old_bleak_client,
-    mock_new_bleak_client,
-    mock_establish_connection,
-):
+async def test_reset_device_with_debug_log_subscription(mock_establish_connection):
+    mock_old_device = mock.create_autospec(bleak.BLEDevice)
+    mock_new_device = mock.create_autospec(bleak.BLEDevice)
     mock_old_device.name = "OLD DEVICE NAME"
     mock_new_device.name = "NEW DEVICE NAME"
+    mock_old_bleak_client = mock.create_autospec(bleak.BleakClient)
+    mock_new_bleak_client = mock.create_autospec(bleak.BleakClient)
     mock_establish_connection.return_value = mock_old_bleak_client
 
     conn = ble.BleConnection(mock_old_device)


### PR DESCRIPTION
This fixes numerous problems with the upgrade to python 3.12, as first reported in https://github.com/dknowles2/ha-pitboss/issues/42

* Update the devcontainer to use python 3.12
* Replace js2py with dukpy: js2py doesn't work with python 3.12, and seems to be unmaintained
* Fix some tests that were injecting mocks incorrectly
* Update github actions to test against python 3.11 and 3.12