### PR TITLE
Remove the WSMsgType.CLOSE check

### DIFF
--- a/pytboss/wss.py
+++ b/pytboss/wss.py
@@ -9,7 +9,6 @@ from uuid import uuid4
 from aiohttp import (
     ClientSession,
     ClientWebSocketResponse,
-    WSMsgType,
     WSServerHandshakeError,
 )
 
@@ -96,9 +95,6 @@ class WebSocketConnection(Transport):
             async with self._sock:
                 _LOGGER.debug("Waiting for payloads")
                 async for msg in self._sock:
-                    if msg.type == WSMsgType.CLOSE:
-                        _LOGGER.debug("Socket closed: %s", msg.data)
-                        break
                     payload = msg.json()
                     _LOGGER.debug("WSS payload: %s", payload)
                     await self._handle_message(payload)


### PR DESCRIPTION
This is already handled by `ClientWegSocketResponse.__anext__()`