### PR TITLE
Add OTA update support

### DIFF
--- a/pytboss/__init__.py
+++ b/pytboss/__init__.py
@@ -2,4 +2,5 @@
 
 from .api import PitBoss  # noqa: F401
 from .ble import BleConnection  # noqa: F401
+from .ota import OTA  # noqa: F401
 from .wss import WebSocketConnection  # noqa: F401

--- a/pytboss/api.py
+++ b/pytboss/api.py
@@ -14,6 +14,7 @@ from .config import Config
 from .exceptions import UnsupportedOperation
 from .fs import FileSystem
 from .grills import Grill, StateDict, get_grill
+from .ota import OTA
 from .transport import RPCResult, Transport, as_dict
 
 _UPTIME_TTL = 60.0
@@ -74,6 +75,9 @@ class PitBoss:
     config: Config
     """Configuration operations."""
 
+    ota: OTA
+    """Over-the-air firmware update operations."""
+
     def __init__(
         self,
         conn: Transport,
@@ -96,6 +100,7 @@ class PitBoss:
         """
         self.fs = FileSystem(conn)
         self.config = Config(conn)
+        self.ota = OTA(conn)
         self._grill_model = grill_model
         self._control_board = control_board
         self._conn = conn

--- a/pytboss/ota.py
+++ b/pytboss/ota.py
@@ -1,0 +1,46 @@
+"""Client library for Mongoose OS OTA (Over-The-Air update) RPCs."""
+
+from .transport import RPCResult, Transport, as_dict
+
+
+class OTA:
+    """Client library for Mongoose OS OTA RPCs.
+
+    Also see: https://mongoose-os.com/docs/mongoose-os/api/rpc/rpc-service-ota.md
+    """
+
+    def __init__(self, conn: Transport) -> None:
+        """Initializes the class.
+
+        :param conn: Transport for the device.
+        """
+        self._conn = conn
+
+    async def start(self, url: str, commit_timeout: int | None = None) -> RPCResult:
+        """Initiates an OTA update.
+
+        Returns whatever the device answers rather than promising a shape:
+        `OTA.*` is a Mongoose core service, so it is not modelled in
+        `fake_firmware/init.js` and nothing here has been seen answering a
+        real grill.
+
+        :param url: URL of the firmware zip file to download.
+        :param commit_timeout: Optional timeout (in seconds) to auto-commit the
+            new firmware. If the device is not committed within this time it
+            rolls back automatically.
+        """
+        params: dict = {"url": url}
+        if commit_timeout is not None:
+            params["commit_timeout"] = commit_timeout
+        return await self._conn.send_command("OTA.Start", params)
+
+    async def get_status(self) -> dict:
+        """Returns the current OTA update status.
+
+        The returned dict typically contains:
+          - ``state``: current OTA state string (e.g. ``"idle"``, ``"progress"``,
+            ``"error"``)
+          - ``msg``: human-readable message
+          - ``progress``: download progress (0–100) while downloading
+        """
+        return as_dict(await self._conn.send_command("OTA.Status", {}))

--- a/tests/test_ota.py
+++ b/tests/test_ota.py
@@ -1,0 +1,44 @@
+"""Tests for OTA RPC client."""
+
+from unittest import mock
+
+import pytest
+
+from pytboss.ota import OTA
+
+
+@pytest.fixture
+def mock_conn():
+    conn = mock.AsyncMock()
+    conn.send_command = mock.AsyncMock(return_value={})
+    return conn
+
+
+async def test_ota_start(mock_conn):
+    ota = OTA(mock_conn)
+    await ota.start("http://example.com/firmware.zip")
+    mock_conn.send_command.assert_awaited_once_with(
+        "OTA.Start", {"url": "http://example.com/firmware.zip"}
+    )
+
+
+async def test_ota_start_with_commit_timeout(mock_conn):
+    ota = OTA(mock_conn)
+    await ota.start("http://example.com/firmware.zip", commit_timeout=120)
+    mock_conn.send_command.assert_awaited_once_with(
+        "OTA.Start",
+        {"url": "http://example.com/firmware.zip", "commit_timeout": 120},
+    )
+
+
+async def test_ota_get_status(mock_conn):
+    mock_conn.send_command.return_value = {
+        "state": "progress",
+        "msg": "Downloading...",
+        "progress": 42,
+    }
+    ota = OTA(mock_conn)
+    result = await ota.get_status()
+    mock_conn.send_command.assert_awaited_once_with("OTA.Status", {})
+    assert result["state"] == "progress"
+    assert result["progress"] == 42


### PR DESCRIPTION
Adds Mongoose OS's OTA service — `OTA.Start` and `OTA.Status` — as `PitBoss.ota`, alongside the existing `fs` and `config` helpers.

Part of #167.

## Narrowed from the original branch

This branch previously added nine loose RPC wrappers to `PitBoss` as well. Those are gone; what remains is `ota.py`, its tests, and the three lines that wire it up.

Two of the nine have since landed anyway, via #530:

| was | now |
|---|---|
| `reboot()` | merged in #530, unchanged |
| `wifi_awake_wdt()` | merged in #530 as **`request_fast_updates()`** |

The rename matters and is worth not undoing here. `PB.WiFiAwakeWDT` does not keep the WiFi module awake — it sets a five-minute countdown during which the status-push timer reschedules to `wsFastInterval` instead of `wsSlowInterval` (5 s instead of 60 s), and it only affects the cloud WebSocket, only while the grill is on. The old name described something the RPC does not do.

The remaining seven — `list_rpcs`, `rename_device`, `set_wifi_credentials`, `load_mcu_firmware`, `get_mcu_firmware_load_status`, `query_mcu_firmware_version`, `scan_wifi` — are not OTA and are dropped rather than carried. Each is easier to argue for on its own; several are ones where a wrong call takes the grill off its network or leaves the MCU mid-flash.

**One judgement call worth naming:** the three `PB.*MCUFirmware*` wrappers are firmware-loading, so they are arguably in scope for "OTA". I read the instruction strictly — `OTA.*` is Mongoose's own service and `PB.LoadMCUFirmware` is a different mechanism against a different processor. Easy to add back if that reading is wrong.

## Auth

No `_authenticate` call, deliberately. `OTA.*` is a Mongoose core namespace, not `PB.*`, and `checkPassword` only guards the handlers the app registers — the same reason `fs.py` and `config.py` do not authenticate either. Consistent with the rest of the library.

## What is not verified

`OTA.Start` and `OTA.Status` are **not modelled in `fake_firmware/init.js`**, because it only registers the app's own handlers — the same gap `Sys.Reboot` has. So the wrappers match [Mongoose's documented RPC service](https://mongoose-os.com/docs/mongoose-os/api/rpc/rpc-service-ota.md), and the tests pin the request shape, but nothing here demonstrates a real grill answering them. Flagging rather than implying otherwise.

Anyone testing this against hardware should also know it is the sharpest edge in the library: a bad OTA image is how a grill stops working entirely. `commit_timeout` exists for exactly that and is worth using.

## Testing

745 tests pass (3 new), `ruff check`, `ruff format --check` and `mypy .` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
