### PR TITLE
Polish remaining thin/missing docstrings

### DIFF
--- a/pytboss/api.py
+++ b/pytboss/api.py
@@ -67,11 +67,14 @@ class PitBoss:
         await self._conn.connect()
 
     async def stop(self) -> None:
-        """Stops any background polling."""
+        """Disconnects from the grill and stops any background connection tasks."""
         await self._conn.disconnect()
 
     async def subscribe_state(self, callback: StateCallback):
         """Registers a callback to receive grill state updates.
+
+        The callback receives the same `StateDict` instance on every call,
+        shared across all subscribers; it should be treated as read-only.
 
         :param callback: Callback function that will receive updated grill state.
         """
@@ -81,6 +84,10 @@ class PitBoss:
 
     async def subscribe_vdata(self, callback: VDataCallback):
         """Registers a callback to receive VData updates.
+
+        If multiple callbacks are subscribed, they all receive the same
+        `dict` instance for a given update; it should be treated as
+        read-only.
 
         :param callback: Callback function that will receive updated VData.
         """
@@ -217,7 +224,12 @@ class PitBoss:
         return await self._send_command("turn-primer-motor-off")
 
     async def get_state(self) -> StateDict:
-        """Retrieves the current grill state."""
+        """Issues a live RPC to fetch and return the current grill state.
+
+        Unlike `subscribe_state()`, this does not use the cached state
+        maintained from prior pushed updates; it always queries the grill
+        directly.
+        """
         resp = await self._conn.send_command(
             "PB.GetState", await self._authenticate({})
         )
@@ -230,32 +242,49 @@ class PitBoss:
         return await self._conn.send_command("PB.GetFirmwareVersion", {})
 
     async def set_mcu_update_timer(self, frequency=2):
-        """:meta private:"""
+        """Sets how often (in seconds) the MCU sends status updates.
+
+        :meta private:
+        """
         return await self._conn.send_command(
             "PB.SetMCU_UpdateFrequency", {"frequency": frequency}
         )
 
     async def set_wifi_update_frequency(self, fast=5, slow=60):
-        """:meta private:"""
+        """Sets how often (in seconds) the device sends WiFi status updates.
+
+        :meta private:
+        """
         return await self._conn.send_command(
             "PB.SetWifiUpdateFrequency",
             await self._authenticate({"slow": slow, "fast": fast}),
         )
 
     async def set_virtual_data(self, data: dict):
-        """:meta private:"""
+        """Sets arbitrary virtual data on the device.
+
+        :meta private:
+        """
         return await self._conn.send_command(
             "PB.SetVirtualData", await self._authenticate(data)
         )
 
     async def get_virtual_data(self):
-        """:meta private:"""
+        """Retrieves virtual data previously set with `set_virtual_data()`.
+
+        :meta private:
+        """
         return await self._conn.send_command(
             "PB.GetVirtualData", await self._authenticate({})
         )
 
     async def get_uptime(self) -> float:
-        """:meta private:"""
+        """Returns the device's uptime, in seconds.
+
+        Cached for up to 5 seconds between RPCs.
+
+        :meta private:
+        """
         now = int(time())
         if not self._last_uptime_check or now - self._last_uptime_check > 5:
             result = await self._conn.send_command("PB.GetTime", {})

--- a/pytboss/ble.py
+++ b/pytboss/ble.py
@@ -65,7 +65,10 @@ class BleConnection(Transport):
         self._reconnecting = False
 
     async def connect(self) -> None:
-        """Starts the connection to the device."""
+        """Starts the connection to the device.
+
+        Does nothing if already connected or if no BLE device was set.
+        """
         if self._is_connected:
             _LOGGER.warning("Already connected. Ignoring call to connect().")
             return

--- a/pytboss/grills.py
+++ b/pytboss/grills.py
@@ -185,7 +185,11 @@ class Command:
 
     @classmethod
     def from_dict(cls, cmd_dict) -> "Command":
-        """Creates a Command from a JSON dict."""
+        """Creates a Command from a JSON dict.
+
+        :param cmd_dict: A `control_board_commands` entry from `grills.json`,
+            with `name`, `slug`, `hexadecimal`, and `function` keys.
+        """
         js_func = _scrub_js(cmd_dict["function"])
         return cls(
             name=cmd_dict["name"],
@@ -195,7 +199,11 @@ class Command:
         )
 
     def __call__(self, *args) -> str:
-        """Returns a hexadecimal command string."""
+        """Returns a hexadecimal command string.
+
+        :raise NotImplementedError: If this command has neither a static
+            hexadecimal value nor a JavaScript function to generate one.
+        """
         if self._hex:
             return self._hex
 
@@ -223,7 +231,12 @@ class ControlBoard:
 
     @classmethod
     def from_dict(cls, ctrl_dict) -> "ControlBoard":
