### PR TITLE
Remove stale black/pylint references from editor config

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -15,7 +15,6 @@
                 "charliermarsh.ruff",
                 "github.vscode-pull-request-github",
                 "mongoose-os.mongoose-os-ide",
-                "ms-python.black-formatter",
                 "ms-python.mypy-type-checker",
                 "ms-python.python",
                 "ms-python.vscode-pylance",
@@ -27,12 +26,13 @@
             "settings": {
                 "files.eol": "\n",
                 "editor.tabSize": 4,
-                "python.pythonPath": "/usr/bin/python3",
                 "python.analysis.autoSearchPaths": false,
-                "python.linting.pylintEnabled": true,
-                "python.linting.enabled": true,
-                "python.formatting.provider": "black",
-                "python.formatting.blackPath": "/usr/local/py-utils/bin/black",
+                "[python]": {
+                    "editor.defaultFormatter": "charliermarsh.ruff",
+                    "editor.codeActionsOnSave": {
+                        "source.organizeImports": "explicit"
+                    }
+                },
                 "editor.formatOnPaste": false,
                 "editor.formatOnSave": true,
                 "editor.formatOnType": true,

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,7 @@
 {
-    "python.formatting.provider": "black",
-    "python.pythonPath": "/usr/local/bin/python",
+    "[python]": {
+        "editor.defaultFormatter": "charliermarsh.ruff"
+    },
     "python.testing.pytestEnabled": true,
     "mos.port": "/dev/ttyUSB0",
     "mos.board": "ESP32"


### PR DESCRIPTION
## Summary
- `.devcontainer.json` and `.vscode/settings.json` still configured `black` as the Python formatter and enabled pylint, but neither is installed or run anywhere — `ruff` (check + format) has been the actual formatter/linter via pre-commit for a while. Point the default formatter at the ruff extension instead.
- Remove `setup.cfg`, which is empty (0 bytes) and unread by any tool — all config lives in `pyproject.toml`/`mypy.ini`/`pytest.ini`.

## Test plan
- No functional code paths touched (editor/devcontainer config + a dead empty file); nothing to run.
- [x] Verified this branch merges cleanly with the other two tooling PRs and the combined result still passes all checks

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>