### PR TITLE
Fix recipeStep TypedDict field typed as bool instead of int

### DIFF
--- a/pytboss/grills.py
+++ b/pytboss/grills.py
@@ -160,7 +160,7 @@ class StateDict(TypedDict, total=False):
     isFahrenheit: bool
     """Whether the temperature readings are in Fahrenheit."""
 
-    recipeStep: bool
+    recipeStep: int
     """The current recipe step number."""
 
     recipeTime: int


### PR DESCRIPTION
## Summary
- `StateDict.recipeStep` in `pytboss/grills.py` was typed `bool`, but the control-board JS (`grills.json`'s `status_function`) assigns it the raw parsed byte value (`recipeStep: parts[37]`), and its own docstring already calls it "the current recipe step number" — clearly meant to be `int`.

## Test plan
- [x] `mypy pytboss/grills.py` passes
- [x] `ruff check pytboss/grills.py` passes
- [x] `pytest tests/test_grills.py` passes (390 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)