### PR TITLE
Stop doing unit conversion for temperature readings

### DIFF
--- a/tests/test_grills.py
+++ b/tests/test_grills.py
@@ -25,7 +25,7 @@ TEMPERATURE_FIELDS = (
 )
 
 
-def f_to_c(temp: int | None) -> int | None:
+def f_to_c(temp: int) -> int:
     """Converts a temperature from Fahrenheit to Celsius."""
     if temp is None:
         return temp


### PR DESCRIPTION
Grills that lack an `fToC` function in their JS snippets seem to perform the unit conversion within the control board. So there's no need for us to perform an additional conversion.

This should address the latest comments in https://github.com/dknowles2/ha-pitboss/issues/52