### PR TITLE
Bump ruff-pre-commit hook and pyupgrade/typing-update targets

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,8 @@ updates:
     directory: "/"
     schedule:
       interval: daily
+
+  - package-ecosystem: "pre-commit"
+    directory: "/"
+    schedule:
+      interval: daily

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,7 @@ repos:
       - id: python-typing-update
         stages: [manual]
         args:
-          - --py310-plus
+          - --py312-plus
           - --force
           - --keep-updates
         files: ^.*\.py$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ repos:
     rev: v3.20.0
     hooks:
       - id: pyupgrade
-        args: [--py310-plus]
+        args: [--py312-plus]
         stages: [manual]
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0
@@ -30,7 +30,7 @@ repos:
           - --keep-updates
         files: ^.*\.py$
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.11.13
+    rev: v0.16.0
     hooks:
       - id: ruff
         args:

--- a/pytboss/grills.py
+++ b/pytboss/grills.py
@@ -330,9 +330,7 @@ class Grill:
             min_temp=min_temp,
             max_temp=max_temp,
             meat_probes=grill_dict["meat_probes"],
-            temp_increments=[
-                int(t) for t in grill_dict["temp_increment"].split("/")
-            ],
+            temp_increments=[int(t) for t in grill_dict["temp_increment"].split("/")],
             json=grill_dict,
             control_board=ControlBoard.from_dict(grill_dict["control_board"]),
         )


### PR DESCRIPTION
## Summary
- `.pre-commit-config.yaml`'s `ruff-pre-commit` hook was pinned at `v0.11.13` while the actual `ruff` dependency has moved on to `0.16.0` — `pre-commit run` and `ruff` locally/in CI could disagree. Root cause: `dependabot.yml` only watched `pip`/`github-actions`, never the `pre-commit` ecosystem, so hook revs silently never got bumped. Bump the hook to `v0.16.0` and add a `pre-commit` ecosystem entry to `dependabot.yml` so this doesn't happen again.
- Point `pyupgrade` and `python-typing-update` at `--py312-plus` instead of `--py310-plus`, matching `requires-python = ">=3.12"` in `pyproject.toml`.
- Running the now-current ruff formatter surfaced one real formatting diff in `pytboss/grills.py` that the stale pre-commit hook had been silently missing — included here since it's a direct consequence of the version bump.

## Test plan
- [x] `ruff check .` / `ruff format --check .` clean with `ruff==0.16.0`
- [x] `pytest` — 486 passed
- [x] `mypy .` — clean
- [x] `pre-commit run --all-files` — confirmed the `v0.16.0` tag resolves and all hooks pass
- [x] Verified this branch merges cleanly with the other two tooling PRs and the combined result still passes all checks

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>