### PR TITLE
Fix PBV3 M BLE payloads being silently dropped

### DIFF
--- a/pytboss/ble.py
+++ b/pytboss/ble.py
@@ -147,17 +147,21 @@ class BleConnection(Transport):
     ):
         _LOGGER.debug("Debug log received: %s", data)
         parts = data.decode("utf-8").split()
-        if len(parts) != 3:
+        if len(parts) == 3:
+            head, payload, tail = parts
+            checksum = int(tail[1 : len(tail) - 1])  # noqa: E203
+            if len(payload) != checksum:
+                # Bad payload; ignore.
+                _LOGGER.debug(
+                    "Ignoring message with bad checksum (%d != %d)",
+                    len(payload),
+                    checksum,
+                )
+                return
+        elif len(parts) == 2:
+            head, payload = parts
+        else:
             # Unknown payload; ignore.
-            return
-
-        head, payload, tail = parts
-        checksum = int(tail[1 : len(tail) - 1])  # noqa: E203
-        if len(payload) != checksum:
-            # Bad payload; ignore.
-            _LOGGER.debug(
-                "Ignoring message with bad checksum (%d != %d)", len(payload), checksum
-            )
             return
         if head == "<==PB:" and self._state_callback:
             status_payload = temperatures_payload = None

--- a/tests/test_ble.py
+++ b/tests/test_ble.py
@@ -102,6 +102,40 @@ async def test_subscribe_debug_logs(
 @mock.patch("bleak_retry_connector.establish_connection")
 @mock.patch("bleak.BleakClient", spec=True)
 @mock.patch("bleak.BLEDevice", spec=True)
+async def test_subscribe_debug_logs_pbv3m(
+    mock_device, mock_bleak_client, mock_establish_connection
+):
+    mock_establish_connection.return_value = mock_bleak_client
+
+    conn = ble.BleConnection(mock_device)
+    state_cb = mock.AsyncMock()
+    conn.set_state_callback(state_cb)
+    await conn.connect()
+
+    # PBV3 M payloads have no checksum suffix — only 2 whitespace-separated parts.
+    state_data = bytearray(
+        b"<==PB:  FE0B020205090600090600090600000000000802000802010200000000000000000000000000000100000000FF"
+    )
+    await conn._on_debug_log_received(None, state_data)
+    state_cb.assert_awaited_once_with(
+        "FE0B020205090600090600090600000000000802000802010200000000000000000000000000000100000000FF",
+        None,
+    )
+
+    state_cb.reset_mock()
+    temp_data = bytearray(
+        b"<==PB:  FE0C02020509060009060009060000000000080201030000080201FF"
+    )
+    await conn._on_debug_log_received(None, temp_data)
+    state_cb.assert_awaited_once_with(
+        None,
+        "FE0C02020509060009060009060000000000080201030000080201FF",
+    )
+
+
+@mock.patch("bleak_retry_connector.establish_connection")
+@mock.patch("bleak.BleakClient", spec=True)
+@mock.patch("bleak.BLEDevice", spec=True)
 async def test_send_command(mock_device, mock_bleak_client, mock_establish_connection):
     mock_establish_connection.return_value = mock_bleak_client
     loop = asyncio.get_running_loop()


### PR DESCRIPTION
## Summary

- PBV3 M devices send BLE debug log payloads with only 2 whitespace-separated parts (no checksum suffix)
- The existing code required exactly 3 parts, silently discarding all PBV3 M messages
- This prevented any state callbacks from firing for PBV3 M devices

## Changes

Updated `_on_debug_log_received` in [pytboss/ble.py](pytboss/ble.py) to handle both payload formats:
- **3 parts** (`<head> <payload> {checksum}`): existing behavior, checksum validated
- **2 parts** (`<head> <payload>`): new — checksum validation skipped, payload processed normally
- **anything else**: ignored as before

Fixes #421