### PR TITLE
Add branch-coverage tests for codec/transport/ble/wss

### DIFF
--- a/tests/test_ble.py
+++ b/tests/test_ble.py
@@ -261,3 +261,114 @@ async def test_on_rpc_error_received(
 def test_encode_decode_len():
     assert ble._encode_len(2**32 - 1) == bytearray([255, 255, 255, 255])
     assert ble._decode_len(bytearray([255, 255, 255, 255])) == 2**32 - 1
+
+
+@mock.patch("bleak_retry_connector.establish_connection")
+@mock.patch("bleak.BleakClient", spec=True)
+@mock.patch("bleak.BLEDevice", spec=True)
+async def test_connect_when_already_connected(
+    mock_device, mock_bleak_client, mock_establish_connection
+):
+    mock_establish_connection.return_value = mock_bleak_client
+
+    conn = ble.BleConnection(mock_device)
+    await conn.connect()
+    assert conn.is_connected()
+
+    # Connecting again should be a no-op (with a warning logged).
+    await conn.connect()
+    mock_establish_connection.assert_awaited_once()
+
+
+@mock.patch("bleak_retry_connector.establish_connection")
+async def test_connect_no_device(mock_establish_connection):
+    mock_device = mock.create_autospec(bleak.BLEDevice)
+    conn = ble.BleConnection(mock_device)
+    conn._ble_device = None
+
+    await conn.connect()
+
+    assert not conn.is_connected()
+    mock_establish_connection.assert_not_awaited()
+
+
+@mock.patch("bleak_retry_connector.establish_connection")
+@mock.patch("bleak.BleakClient", spec=True)
+@mock.patch("bleak.BLEDevice", spec=True)
+async def test_disconnect_swallows_exception(
+    mock_device, mock_bleak_client, mock_establish_connection
+):
+    mock_establish_connection.return_value = mock_bleak_client
+    conn = ble.BleConnection(mock_device)
+    await conn.connect()
+
+    mock_bleak_client.disconnect.side_effect = Exception("Bluetooth is awful")
+
+    await conn.disconnect()  # Should not raise.
+    assert not conn.is_connected()
+
+
+async def test_send_prepared_command_no_client():
+    mock_device = mock.create_autospec(bleak.BLEDevice)
+    conn = ble.BleConnection(mock_device)
+    # Never connected, so there is no BLE client yet.
+    await conn._send_prepared_command({"id": 1, "method": "foo", "params": {}})
+
+
+async def test_on_rpc_data_received_no_client():
+    mock_device = mock.create_autospec(bleak.BLEDevice)
+    conn = ble.BleConnection(mock_device)
+    # Never connected, so there is no BLE client yet.
+    await conn._on_rpc_data_received(mock.Mock(), bytearray([0, 0, 0, 0]))
+
+
+@mock.patch("bleak_retry_connector.establish_connection")
+@mock.patch("bleak.BleakClient", spec=True)
+@mock.patch("bleak.BLEDevice", spec=True)
+async def test_debug_log_bad_checksum(
+    mock_device, mock_bleak_client, mock_establish_connection
+):
+    mock_establish_connection.return_value = mock_bleak_client
+    conn = ble.BleConnection(mock_device)
+    state_cb = mock.AsyncMock()
+    conn.set_state_callback(state_cb)
+    await conn.connect()
+
+    # Checksum (5) doesn't match the actual payload length (10).
+    bad_data = bytearray("<==PB: FE0B.STATE [5]".encode("utf-8"))
+    await conn._on_debug_log_received(None, bad_data)
+    state_cb.assert_not_awaited()
+
+
+@mock.patch("bleak_retry_connector.establish_connection")
+@mock.patch("bleak.BleakClient", spec=True)
+@mock.patch("bleak.BLEDevice", spec=True)
+async def test_debug_log_unknown_format(
+    mock_device, mock_bleak_client, mock_establish_connection
+):
+    mock_establish_connection.return_value = mock_bleak_client
+    conn = ble.BleConnection(mock_device)
+    state_cb = mock.AsyncMock()
+    conn.set_state_callback(state_cb)
+    await conn.connect()
+
+    # Neither 2 nor 3 whitespace-separated parts; should be ignored.
+    await conn._on_debug_log_received(None, bytearray(b"<==PB:"))
+    state_cb.assert_not_awaited()
+
+
+@mock.patch("bleak_retry_connector.establish_connection")
+@mock.patch("bleak.BleakClient", spec=True)
+@mock.patch("bleak.BLEDevice", spec=True)
+async def test_debug_log_vdata(
+    mock_device, mock_bleak_client, mock_establish_connection
+):
+    mock_establish_connection.return_value = mock_bleak_client
+    conn = ble.BleConnection(mock_device)
+    vdata_cb = mock.AsyncMock()
+    conn.set_vdata_callback(vdata_cb)
+    await conn.connect()
+
+    data = bytearray(b'<==PBD:  {"foo":"bar"}')
+    await conn._on_debug_log_received(None, data)
+    vdata_cb.assert_awaited_once_with('{"foo":"bar"}')

--- a/tests/test_codec.py
+++ b/tests/test_codec.py
@@ -15,3 +15,9 @@ def test_encode_decode():
     check = codec.decode(param, key=codec.timed_key(12.0))
     # And then we compare that the saved version matches
     assert saved == check
+
+
+def test_decode_without_marker():
+    # If no 0xFF marker is found in the decoded stream, the raw decoded
+    # bytes are returned as-is instead of raising.
+    assert codec.decode(b"") == b""

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -1,0 +1,34 @@
+from pytboss.transport import Transport
+
+
+class FakeTransport(Transport):
+    """Minimal concrete Transport for exercising the base class directly."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.sent: list[dict] = []
+        self._connected = False
+
+    async def connect(self) -> None:
+        self._connected = True
+
+    async def disconnect(self) -> None:
+        self._connected = False
+
+    def is_connected(self) -> bool:
+        return self._connected
+
+    async def _send_prepared_command(self, cmd: dict) -> None:
+        self.sent.append(cmd)
+
+
+async def test_send_command_without_answer():
+    conn = FakeTransport()
+    await conn.send_command_without_answer("Some.Method", {"foo": "bar"})
+    assert conn.sent == [{"id": 1, "method": "Some.Method", "params": {"foo": "bar"}}]
+
+
+async def test_on_command_response_unknown_id():
+    conn = FakeTransport()
+    handled = await conn._on_command_response({"id": 999, "result": {}})
+    assert handled is False

--- a/tests/test_wss.py
+++ b/tests/test_wss.py
@@ -239,6 +239,25 @@ async def test_external_session_not_closed():
     await external_session.close()
 
 
+async def test_status_no_state_callback(conn: wss.WebSocketConnection) -> None:
+    # No state callback registered; the payload should be silently ignored.
+    await conn._handle_message({"status": ["state"]})
+
+
+async def test_vdata_result_payload(conn: wss.WebSocketConnection) -> None:
+    vdata_callback = AsyncMock()
+    conn.set_vdata_callback(vdata_callback)
+    await conn._handle_message({"result": "some-vdata"})
+    vdata_callback.assert_awaited_once_with("some-vdata")
+
+
+async def test_result_payload_no_vdata_callback(
+    conn: wss.WebSocketConnection,
+) -> None:
+    # No vdata callback registered; the payload should be silently ignored.
+    await conn._handle_message({"result": "some-vdata"})
+
+
 async def test_internal_session_closed():
     """Test that internal sessions are closed when disconnect is called."""
     # Create a connection without providing a session (it will create its own)


### PR DESCRIPTION
## Summary
Filled in the remaining untested branches across the transport-layer modules:
- `pytboss/codec.py` — the "no 0xFF marker found" path in `decode()`
- `pytboss/transport.py` — `send_command_without_answer()` and the unknown-id path in `_on_command_response()` (no dedicated test file existed for the base class at all)
- `pytboss/ble.py` — double-connect guard, connecting with no device, disconnect swallowing an exception, `_send_prepared_command`/`_on_rpc_data_received` with no BLE client yet, bad debug-log checksum, unknown debug-log format, and the vdata debug-log path
- `pytboss/wss.py` — status payload with no state callback registered, and the vdata `result` payload path (both with and without a registered vdata callback)

`codec.py`, `transport.py`, `ble.py`, and `wss.py` are all now at 100% line coverage.

## Test plan
- [x] `ruff check` / `ruff format --check`
- [x] `mypy pytboss`
- [x] `pytest` (455 passed)