-        """Creates a ControlBoard from a JSON dict."""
+        """Creates a ControlBoard from a JSON dict.
+
+        :param ctrl_dict: A `control_board` entry from `grills.json`, with
+            `name`, `control_board_commands`, `status_function`, and
+            `temperature_function` keys.
+        """
         return cls(
             name=ctrl_dict["name"],
             commands={
@@ -281,7 +294,12 @@ class Grill:
 
     @classmethod
     def from_dict(cls, grill_dict) -> "Grill":
-        """Creates a Grill from a JSON dict."""
+        """Creates a Grill from a JSON dict.
+
+        :param grill_dict: A top-level entry from `grills.json`, with `name`,
+            `control_board`, `meat_probes`, `temp_increment`, `min_temp`, and
+            `max_temp` keys.
+        """
         min_temp = None
         try:
             min_temp = int(grill_dict["min_temp"])

--- a/pytboss/transport.py
+++ b/pytboss/transport.py
@@ -1,4 +1,9 @@
-"""Base class for transport protocols."""
+"""Shared RPC-over-futures request/response machinery for transports.
+
+Concrete transports (`pytboss.ble.BleConnection`, `pytboss.wss.WebSocketConnection`)
+subclass `Transport` and implement the connection-specific details; this
+module handles matching outgoing commands to their responses via futures.
+"""
 
 import asyncio
 from abc import ABC, abstractmethod
@@ -13,20 +18,26 @@ from .exceptions import RPCError
 
 
 class RawStateCallback(Protocol):
+    """Callback invoked by a `Transport` with raw, unparsed state payloads."""
+
     async def __call__(
         self, status_payload: str | None, temperatures_payload: str | None = None
     ) -> None: ...
 
 
 RawVDataCallback = Callable[[str], Awaitable[None]]
+"""Callback invoked by a `Transport` with a raw, unparsed VData payload."""
+
 SendCommandFn = Callable[
     [str, dict[Any, Any], DefaultNamedArg(float | None, "timeout")],
     Awaitable[dict[Any, Any] | None],
 ]
+"""Signature shared by `Transport.send_command` and `send_command_without_answer`."""
 
 
 class Transport(ABC):
-    """Base class for transport protocols."""
+    """Abstract base class implementing the RPC request/response protocol
+    shared by all connection types."""
 
     def __init__(self, loop: AbstractEventLoop | None = None) -> None:
         self._lock = Lock()

--- a/pytboss/wss.py
+++ b/pytboss/wss.py
@@ -21,7 +21,12 @@ _MAX_BACKOFF_TIME = 30.0
 
 
 class WebSocketConnection(Transport):
-    """WebSocket transport for PitBoss grills."""
+    """WebSocket transport for PitBoss grills.
+
+    Unlike `pytboss.ble.BleConnection`, this transport automatically
+    reconnects with exponential backoff (up to `_MAX_BACKOFF_TIME` seconds
+    between attempts) if the connection drops.
+    """
 
     def __init__(
         self,
@@ -59,7 +64,12 @@ class WebSocketConnection(Transport):
         await self._subscribed.wait()
 
     async def disconnect(self) -> None:
-        """Stops the connection to the device."""
+        """Stops the connection to the device.
+
+        Also closes the underlying aiohttp session if it was created
+        internally (i.e. no `session` was passed to `__init__`), and waits
+        for the background reconnect/subscribe task to finish.
+        """
         self._keep_running = False
         if self._sock:
             await self._sock.close()


### PR DESCRIPTION
## Summary
Lower-priority docstring polish, follow-up to #476 and #479. No behavior changes.

- `api.py`: clarified `stop()`'s wording (neither BLE nor WSS actually "polls"), noted that `subscribe_state`/`subscribe_vdata` callbacks share a mutable instance across subscribers, distinguished `get_state()`'s live RPC from the cached/subscribed state, and gave the `:meta private:` RPC helpers (`set_mcu_update_timer`, `set_wifi_update_frequency`, `set_virtual_data`, `get_virtual_data`, `get_uptime`) real one-line descriptions (still hidden from generated docs via `:meta private:`).
- `ble.py`: noted that `connect()` is a no-op if already connected or if no BLE device was set.
- `wss.py`: documented `WebSocketConnection`'s automatic-reconnect-with-backoff behavior (unlike `BleConnection`, which requires a manual `reset_device()` call), and that `disconnect()` also closes an internally-created session and awaits the background subscribe task.
- `transport.py`: differentiated the module docstring from the `Transport` class docstring, and added docstrings to the previously-undocumented `RawStateCallback`/`RawVDataCallback`/`SendCommandFn` type aliases.
- `grills.py`: documented the expected `grills.json` schema keys for `Command.from_dict`/`ControlBoard.from_dict`/`Grill.from_dict`, and the `NotImplementedError` raised by `Command.__call__`.

## Test plan
- [x] `mypy .` passes (25 source files)
- [x] `ruff check .` passes
- [x] `pytest` passes (486 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)