### PR TITLE
Fix incorrect and undocumented docstrings across pytboss

### DIFF
--- a/fake_firmware/README.md
+++ b/fake_firmware/README.md
@@ -9,7 +9,7 @@ or smoker.
 The firmware (`init.js`) is a copy of the official Dansons firmware used by
 the grill. It can be installed to an ESP32 using the utilities provided by
 Mongoose OS (http://www.mongoose-os.com), which is the same base operating
-system installed on PitBoss devices. The additioanl files in this directory
+system installed on PitBoss devices. The additional files in this directory
 implement fake versions of the firmware dependencies that return reasonable
 approximations of data that would be returned by a PitBoss device.
 
@@ -19,7 +19,7 @@ Files of note:
     attached to a PitBoss device's ESP32 UART pins.
 *   `lib_ws.js` - WebSocket library implementation that replaces calls with
     NOOP functions. This is a custom library written for the PitBoss firmware
-    and is not shipped with Mongoose OS. The fake firware does not need
+    and is not shipped with Mongoose OS. The fake firmware does not need
     WebSocket support (since it doesn't need to talk to the PitBoss cloud
     servers), so the implementation details are irrelevant.
 *   `../mos.yml` - A Mongoose OS configuration file that sets up a base image

--- a/pytboss/__init__.py
+++ b/pytboss/__init__.py
@@ -1,4 +1,4 @@
-"""Client library for interacting with PitBoss grills over Bluetooth LE."""
+"""Client library for controlling PitBoss/Dansons grills over Bluetooth LE or WebSocket."""
 
 from .api import PitBoss  # noqa: F401
 from .ble import BleConnection  # noqa: F401

--- a/pytboss/api.py
+++ b/pytboss/api.py
@@ -1,4 +1,4 @@
-"""Client library for interacting with PitBoss grills over Bluetooth LE."""
+"""High-level client API for controlling PitBoss/Dansons grills."""
 
 import asyncio
 import inspect
@@ -184,7 +184,7 @@ class PitBoss:
         """Sets the target temperature for probe 2.
 
         :param temp: Target probe temperature.
-        :raise pyschlage.exceptions.UnsupportedOperation: When probe 2's
+        :raise pytboss.exceptions.UnsupportedOperation: When probe 2's
             target temperature cannot be set.
         """
         cmd = "set-probe-2-temperature"

--- a/pytboss/auth.py
+++ b/pytboss/auth.py
@@ -10,7 +10,13 @@ API_URL = "https://api-prod.dansonscorp.com/api/v1"
 async def async_login(
     session: ClientSession, email: str, password: str
 ) -> dict[str, str]:
-    """Authenticates the user for the PitBoss API and returns auth headers."""
+    """Authenticates against the PitBoss cloud API and returns auth headers.
+
+    :param session: An open aiohttp session to issue the request on.
+    :param email: The PitBoss account email address.
+    :param password: The PitBoss account password.
+    :raise pytboss.exceptions.Unauthorized: If the credentials are rejected.
+    """
     params = {"email": email, "password": password}
     async with session.post(f"{API_URL}/login/app", params=params) as response:
         response_json = await response.json()

--- a/pytboss/fs.py
+++ b/pytboss/fs.py
@@ -19,11 +19,14 @@ class FileSystem:
         self._conn = conn
 
     async def get_file_list(self) -> dict:
-        """:meta private:"""
+        """Lists files present on the device's filesystem."""
         return await self._conn.send_command("FS.List", {})
 
-    async def get_file_content(self, filename) -> str:
-        """:meta private:"""
+    async def get_file_content(self, filename: str) -> str:
+        """Reads and returns the full text content of a file on the device.
+
+        :param filename: Path of the file to read.
+        """
         length = 512
         offset = 0
         content = ""
@@ -36,17 +39,30 @@ class FileSystem:
             if resp["left"] == 0:
                 return content
 
-    async def set_file_content(self, filename, data, append) -> dict:
-        """:meta private:"""
+    async def set_file_content(self, filename: str, data: str, append: bool) -> dict:
+        """Writes content to a file on the device.
+
+        :param filename: Path of the file to write.
+        :param data: Content to write.
+        :param append: If True, appends to the existing file instead of
+            overwriting it.
+        """
         return await self._conn.send_command(
             "FS.Put",
             {"filename": filename, "data": data, "append": append},
         )
 
-    async def rename_file(self, src, dst) -> dict:
-        """:meta private:"""
+    async def rename_file(self, src: str, dst: str) -> dict:
+        """Renames a file on the device.
+
+        :param src: Existing filename.
+        :param dst: New filename.
+        """
         return await self._conn.send_command("FS.Rename", {"src": src, "dst": dst})
 
-    async def delete_file(self, filename) -> dict:
-        """:meta private:"""
+    async def delete_file(self, filename: str) -> dict:
+        """Deletes a file from the device.
+
+        :param filename: Path of the file to delete.
+        """
         return await self._conn.send_command("FS.Remove", {"filename": filename})

--- a/pytboss/grills.py
+++ b/pytboss/grills.py
@@ -239,13 +239,23 @@ class ControlBoard:
         return evaljs(js, message=message)
 
     def parse_status(self, message: str) -> StateDict | None:
-        """Parses a status message."""
+        """Parses a status message.
+
+        :param message: Raw status payload received from the grill.
+        :raise NotImplementedError: If this control board has no status-parsing
+            routine.
+        """
         if not self._status_js_func:
             raise NotImplementedError
         return self._evaljs(self._status_js_func, message)
 
     def parse_temperatures(self, message: str) -> StateDict | None:
-        """Parses a temperatures message."""
+        """Parses a temperatures message.
+
+        :param message: Raw temperatures payload received from the grill.
+        :raise NotImplementedError: If this control board has no
+            temperatures-parsing routine.
+        """
         if not self._temperatures_js_func:
             raise NotImplementedError
         return self._evaljs(self._temperatures_js_func, message)
@@ -313,6 +323,9 @@ class Grill:
 def get_grills(control_board: str | None = None) -> Iterable[Grill]:
     """Retrieves grill specifications.
 
+    Grills with no status-parsing routine, or whose name is listed in
+    `UNSUPPORTED_MODELS`, are silently excluded.
+
     :param control_board: If specified, returns only grills with this control board.
     """
     for grill in _get_grills().values():
@@ -327,7 +340,14 @@ def get_grills(control_board: str | None = None) -> Iterable[Grill]:
 def get_grill(grill_name: str) -> Grill:
     """Retrieves a grill specification.
 
+    Unlike `get_grills()`, this does not exclude names listed in
+    `UNSUPPORTED_MODELS`; requesting one of those names will succeed here
+    but its control board's `parse_status`/`parse_temperatures` may raise
+    `NotImplementedError` when actually used.
+
     :param grill_name: The name of the grill specification to retrieve.
+    :raise pytboss.exceptions.InvalidGrill: If `grill_name` is not a known
+        grill model.
     """
     if (grill := _get_grills().get(grill_name, None)) is None:
         raise InvalidGrill(f"Unknown grill name: {grill_name}")

--- a/pytboss/transport.py
+++ b/pytboss/transport.py
@@ -77,6 +77,8 @@ class Transport(ABC):
         :param method: The method to call.
         :param params: Parameters to send with the command.
         :param timeout: Timeout for the call.
+        :raise pytboss.exceptions.RPCError: If the device returns an error response.
+        :raise TimeoutError: If `timeout` elapses before a response is received.
         """
         cmd = await self._prepare_command(method, params)
         future = self._loop.create_future()
@@ -94,6 +96,7 @@ class Transport(ABC):
         :param method: The method to call.
         :param params: Parameters to send with the command.
         :param timeout: Timeout for the call.
+        :raise TimeoutError: If `timeout` elapses before the command is sent.
         """
         async with asyncio.timeout(timeout):
             await self._send_prepared_command(


### PR DESCRIPTION
## Summary
- `api.py`/`__init__.py` module docstrings claimed "over Bluetooth LE" even though `PitBoss` and the package work identically over WebSocket (`pytboss.wss.WebSocketConnection`).
- `set_probe_2_temperature`'s docstring referenced `pyschlage.exceptions` (a different, unrelated project of the author's) instead of `pytboss.exceptions` — clear copy-paste error.
- Documented previously-undocumented raises: `get_grill()`'s `InvalidGrill`, `parse_status`/`parse_temperatures`'s `NotImplementedError`, `async_login`'s `Unauthorized`, and `Transport.send_command`/`send_command_without_answer`'s `RPCError`/`TimeoutError`.
- Documented that `get_grill()` does not filter `UNSUPPORTED_MODELS` the way `get_grills()` does — a caller can construct a `PitBoss` with an unsupported model name and only discover the problem later, deep in the state-parsing callback chain.
- `fs.py`'s `FileSystem` methods had only bare `:meta private:` docstrings with no parameter type hints, unlike the parallel `Config` class — gave them real docstrings and type hints.
- Fixed typos in `fake_firmware/README.md` ("additioanl", "firware").

No behavior changes — docstrings and type hints only.

## Test plan
- [x] `mypy .` passes (25 source files)
- [x] `ruff check .` passes
- [x] `pytest` passes (486 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)