### PR TITLE
Skip grill IDs the API refuses to serve

### DIFF
--- a/scripts/dump_grills.py
+++ b/scripts/dump_grills.py
@@ -34,35 +34,52 @@ API_URL = "https://api-prod.dansonscorp.com/api/v1"
 async def get_grill_details(
     session: ClientSession, grill_id: int, attempts: int = 3
 ) -> dict[str, Any]:
-    """Fetches one grill definition, retrying dropped connections.
+    """Fetches one grill definition, or an empty dict if the API can't serve it.
 
-    The API hangs up on the occasional request part way through a full dump.
-    Without a retry that aborts the run, so the caller has to start over.
+    The ID space has gaps, and the API is inconsistent about how it reports
+    them: most return 404, but some return a persistent 500 (67 and 128 at the
+    time of writing, verified over repeated requests). It also hangs up on the
+    occasional request part way through a full sweep. None of these should
+    abort the whole run, so connection drops and server errors are retried, and
+    an ID that still won't load is skipped like a 404.
+
+    Client errors other than 404 are raised: a 401 means the credentials are
+    wrong, and retrying or skipping would quietly produce a partial catalogue.
     """
     _LOGGER.info("Fetching grill details for grill_id: %s", grill_id)
     for attempt in range(1, attempts + 1):
         try:
             resp = await session.get(f"{API_URL}/grills/{grill_id}")
-            try:
-                resp.raise_for_status()
-            except ClientResponseError as ex:
-                if ex.status == 404:
-                    _LOGGER.warning("Unknown grill ID: %s", grill_id)
-                    return {}
-                raise
+            resp.raise_for_status()
             resp_json = await resp.json()
-        except (ClientConnectionError, TimeoutError):
+        except ClientResponseError as ex:
+            if ex.status == 404:
+                _LOGGER.warning("Unknown grill ID: %s", grill_id)
+                return {}
+            if ex.status < 500:
+                raise
+            if attempt == attempts:
+                _LOGGER.warning(
+                    "Skipping grill ID %s: server returned %s on all %s attempts",
+                    grill_id,
+                    ex.status,
+                    attempts,
+                )
+                return {}
+            _LOGGER.warning("Server error %s for grill_id %s", ex.status, grill_id)
+        except (ClientConnectionError, TimeoutError) as ex:
             if attempt == attempts:
                 raise
-            delay = 2**attempt
-            _LOGGER.warning(
-                "Connection dropped for grill_id %s; retrying in %ss", grill_id, delay
-            )
-            await sleep(delay)
-            continue
-        if resp_json["status"] != "success":
-            raise Error(resp_json["message"])
-        return resp_json["data"]["grill"]
+            _LOGGER.warning("Connection dropped for grill_id %s: %s", grill_id, ex)
+        else:
+            if resp_json["status"] != "success":
+                raise Error(resp_json["message"])
+            return resp_json["data"]["grill"]
+
+        delay = 2**attempt
+        _LOGGER.info("Retrying grill_id %s in %ss", grill_id, delay)
+        await sleep(delay)
+
     raise Error(f"Could not fetch grill_id {grill_id}")
 
 
@@ -74,15 +91,24 @@ async def main():
             session, cfg["pitboss"]["username"], cfg["pitboss"]["password"]
         )
     grills = {}
+    skipped = []
     async with ClientSession(headers=auth_headers) as session:
         for i in range(1, 150):
             try:
                 grill = await get_grill_details(session, i)
                 if not grill:
+                    skipped.append(i)
                     continue
             except InvalidGrill:
                 break
             grills[grill["name"]] = grill
+
+    # Log a summary so a sweep that quietly collected less than usual is
+    # visible in the run output rather than only in the resulting diff.
+    if skipped:
+        _LOGGER.warning("Skipped %d grill IDs: %s", len(skipped), skipped)
+    _LOGGER.info("Collected %d grill definitions", len(grills))
+
     print(json.dumps(grills, indent=2, sort_keys=True))
 
 


### PR DESCRIPTION
## Summary

A manual `update-grills.yml` run died at `grill_id 67`:

```
aiohttp.client_exceptions.ClientResponseError: 500, message='Internal Server Error',
url='https://api-prod.dansonscorp.com/api/v1/grills/67'
```

The ID space has gaps, and the API is inconsistent about how it reports them. Most return 404, which `get_grill_details` already skips. Two do not.

## What I found

Probing the nine IDs absent from `grills.json` (67, 73, 94, 102, 103, 111, 118, 128, 132):

| IDs | Response |
|---|---|
| 67, 128 | **persistent 500** — 67 verified on three consecutive requests |
| 73, 94, 102, 103, 111, 118, 132 | 200, but each is a duplicate ID for a model already in the catalogue under a different ID |

So neither 500 ID is a real catalogue entry, and nothing is missing because of them. `grill_id 67` is also the same ID that aborted an earlier local run of mine with `ClientConnectionError` — the server has been unhappy with it for a while.

## Change

- Retry server errors alongside dropped connections, then skip an ID that still won't load — the same treatment 404 already gets.
- Client errors other than 404 still raise. A 401 means the credentials are wrong, and retrying or skipping it would quietly produce a partial catalogue instead of failing loudly.
- Log a summary of skipped IDs and the collected count, so a sweep that gathered less than usual shows up in the run output rather than only in the resulting diff.

## Verified

Full local sweep with the fix:

```
WARNING  Server error 500 for grill_id 67
INFO     Retrying grill_id 67 in 2s
WARNING  Server error 500 for grill_id 67
INFO     Retrying grill_id 67 in 4s
WARNING  Skipping grill ID 67: server returned 500 on all 3 attempts
...
WARNING  Skipped 2 grill IDs: [67, 128]
INFO     Collected 140 grill definitions
exit=0
```

`ruff`, `ruff format --check` and `mypy` clean.

## Bonus: the refresh is safe

That sweep also produced the first complete catalogue since 2025-12-02, so I diffed it against the checked-in one. **No parsing routine or command changed on any of the 140 models**, and no model was added or removed. The entire eight-month diff is metadata:

| Models affected | Field |
|---|---|
| 140 | `app_layout` — new field |
| 6 | `control_board.platform_id`, `control_board.updated_at` |
| 1 | `friendly_name` (`PBV4DX`: `None` → `''`), `updated_at` |

`control_board.device_status_function` is also a new key, but null on every model.

So the backlog everyone was braced for is inert — no risk to the test suite. Once this lands, a `workflow_dispatch` run should produce a large but entirely additive PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
