### PR TITLE
Run the grills.json sync weekly instead of daily

### DIFF
--- a/.github/workflows/update-grills.yml
+++ b/.github/workflows/update-grills.yml
@@ -2,7 +2,7 @@ name: Update grills.json
 
 on:
   schedule:
-    - cron: '0 0 * * *' # Runs at 00:00 UTC every day
+    - cron: '0 0 * * 4' # Runs at 00:00 UTC every Thursday
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary

Drops the `update-grills.yml` schedule from nightly to weekly, on Thursdays at 00:00 UTC.

The vendor catalogue changes rarely — the last real movement was 2025-12-02 — so a nightly sweep of 149 sequential API requests wasn't buying much. Thursday leaves a couple of working days plus the weekend to deal with anything a refresh breaks, which matters because a definitions update can introduce a model whose parsing routine fails the test suite (as the LBL/LFS boards did in #491).

```diff
-    - cron: '0 0 * * *' # Runs at 00:00 UTC every day
+    - cron: '0 0 * * 4' # Runs at 00:00 UTC every Thursday
```

`workflow_dispatch` is untouched, so on-demand runs still work.

## Notes

00:00 UTC Thursday is Wednesday evening in US timezones (~20:00 EDT), and these runs have historically started 50–110 minutes late from top-of-hour congestion on shared runners, so in practice the PR will be waiting first thing Thursday morning. `0 12 * * 4` would instead land around 08:00 EDT Thursday if that's preferable.

At weekly cadence a failed run now means seven days without a sync rather than one, so the connection retry and atomic write added in #492 carry a bit more weight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
