### PR TITLE
Derive the fahrenheit conversion from the routine, not a board list

### DIFF
--- a/tests/test_grills.py
+++ b/tests/test_grills.py
@@ -7,11 +7,6 @@ import pytest
 from pytboss import grills as grills_lib
 from pytboss.exceptions import InvalidGrill
 
-# Most control boards perform the fahrenheit to celsius conversion internally,
-# however these boards do NOT and instead rely on the conversion to happen in
-# their JS snippets.
-_HAS_FTOC = ("LFS", "PBA", "PBE", "PBM", "PBT", "PBV", "PBM2", "PBV2", "PBVA", "PBL3")
-
 TEMPERATURE_FIELDS = (
     "p1Target",
     "p2Target",
@@ -62,6 +57,19 @@ class JSFunc:
         return "\n".join(
             f"{i:3} {line}" for i, line in enumerate(self._js.splitlines())
         )
+
+    def converts_to_celsius(self):
+        """Whether this routine converts fahrenheit to celsius itself.
+
+        Most control boards convert internally and report whichever unit the
+        grill is set to, but some report fahrenheit always and rely on an
+        ftoc() helper in their JS snippet. Read that off the routine rather
+        than maintaining a list of board names: a definitions refresh can
+        introduce a board that converts, and the two routines for one board
+        do not always agree -- PBL3 converts in its temperatures reply but
+        not in its status reply.
+        """
+        return "ftoc" in self._js
 
     def has_key(self, k, ignore_comments=True):
         if ignore_comments:
@@ -183,7 +191,7 @@ class TestGetGrills:
                     continue
 
                 temp = want[key]
-                if grill.control_board.name in _HAS_FTOC:
+                if js.converts_to_celsius():
                     temp = f_to_c(want[key])
                 try:
                     assert status[key] == temp, f"{key}: {status[key]} != {temp}"  # type: ignore[literal-required]
@@ -307,7 +315,7 @@ class TestGetGrills:
                 if key not in msg or key not in want:
                     continue
                 temp = want[key]
-                if grill.control_board.name in _HAS_FTOC:
+                if js.converts_to_celsius():
                     temp = f_to_c(want[key])
                 try:
                     assert status[key] == temp, f"{key}: {status[key]} != {temp}"  # type: ignore[literal-required]


### PR DESCRIPTION
## Summary

`_HAS_FTOC` hardcoded which control boards convert fahrenheit to celsius inside their JS rather than internally:

```python
_HAS_FTOC = ("LFS", "PBA", "PBE", "PBM", "PBT", "PBV", "PBM2", "PBV2", "PBVA", "PBL3")
```

That list has to be hand-edited whenever a definitions refresh introduces a converting board, and the tests fail until someone does it — one more way a routine `grills.json` update breaks CI, which is the failure mode that kept the sync workflow unattended for months.

The routines already carry the answer. Testing for an `ftoc()` helper in the snippet matches the list on **18 of 19 boards**:

| | in `_HAS_FTOC` | has `ftoc()` |
|---|---|---|
| LFS, PBA, PBE, PBM, PBM2, PBT, PBV, PBV2, PBVA, PBL3 | yes | yes |
| LBL, PBB, PBC, PBC2, PBD, PBG, PBL, PBP | no | no |
| **PBX1** | **no** | **yes** |

`PBX1` is in `UNSUPPORTED_MODELS`, so it's never exercised — the list has been quietly wrong there without anyone noticing.

## Per-routine is more accurate than per-board

A board-level list can't express what the data actually says. `PBL3` has an `ftoc()` helper in its **temperatures** reply but not in its **status** reply:

```
board  status  temps
PBL3   False   True    <-- one list entry cannot describe both
```

`test_parse_state` and `test_parse_temperatures` each now read the predicate off the routine they're actually testing.

## Change

`_HAS_FTOC` is gone. `JSFunc` gains:

```python
def converts_to_celsius(self):
    return "ftoc" in self._js
```

Both call sites use it in place of the board-name lookup.

## Verified

513 tests pass; `ruff`, `ruff format --check` and `mypy` clean.

The predicate is load-bearing rather than vacuously true — inverting it fails 146 tests:

```
--- with the predicate inverted:
146 failed, 271 passed
--- restored:
417 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
