### PR TITLE
Fix pytest parametrize generator deprecation warning

### DIFF
--- a/tests/test_grills.py
+++ b/tests/test_grills.py
@@ -121,12 +121,12 @@ class TestGetGrills:
         grills = list(grills_lib.get_grills("PBL"))
         assert len(grills) > 0
 
-    @pytest.mark.parametrize("grill", grills_lib.get_grills(), ids=idfn)
+    @pytest.mark.parametrize("grill", list(grills_lib.get_grills()), ids=idfn)
     def test_js_commands(self, grill: grills_lib.Grill):
         for cmd in grill.control_board.commands.values():
             cmd(11)
 
-    @pytest.mark.parametrize("grill", grills_lib.get_grills(), ids=idfn)
+    @pytest.mark.parametrize("grill", list(grills_lib.get_grills()), ids=idfn)
     def test_parse_temperatures(self, grill: grills_lib.Grill):
         assert grill.control_board._temperatures_js_func is not None
         js = JSFunc(grill.control_board._temperatures_js_func)
@@ -188,7 +188,7 @@ class TestGetGrills:
                         continue
                     raise
 
-    @pytest.mark.parametrize("grill", grills_lib.get_grills(), ids=idfn)
+    @pytest.mark.parametrize("grill", list(grills_lib.get_grills()), ids=idfn)
     def test_parse_state(self, grill: grills_lib.Grill):
         msg = Message()
         assert grill.control_board._status_js_func is not None


### PR DESCRIPTION
## Summary
`pytest.mark.parametrize()` with a generator as `argvalues` is deprecated as of pytest 9 (`PytestRemovedIn10Warning`), and the test suite currently emits 3 of these warnings from `tests/test_grills.py`. Wrapped the `grills_lib.get_grills()` calls in `list(...)` at each of the three parametrize sites.

## Test plan
- [x] `ruff check` / `ruff format --check`
- [x] `mypy pytboss`
- [x] `pytest` (441 passed, 0 warnings — previously 3 warnings)