### PR TITLE
Fix _reconnecting flag leak in reset_device() on connection failure

### DIFF
--- a/pytboss/ble.py
+++ b/pytboss/ble.py
@@ -106,11 +106,13 @@ class BleConnection(Transport):
         """
         self._reconnecting = True
         _LOGGER.debug("Resetting device to: %s", ble_device)
-        await self.disconnect()
-        self._is_connected = False
-        self._ble_device = ble_device
-        await self.connect()
-        self._reconnecting = False
+        try:
+            await self.disconnect()
+            self._is_connected = False
+            self._ble_device = ble_device
+            await self.connect()
+        finally:
+            self._reconnecting = False
 
     def is_connected(self) -> bool:
         """Whether the device is currently connected."""

--- a/tests/test_ble.py
+++ b/tests/test_ble.py
@@ -82,6 +82,42 @@ async def test_reset_device(mock_establish_connection):
 
 
 @mock.patch("bleak_retry_connector.establish_connection")
+async def test_reset_device_connect_failure_resets_reconnecting_flag(
+    mock_establish_connection,
+):
+    """Regression test: _reconnecting must be reset to False even if connect() fails.
+
+    Before this fix, if establish_connection() raised during reset_device(),
+    _reconnecting would be stuck at True, silently suppressing the
+    disconnect_callback on any subsequent disconnection event.
+    """
+    mock_old_device = mock.create_autospec(bleak.BLEDevice)
+    mock_new_device = mock.create_autospec(bleak.BLEDevice)
+    mock_old_device.name = "OLD DEVICE NAME"
+    mock_new_device.name = "NEW DEVICE NAME"
+    mock_old_bleak_client = mock.create_autospec(bleak.BleakClient)
+    mock_establish_connection.return_value = mock_old_bleak_client
+
+    disconnect_callback = mock.Mock()
+    conn = ble.BleConnection(mock_old_device, disconnect_callback=disconnect_callback)
+    await conn.connect()
+
+    # Simulate establish_connection failing during the reset (e.g. out of BLE slots)
+    mock_establish_connection.side_effect = Exception("No connection slots available")
+
+    try:
+        await conn.reset_device(mock_new_device)
+    except Exception:
+        pass
+
+    # _reconnecting must be False so future disconnect events fire the callback
+    assert not conn._reconnecting
+    # And the disconnect callback should be invocable; simulate a disconnect event
+    conn._on_disconnected(mock_old_bleak_client)
+    disconnect_callback.assert_called_once_with(mock_old_bleak_client)
+
+
+@mock.patch("bleak_retry_connector.establish_connection")
 @mock.patch("bleak.BleakClient", spec=True)
 @mock.patch("bleak.BLEDevice", spec=True)
 async def test_subscribe_debug_logs(


### PR DESCRIPTION
## Problem

When `establish_connection()` raises during `reset_device()` (e.g. `BleakOutOfConnectionSlotsError` when the Bluetooth adapter/proxy is out of connection slots), `_reconnecting` was left permanently set to `True`. This silently suppressed `disconnect_callback` on all future disconnection events, making it impossible for callers (e.g. Home Assistant integration) to detect the dropped connection and trigger recovery.

This is the root cause reported in #116:

```
bleak_retry_connector.BleakOutOfConnectionSlotsError: PBC-09ED444 - 40:08:84:F1:3C:22: Failed to connect after 10 attempt(s): No backend with an available connection slot ...
```

After the connection failure, `_reconnecting` was stuck at `True` so no subsequent disconnect events could propagate.

## Fix

Wrap the body of `reset_device()` in `try/finally` so `_reconnecting` is always reset to `False`, even when `connect()` raises.

## Testing

Added a regression test `test_reset_device_connect_failure_resets_reconnecting_flag` that:
1. Connects a `BleConnection`
2. Simulates `establish_connection()` raising during `reset_device()`
3. Asserts `_reconnecting` is `False` afterwards
4. Asserts the disconnect callback fires correctly on a subsequent disconnection

Fixes #116