### PR TITLE
Stop closing externally provided session.

### DIFF
--- a/tests/test_wss.py
+++ b/tests/test_wss.py
@@ -217,3 +217,33 @@ async def test_command_wrong_app_id(
 
     state_callback.assert_not_awaited()
     vdata_callback.assert_not_awaited()
+
+
+async def test_external_session_not_closed():
+    """Test that external sessions are not closed when disconnect is called."""
+    # Create an external session
+    external_session = ClientSession()
+    
+    # Create a connection with the external session
+    conn = wss.WebSocketConnection("_grill_id_", session=external_session)
+    
+    # Disconnect should not close the external session
+    await conn.disconnect()
+    
+    # The external session should still be open
+    assert not external_session.closed
+    
+    # Clean up
+    await external_session.close()
+
+
+async def test_internal_session_closed():
+    """Test that internal sessions are closed when disconnect is called."""
+    # Create a connection without providing a session (it will create its own)
+    conn = wss.WebSocketConnection("_grill_id_")
+    
+    # Disconnect should close the internal session
+    await conn.disconnect()
+    
+    # The internal session should be closed
+    assert conn._session.closed


### PR DESCRIPTION
This PR improves the management of `ClientSession` ownership in the `WebSocketConnection` class and adds corresponding tests to ensure correct resource cleanup behaviour. The main focus is to prevent closing externally provided sessions and to guarantee internally created sessions are properly closed. For example, I was seeing this warning in HomeAssistant when using the `ha-pitboss` integration: 
```
Detected that custom integration 'pitboss' closes the Home Assistant aiohttp session at 
custom_components/pitboss/__init__.py, line 120: await conn.disconnect(). 
Please create a bug report at https://github.com/dknowles2/ha-pitboss/issues
```