### PR TITLE
Pass both state payloads to the callback

### DIFF
--- a/pytboss/api.py
+++ b/pytboss/api.py
@@ -94,6 +94,7 @@ class PitBoss:
 
         if not state:
             # Unknown or invalid payload; ignore.
+            _LOGGER.debug("Could not parse state payload: %s", payload)
             return
 
         async with self._lock:

--- a/pytboss/api.py
+++ b/pytboss/api.py
@@ -83,18 +83,27 @@ class PitBoss:
         async with self._lock:
             self._vdata_callbacks.append(callback)
 
-    async def _on_state_received(self, payload: str):
-        _LOGGER.debug("State received: %s", payload)
-        state = None
-        match payload[:4]:
-            case "FE0B":
-                state = self.spec.control_board.parse_status(payload)
-            case "FE0C":
-                state = self.spec.control_board.parse_temperatures(payload)
+    async def _on_state_received(
+        self, status_payload: str | None, temperatures_payload: str | None
+    ) -> None:
+        _LOGGER.debug(
+            "State received: status=%s, temperatures=%s",
+            status_payload,
+            temperatures_payload,
+        )
+        state = StateDict()
+        if status_payload:
+            if new_state := self.spec.control_board.parse_status(status_payload):
+                state.update(new_state)
+        if temperatures_payload:
+            if new_state := self.spec.control_board.parse_temperatures(
+                temperatures_payload
+            ):
+                state.update(new_state)
 
         if not state:
             # Unknown or invalid payload; ignore.
-            _LOGGER.debug("Could not parse state payload: %s", payload)
+            _LOGGER.debug("Could not parse state payload")
             return
 
         async with self._lock:

--- a/pytboss/transport.py
+++ b/pytboss/transport.py
@@ -11,7 +11,7 @@ from mypy_extensions import DefaultNamedArg
 
 from .exceptions import RPCError
 
-RawStateCallback = Callable[[str], Awaitable[None]]
+RawStateCallback = Callable[[str | None, str | None], Awaitable[None]]
 RawVDataCallback = Callable[[str], Awaitable[None]]
 SendCommandFn = Callable[
     [str, dict[Any, Any], DefaultNamedArg(float | None, "timeout")],

--- a/pytboss/wss.py
+++ b/pytboss/wss.py
@@ -125,6 +125,7 @@ class WebSocketConnection(Transport):
             if not self._state_callback:
                 return
             for state in payload["status"]:
+                _LOGGER.debug("Calling state callback for %s", state)
                 await self._state_callback(state)
             return
 

--- a/pytboss/wss.py
+++ b/pytboss/wss.py
@@ -124,9 +124,7 @@ class WebSocketConnection(Transport):
         if "status" in payload:
             if not self._state_callback:
                 return
-            for state in payload["status"]:
-                _LOGGER.debug("Calling state callback for %s", state)
-                await self._state_callback(state)
+            await self._state_callback(*payload["status"])
             return
 
         if "id" in payload:
@@ -150,4 +148,4 @@ class WebSocketConnection(Transport):
         if self._sock is None:
             raise NotConnectedError
         async with self._sock_lock:
-            await self._sock.send_json(cmd)
+            await self._sock.send_json(cmd)  # type: ignore

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -49,7 +49,7 @@ class TestApi:
             "FE 0B 01 06 05 01 09 01 01 09 02 09 06 00 09 06 00 02 02 00 02 02 "
             "05 01 01 00 00 00 00 00 00 00 00 00 01 01 01 00 01 01 04 0C 3B 1F"
         ).split()
-        await pitboss._on_state_received("".join(data))
+        await pitboss._on_state_received("".join(data), None)
 
         assert status == {
             "p1Target": 165,
@@ -91,7 +91,7 @@ class TestApi:
             "FE 0C 01 07 00 01 05 00 01 06 05 09 06 00 "
             "09 06 00 02 02 00 02 02 05 02 02 00 01"
         ).split()
-        await pitboss._on_state_received("".join(data))
+        await pitboss._on_state_received(None, "".join(data))
         assert status == {
             "p1Target": 170,
             "p1Temp": 150,

--- a/tests/test_ble.py
+++ b/tests/test_ble.py
@@ -94,9 +94,9 @@ async def test_subscribe_debug_logs(
     conn.set_state_callback(state_cb)
     await conn.connect()
 
-    state_data = bytearray("<==PB: STATE [5]".encode("utf-8"))
+    state_data = bytearray("<==PB: FE0B.STATE [10]".encode("utf-8"))
     await conn._on_debug_log_received(None, state_data)
-    state_cb.assert_awaited_once_with("STATE")
+    state_cb.assert_awaited_once_with("FE0B.STATE", None)
 
 
 @mock.patch("bleak_retry_connector.establish_connection")


### PR DESCRIPTION
This removes the need to call the callback twice in the WebSocket transport.