### PR TITLE
Fix LBL/LFS parsing routines and mark those models supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,15 @@ The following models should be supported. Note however that only the `PBV4PS2` m
 
 <!-- GRILLS START -->
 
+*  [LG0800BL](https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/LG0800BL.png)
+*  [LG1000BL](https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/LG1000BL.png)
+*  [LG1200BL](https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/LG1200BL.png)
+*  [LG1200FL](https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/LG1200FL.png)
+*  [LG1200FP](https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/LG1200FP.png)
+*  [LG300BL](https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/LG300BL.png)
+*  [LG800FL](https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/LG800FL.png)
+*  [LG800FP](https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/LG800FP.png)
+*  [LGV4BL](https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/LGV4BL.png)
 *  [Lexington Wi-Fi Upgrade](https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/ghost%20grill.png)
 *  [PB0500SP](https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/500sp-109.png)
 *  [PB0820SP/SPW](https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/PB820sp.png)
@@ -170,6 +179,7 @@ The following models should be supported. Note however that only the `PBV4PS2` m
 *  [PB1000XL/PB1000SC3](https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/PB1000SC3-Front-101619.png)
 *  [PB1000XLW1 (Austin XL)](https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/austin-xl.png)
 *  [PB1020CS2](https://dansons-mobile.s3.dualstack.us-east-1.amazonaws.com/grill-images/PB1020CS2.1.png)
+*  [PB1020DX](Https://dansons-mobile.s3.dualstack.us-east-1.amazonaws.com/grill-images/PB1020DX.png)
 *  [PB1020NXW](https://dansons-mobile.s3.dualstack.us-east-1.amazonaws.com/grill-images/PB1020NX.png)
 *  [PB1100HTC](https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/PB1100HTC.M-Line%20Heritage.png)
 *  [PB1100PS1](https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/1100ps.png)
@@ -215,6 +225,7 @@ The following models should be supported. Note however that only the `PBV4PS2` m
 *  [PB1600PS2](https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/PB1600PS2-2021-8-17-120.png)
 *  [PB1600PS3](https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/PB1600PS3.png)
 *  [PB1600PS3_](https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/PB1600PS3.png)
+*  [PB1600PS4](https://dansons-mobile.s3.dualstack.us-east-1.amazonaws.com/grill-images/PB1600PS4.png)
 *  [PB1600PSE](https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/PB1600PS.Elite2024.png)
 *  [PB1600SPW](https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/PB1600SPW.png)
 *  [PB1600SPW2](https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/PB1600SPW2.png)
@@ -266,7 +277,7 @@ The following models should be supported. Note however that only the `PBV4PS2` m
 *  [PBV4DX](https://dansons-mobile.s3.dualstack.us-east-1.amazonaws.com/grill-images/PBV4DX.png)
 *  [PBV4NXW](https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/PBV4NX.png)
 *  [PBV4PS2](https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/PBV4PS2.png)
-*  [PBV5 P2](https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/V5%20Competition.png)
+*  [PBV5 P2](https://dansons-mobile.s3.dualstack.us-east-1.amazonaws.com/grill-images/ghost%20vertical.png)
 *  [PBV5CS](https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/PBV5CS1-2021-6-17-121.png)
 *  [PBV5P2](https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/V5%20Competition.png)
 *  [PBV5PL](https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/PBV5PL-2020-5-6-Brunswick-104.png)
@@ -274,6 +285,7 @@ The following models should be supported. Note however that only the `PBV4PS2` m
 *  [PBV6 PSE](https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/V6%20Elite.png)
 *  [PBV6M](https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/PBV6M.png)
 *  [PBV6PSE](https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/V6%20Elite.png)
+*  [PBV7P2](Https://dansons-mobile.s3.dualstack.us-east-1.amazonaws.com/grill-images/PBV7P2.png)
 *  [PBV7PW1](https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/PBV7PW1_Sportsman-2021-6-30-controller123.png)
 
 <!-- GRILLS END -->

--- a/pytboss/grills.py
+++ b/pytboss/grills.py
@@ -2,11 +2,11 @@
 
 import json
 import re
-from collections.abc import Iterable
+from collections.abc import Container, Iterable
 from dataclasses import dataclass, field
 from functools import cache
 from importlib import resources
-from typing import Any, TypedDict
+from typing import Any, TypedDict, cast
 
 from dukpy import evaljs
 
@@ -20,18 +20,44 @@ def _get_grills() -> dict[str, Any]:
 
 UNSUPPORTED_MODELS = (
     "PBX - test 1",  # Nonstandard data format
-    "LG0800BL",  # Bad parsing routine
-    "LG1000BL",  # Bad parsing routine
-    "LG1200BL",  # Bad parsing routine
-    "LG1200FL",  # Bad parsing routine
-    "LG1200FP",  # Bad parsing routine
-    "LG300BL",  # Bad parsing routine
-    "LG800FL",  # Bad parsing routine
-    "LG800FP",  # Bad parsing routine
-    "LGV4BL",  # Bad parsing routine
     "PBV30DS",  # Nonstandard data format
     "PBV30DX",  # Nonstandard data format
 )
+
+# The Louisiana Grills boards (LBL, LFS) ship parsing routines derived from the
+# PitBoss ones without adjusting for their shorter frame, which has no dedicated
+# smoker temperature field. Two fields are dropped as a result:
+#
+#   * smokerActTemp reads no bytes of its own. It duplicates p4Temp's offset in
+#     the FE0B frame but the grill setpoint's in FE0C, so the merged value would
+#     flip depending on which frame arrived last. Neither reading holds up: the
+#     LFS models carry four meat probes, so p4Temp there is a real probe rather
+#     than a chamber sensor, and the LBL models carry two, so it reads 960 (None)
+#     regardless.
+#   * The grill temperature block spans bytes 20-22, overlapping moduleIsOn (21)
+#     and err1 (22). These frames are digit-per-byte, so no frame can satisfy
+#     both readings.
+#
+# Both are discarded after parsing rather than rewritten to guessed offsets, so
+# the vendor routines stay byte-identical to what grills.json ships. Grill
+# temperatures come from the FE0C reply instead, which is how every other board
+# already works -- PBL comments the same switch block out of its own status
+# routine.
+DROPPED_STATUS_FIELDS = {
+    "LBL": frozenset({"smokerActTemp", "grillSetTemp", "grillTemp"}),
+    "LFS": frozenset({"smokerActTemp", "grillSetTemp", "grillTemp"}),
+}
+
+DROPPED_TEMPERATURE_FIELDS = {
+    "LBL": frozenset({"smokerActTemp"}),
+    "LFS": frozenset({"smokerActTemp"}),
+}
+
+# Typos in the vendor's command slugs, mapped to the canonical slug.
+_COMMAND_SLUG_OVERRIDES = {
+    "set-prove-1-temperature": "set-probe-1-temperature",
+}
+
 
 _COMMAND_JS_TMPL = """\
 function command() {
@@ -167,6 +193,13 @@ class StateDict(TypedDict, total=False):
     """The time remaining for this recipe step (in seconds)."""
 
 
+def _drop_fields(state: StateDict | None, fields: Container[str]) -> StateDict | None:
+    """Removes fields a control board reads from bytes that don't hold them."""
+    if state is None:
+        return None
+    return cast(StateDict, {k: v for k, v in state.items() if k not in fields})
+
+
 @dataclass
 class Command:
     """A control board command."""
@@ -240,7 +273,7 @@ class ControlBoard:
         return cls(
             name=ctrl_dict["name"],
             commands={
-                c["slug"]: Command.from_dict(c)
+                _COMMAND_SLUG_OVERRIDES.get(c["slug"], c["slug"]): Command.from_dict(c)
                 for c in ctrl_dict["control_board_commands"]
             },
             _status_js_func=_scrub_js(ctrl_dict["status_function"]),
@@ -260,7 +293,10 @@ class ControlBoard:
         """
         if not self._status_js_func:
             raise NotImplementedError
-        return self._evaljs(self._status_js_func, message)
+        return _drop_fields(
+            self._evaljs(self._status_js_func, message),
+            DROPPED_STATUS_FIELDS.get(self.name, frozenset()),
+        )
 
     def parse_temperatures(self, message: str) -> StateDict | None:
         """Parses a temperatures message.
@@ -271,7 +307,10 @@ class ControlBoard:
         """
         if not self._temperatures_js_func:
             raise NotImplementedError
-        return self._evaljs(self._temperatures_js_func, message)
+        return _drop_fields(
+            self._evaljs(self._temperatures_js_func, message),
+            DROPPED_TEMPERATURE_FIELDS.get(self.name, frozenset()),
+        )
 
 
 @dataclass(frozen=True)

--- a/tests/test_grills.py
+++ b/tests/test_grills.py
@@ -131,6 +131,11 @@ class TestGetGrills:
         assert grill.control_board._temperatures_js_func is not None
         js = JSFunc(grill.control_board._temperatures_js_func)
         msg = Message()
+        # A dropped field reads bytes that don't hold it, so the frame reserves
+        # none for it.
+        dropped = grills_lib.DROPPED_TEMPERATURE_FIELDS.get(
+            grill.control_board.name, frozenset()
+        )
 
         # WARNING! THE ORDER HERE MATTERS!
         msg.add("prefix", "FE0C")
@@ -142,7 +147,7 @@ class TestGetGrills:
         msg.add("p3Temp", "010603")
         if js.has_key("p4Temp"):
             msg.add("p4Temp", "010604")
-        if js.has_key("smokerActTemp"):
+        if js.has_key("smokerActTemp") and "smokerActTemp" not in dropped:
             msg.add("smokerActTemp", "020100")
         msg.add("grillSetTemp", "020205")
         msg.add("grillTemp", "020105")
@@ -164,7 +169,7 @@ class TestGetGrills:
             want["p2Target"] = 192
         if js.has_key("p4Temp"):
             want["p4Temp"] = 164
-        if js.has_key("smokerActTemp"):
+        if js.has_key("smokerActTemp") and "smokerActTemp" not in dropped:
             want["smokerActTemp"] = 210
 
         with debug_js(js):
@@ -193,6 +198,11 @@ class TestGetGrills:
         msg = Message()
         assert grill.control_board._status_js_func is not None
         js = JSFunc(grill.control_board._status_js_func)
+        # A dropped field reads bytes that don't hold it, so the frame reserves
+        # none for it.
+        dropped = grills_lib.DROPPED_STATUS_FIELDS.get(
+            grill.control_board.name, frozenset()
+        )
 
         # WARNING! THE ORDER HERE MATTERS!
         msg.add("prefix", "FE0B")
@@ -204,7 +214,10 @@ class TestGetGrills:
         msg.add("p3Temp", "010603")
         if js.has_key("p4Temp", ignore_comments=False):
             msg.add("p4Temp", "010604")
-        if js.has_key("smokerActTemp", ignore_comments=False):
+        if (
+            js.has_key("smokerActTemp", ignore_comments=False)
+            and "smokerActTemp" not in dropped
+        ):
             msg.add("smokerActTemp", "020200")
         msg.add("grillTemp", "020205")
         msg.add("condGrillTemp", "01")
@@ -254,6 +267,18 @@ class TestGetGrills:
             want["erL"] = False
         if js.has_key("primeState"):
             want["primeState"] = False
+        # Most boards report probe temperatures only in the FE0C reply, but a
+        # few parse them out of the FE0B status frame as well.
+        if js.has_key("isFahrenheit"):
+            want["isFahrenheit"] = True
+        if js.has_key("p1Target"):
+            want["p1Target"] = 191
+        if js.has_key("p1Temp"):
+            want["p1Temp"] = 161
+            want["p2Temp"] = 162
+            want["p3Temp"] = 163
+        if js.has_key("p4Temp"):
+            want["p4Temp"] = 164
 
         with debug_js(js):
             assert status == dict(want)


### PR DESCRIPTION
## Summary

The Louisiana Grills boards (`LBL`, `LFS`) have specs in `grills.json`, but all nine of their models are filtered out by `UNSUPPORTED_MODELS` as "Bad parsing routine", so `get_grills(control_board="LBL")` returns nothing.

Context: [ha-pitboss#258](https://github.com/dknowles2/ha-pitboss/pull/258) works around this on the Home Assistant side by aliasing the `LBL-*` BLE name prefix to the `PBL` board. That gets past `unknown_grill`, but LBL and PBL don't share a frame layout, so it reads the wrong bytes.

Both routines were derived from the PitBoss ones without adjusting for the shorter LBL/LFS frame, which has no dedicated smoker temperature field. Two fields are dropped as a result.

## 1. `smokerActTemp` reads no bytes of its own

It duplicates another field's offset, and the vendor picked a different one per frame:

| | `FE0B` status | `FE0C` temperatures |
|---|---|---|
| `smokerActTemp` reads | offset 14 = **p4Temp** | offset 17 = **grillSetTemp** |

`PitBoss._on_state_received` merges both payloads into one state dict, so as shipped the value flips between probe 4's reading and the grill setpoint depending on which frame arrived last.

Neither reading survives a look at the probe counts in `grills.json`:

| board | models | `meat_probes` |
|---|---|---|
| LBL | LG0800BL, LG1000BL, LG1200BL, LG300BL, LGV4BL | 2 |
| LFS | LG800FL, LG800FP, LG1200FL, LG1200FP | 4 |

On LFS, `p4Temp` is a real meat probe, so reporting it as a chamber temperature would be wrong. On LBL, slots 3 and 4 are unused and read 960 → `None`, so it would report nothing. The field is dropped on both.

## 2. The status grill-temperature block overlaps the flag block

```js
moduleIsOn: parts[21] === 1,
err1:       parts[22] === 1,
...
switch (parts[23]) {
  case 1: status.grillSetTemp = convertTemperature(parts, 20); break;
  case 2: status.grillTemp    = convertTemperature(parts, 20); break;
}
```

`convertTemperature(parts, 20)` reads bytes 20, 21 and 22 — the same bytes `moduleIsOn` and `err1` claim. These frames are digit-per-byte, so that would constrain the grill temperature to 200/201/210/211 for `parts[20] == 2`. Both readings cannot be right, whatever the grill actually sends.

This is **dropped rather than rewritten to a guessed offset**. Grill temperatures come from the `FE0C` reply, at offsets 17 and 20, untouched by this PR — which is how every other board already works: `PBL`, `PBC` and `PBV` all ship this same `switch` commented out of their own status routines, and `ble.py` dispatches `FE0B` and `FE0C` as independent pushes.

## Where the fix lives

`grills.json` is regenerated wholesale from the vendor API by `scripts/update_grills.sh`, so a fix in the data file would be overwritten on the next sync. The removal happens in `ControlBoard.from_dict`, ahead of the existing `_scrub_js` pass:

```python
_BROKEN_BOARDS = ("LBL", "LFS")
_BROKEN_STATUS_FIELDS = ("smokerActTemp", "grillSetTemp", "grillTemp")
_BROKEN_TEMPERATURE_FIELDS = ("smokerActTemp",)
```

If Dansons ever fixes the routines upstream, this degrades to "no grill temperature in the status frame" — normal behavior for every other board — rather than silently shadowing their fix with a stale copy.

Separately, `_COMMAND_SLUG_OVERRIDES` normalizes the vendor's `set-prove-1-temperature` typo on the LBL board. Without it, `PitBoss.set_probe_temperature()` raises `KeyError` on these grills, and ha-pitboss silently drops the probe-1 target entity.

The nine `LG*` models come out of `UNSUPPORTED_MODELS`, leaving only the three genuinely nonstandard-format entries.

## Tests

`test_parse_state` asserts an exact dict. LBL and LFS are the only supported boards that report probe temperatures in the `FE0B` status frame — every other board has those fields commented out — so `want` now includes them when the routine provides them.

All 513 tests pass, with the nine LG models now exercised by the parametrized tests instead of skipped. `mypy`, `ruff check` and `ruff format --check` are clean.

```
LG0800BL probes=2   status: no smoker field   temps: grillSet=225 grill=215 p4=164
LG800FL  probes=4   status: no smoker field   temps: grillSet=225 grill=215 p4=164
```

## Note on the vendor data

I re-fetched `LG0800BL` and `LG800FL` from `api-prod.dansonscorp.com` while preparing this: `status_function`, `temperature_function` and the command list are all byte-identical to what's in the repo, so this isn't papering over an upstream fix.

Worth flagging separately: the nightly `update-grills.yml` job has been failing for months (it installs the now-deleted `requirements-dev.txt`, and before that died on missing `~/.pitboss` credentials), so `grills.json` hasn't been refreshed since 2025-12-02.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
