### PR TITLE
Drop vendor bookkeeping fields from the checked-in definitions

### DIFF
--- a/pytboss/grills.json
+++ b/pytboss/grills.json
@@ -3,2609 +3,1774 @@
     "LBL": {
       "control_board_commands": [
         {
-          "control_board_id": 8,
-          "created_at": "2022-12-06T15:28:54.000000Z",
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0902FF",
           "id": 95,
           "name": "Set Temperature to Celcius",
-          "slug": "set-celsius",
-          "updated_at": "2022-12-09T12:11:06.000000Z"
+          "slug": "set-celsius"
         },
         {
-          "control_board_id": 8,
-          "created_at": "2022-12-06T15:31:52.000000Z",
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0901FF",
           "id": 96,
           "name": "Set Temperature to Fahrenheit",
-          "slug": "set-fahrenheit",
-          "updated_at": "2022-12-06T15:31:52.000000Z"
+          "slug": "set-fahrenheit"
         },
         {
-          "control_board_id": 8,
-          "created_at": "2022-12-06T15:33:02.000000Z",
-          "deleted_at": null,
           "description": null,
           "function": "let _hundreds = Math.floor(arguments[0]/100); let _tens = Math.floor((arguments[0] % 100) / 10); let _ones = Math.floor(arguments[0] % 10); return 'FE0501'+formatHex(_hundreds)+formatHex(_tens)+formatHex(_ones) + 'FF';",
           "hexadecimal": null,
           "id": 97,
           "name": "Set Grill Temperature",
-          "slug": "set-temperature",
-          "updated_at": "2022-12-06T15:33:02.000000Z"
+          "slug": "set-temperature"
         },
         {
-          "control_board_id": 8,
-          "created_at": "2022-12-06T15:33:48.000000Z",
-          "deleted_at": null,
           "description": null,
           "function": "let _hundreds = Math.floor(arguments[0]/100); let _tens = Math.floor((arguments[0] % 100) / 10); let _ones = Math.floor(arguments[0] % 10); return 'FE0502'+formatHex(_hundreds)+formatHex(_tens)+formatHex(_ones) + 'FF';",
           "hexadecimal": null,
           "id": 98,
           "name": "Set Probe 1 Temperature",
-          "slug": "set-prove-1-temperature",
-          "updated_at": "2022-12-06T15:33:48.000000Z"
+          "slug": "set-prove-1-temperature"
         },
         {
-          "control_board_id": 8,
-          "created_at": "2022-12-06T15:34:51.000000Z",
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0200FF",
           "id": 99,
           "name": "Turn Light Off",
-          "slug": "turn-light-off",
-          "updated_at": "2022-12-06T15:34:51.000000Z"
+          "slug": "turn-light-off"
         },
         {
-          "control_board_id": 8,
-          "created_at": "2022-12-06T15:35:24.000000Z",
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0201FF",
           "id": 100,
           "name": "Turn Light On",
-          "slug": "turn-light-on",
-          "updated_at": "2022-12-06T15:35:24.000000Z"
+          "slug": "turn-light-on"
         },
         {
-          "control_board_id": 8,
-          "created_at": "2022-12-06T15:36:19.000000Z",
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0102FF",
           "id": 101,
           "name": "Turn Grill Off",
-          "slug": "turn-off",
-          "updated_at": "2022-12-06T15:36:19.000000Z"
+          "slug": "turn-off"
         },
         {
-          "control_board_id": 8,
-          "created_at": "2022-12-06T15:37:20.000000Z",
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0800FF",
           "id": 103,
           "name": "Turn Primer Motor Off",
-          "slug": "turn-primer-motor-off",
-          "updated_at": "2022-12-06T15:37:20.000000Z"
+          "slug": "turn-primer-motor-off"
         },
         {
-          "control_board_id": 8,
-          "created_at": "2022-12-06T15:38:19.000000Z",
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0801FF",
           "id": 104,
           "name": "Turn Primer Motor On",
-          "slug": "turn-primer-motor-on",
-          "updated_at": "2022-12-06T15:38:19.000000Z"
+          "slug": "turn-primer-motor-on"
         }
       ],
-      "created_at": "2022-06-27T00:00:00.000000Z",
-      "deleted_at": null,
       "device_status_function": null,
       "id": 8,
       "name": "LBL",
       "platform_id": 1,
       "site_id": 2,
       "status_function": "if (!message.startsWith(\"FE0B\")) {\r\n  return null;\r\n}\r\nconst parts = parseHexMessage(message);\r\nif (parts < 41) {\r\n  return null;\r\n}\r\nconst status = {\r\n  p1Target: convertTemperature(parts, 2),\r\n  p1Temp: convertTemperature(parts, 5),\r\n  p2Temp: convertTemperature(parts, 8),\r\n  p3Temp: convertTemperature(parts, 11),\r\n  p4Temp: convertTemperature(parts, 14),\r\n  smokerActTemp: convertTemperature(parts, 14),\r\n  moduleIsOn: parts[21] === 1,\r\n  err1: parts[22] === 1,\r\n  err2: parts[23] === 1,\r\n  err3: parts[24] === 1,\r\n  highTempErr: parts[25] === 1,\r\n  fanErr: parts[26] === 1,\r\n  hotErr: parts[27] === 1,\r\n  motorErr: parts[28] === 1,\r\n  noPellets: parts[29] === 1,\r\n  erL: parts[30] === 1,\r\n  fanState: parts[31] === 1,\r\n  hotState: parts[32] === 1,\r\n  motorState: parts[33] === 1,\r\n  lightState: parts[34] === 1,\r\n  primeState: parts[35] === 1,\r\n  isFahrenheit: parts[36] === 1,\r\n  recipeStep: parts[37],\r\n  recipeTime: parts[38] * 3600 + parts[39] * 60 + parts[40],\r\n};\r\nswitch (parts[23]) {\r\n  case 1:\r\n    status.grillSetTemp = convertTemperature(parts, 20);\r\n    break;\r\n  case 2:\r\n    status.grillTemp = convertTemperature(parts, 20);\r\n    break;\r\n}\r\nreturn status;",
-      "temperature_function": "if (!message.startsWith(\"FE0C\")) {\r\n  return null;\r\n}\r\nconst parts = parseHexMessage(message);\r\nif (parts < 24) {\r\n  return null;\r\n}\r\nreturn {\r\n  p1Target: convertTemperature(parts, 2),\r\n  p1Temp: convertTemperature(parts, 5),\r\n  p2Temp: convertTemperature(parts, 8),\r\n  p3Temp: convertTemperature(parts, 11),\r\n  p4Temp: convertTemperature(parts, 14),\r\n  grillSetTemp: convertTemperature(parts, 17),\r\n  grillTemp: convertTemperature(parts, 20),\r\n  smokerActTemp: convertTemperature(parts, 17),\r\n  isFahrenheit: parts[23] === 1,\r\n};",
-      "updated_at": "2023-01-30T14:06:01.000000Z"
+      "temperature_function": "if (!message.startsWith(\"FE0C\")) {\r\n  return null;\r\n}\r\nconst parts = parseHexMessage(message);\r\nif (parts < 24) {\r\n  return null;\r\n}\r\nreturn {\r\n  p1Target: convertTemperature(parts, 2),\r\n  p1Temp: convertTemperature(parts, 5),\r\n  p2Temp: convertTemperature(parts, 8),\r\n  p3Temp: convertTemperature(parts, 11),\r\n  p4Temp: convertTemperature(parts, 14),\r\n  grillSetTemp: convertTemperature(parts, 17),\r\n  grillTemp: convertTemperature(parts, 20),\r\n  smokerActTemp: convertTemperature(parts, 17),\r\n  isFahrenheit: parts[23] === 1,\r\n};"
     },
     "LFS": {
       "control_board_commands": [
         {
-          "control_board_id": 9,
-          "created_at": "2022-12-06T15:28:54.000000Z",
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0902FF",
           "id": 105,
           "name": "Set Temperature to Celcius",
-          "slug": "set-celsius",
-          "updated_at": "2022-12-09T12:11:26.000000Z"
+          "slug": "set-celsius"
         },
         {
-          "control_board_id": 9,
-          "created_at": "2022-12-06T15:31:52.000000Z",
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0901FF",
           "id": 106,
           "name": "Set Temperature to Fahrenheit",
-          "slug": "set-fahrenheit",
-          "updated_at": "2022-12-06T15:31:52.000000Z"
+          "slug": "set-fahrenheit"
         },
         {
-          "control_board_id": 9,
-          "created_at": "2022-12-06T15:33:02.000000Z",
-          "deleted_at": null,
           "description": null,
           "function": "let temp = arguments[1] === false ? Math.round(((arguments[0] * 1.8)+ 32)/5) * 5 : arguments[0]; let _hundreds = Math.floor(temp/100); let _tens = Math.floor((temp % 100) / 10); let _ones = Math.floor(temp % 10); return 'FE0501'+formatHex(_hundreds)+formatHex(_tens)+formatHex(_ones) + 'FF';",
           "hexadecimal": null,
           "id": 107,
           "name": "Set Grill Temperature",
-          "slug": "set-temperature",
-          "updated_at": "2023-01-30T14:09:06.000000Z"
+          "slug": "set-temperature"
         },
         {
-          "control_board_id": 9,
-          "created_at": "2022-12-06T15:34:51.000000Z",
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0200FF",
           "id": 109,
           "name": "Turn Light Off",
-          "slug": "turn-light-off",
-          "updated_at": "2022-12-06T15:34:51.000000Z"
+          "slug": "turn-light-off"
         },
         {
-          "control_board_id": 9,
-          "created_at": "2022-12-06T15:35:24.000000Z",
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0201FF",
           "id": 110,
           "name": "Turn Light On",
-          "slug": "turn-light-on",
-          "updated_at": "2022-12-06T15:35:24.000000Z"
+          "slug": "turn-light-on"
         },
         {
-          "control_board_id": 9,
-          "created_at": "2022-12-06T15:36:19.000000Z",
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0102FF",
           "id": 111,
           "name": "Turn Grill Off",
-          "slug": "turn-off",
-          "updated_at": "2022-12-06T15:36:19.000000Z"
+          "slug": "turn-off"
         },
         {
-          "control_board_id": 9,
-          "created_at": "2022-12-06T15:37:20.000000Z",
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0800FF",
           "id": 113,
           "name": "Turn Primer Motor Off",
-          "slug": "turn-primer-motor-off",
-          "updated_at": "2022-12-06T15:37:20.000000Z"
+          "slug": "turn-primer-motor-off"
         },
         {
-          "control_board_id": 9,
-          "created_at": "2022-12-06T15:38:19.000000Z",
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0801FF",
           "id": 114,
           "name": "Turn Primer Motor On",
-          "slug": "turn-primer-motor-on",
-          "updated_at": "2022-12-06T15:38:19.000000Z"
+          "slug": "turn-primer-motor-on"
         }
       ],
-      "created_at": "2022-06-27T00:00:00.000000Z",
-      "deleted_at": null,
       "device_status_function": null,
       "id": 9,
       "name": "LFS",
       "platform_id": 1,
       "site_id": 2,
       "status_function": "if (!message.startsWith(\"FE0B\")) {\r\n  return null;\r\n}\r\nconst parts = parseHexMessage(message);\r\nif (parts < 41) {\r\n  return null;\r\n}\r\nconst status = {\r\n/*  p1Target: convertTemperature(parts, 2), */\r\n  p1Temp: convertTemperature(parts, 5),\r\n  p2Temp: convertTemperature(parts, 8),\r\n  p3Temp: convertTemperature(parts, 11),\r\n  p4Temp: convertTemperature(parts, 14),\r\n  smokerActTemp: convertTemperature(parts, 14),\r\n  moduleIsOn: parts[21] === 1,\r\n  err1: parts[22] === 1,\r\n  err2: parts[23] === 1,\r\n  err3: parts[24] === 1,\r\n  highTempErr: parts[25] === 1,\r\n  fanErr: parts[26] === 1,\r\n  hotErr: parts[27] === 1,\r\n  motorErr: parts[28] === 1,\r\n  noPellets: parts[29] === 1,\r\n  erL: parts[30] === 1,\r\n  fanState: parts[31] === 1,\r\n  hotState: parts[32] === 1,\r\n  motorState: parts[33] === 1,\r\n  lightState: parts[34] === 1,\r\n  primeState: parts[35] === 1,\r\n  isFahrenheit: parts[36] === 1,\r\n  recipeStep: parts[37],\r\n  recipeTime: parts[38] * 3600 + parts[39] * 60 + parts[40],\r\n};\r\nswitch (parts[23]) {\r\n  case 1:\r\n    status.grillSetTemp = convertTemperature(parts, 20);\r\n    break;\r\n  case 2:\r\n    status.grillTemp = convertTemperature(parts, 20);\r\n    break;\r\n}\r\nif (!status.isFahrenheit) {\r\n  const ftoc = function (temp) {\r\n    if (typeof temp === \"undefined\" || temp === 960) {\r\n      return temp;\r\n    }\r\n    return Math.floor((temp - 32) / 1.8);\r\n  };\r\n  status.p1Target = ftoc(status.p1Target);\r\n  status.p1Temp = ftoc(status.p1Temp);\r\n  status.p2Temp = ftoc(status.p2Temp);\r\n  status.p3Temp = ftoc(status.p3Temp);\r\n  status.p4Temp = ftoc(status.p4Temp);\r\n  status.grillSetTemp = ftoc(status.grillSetTemp);\r\n  status.grillTemp = ftoc(status.grillTemp);\r\n  status.smokerActTemp = ftoc(status.smokerActTemp);\r\n}\r\n\r\nreturn status;",
-      "temperature_function": "if (!message.startsWith(\"FE0C\")) {\r\n  return null;\r\n}\r\nconst parts = parseHexMessage(message);\r\nif (parts < 24) {\r\n  return null;\r\n}\r\nconst temps = {\r\n /* p1Target: convertTemperature(parts, 2), */\r\n  p1Temp: convertTemperature(parts, 5),\r\n  p2Temp: convertTemperature(parts, 8),\r\n  p3Temp: convertTemperature(parts, 11),\r\n  p4Temp: convertTemperature(parts, 14),\r\n  grillSetTemp: convertTemperature(parts, 17),\r\n  grillTemp: convertTemperature(parts, 20),\r\n  smokerActTemp: convertTemperature(parts, 17),\r\n  isFahrenheit: parts[23] === 1,\r\n};\r\n\r\nif (!temps.isFahrenheit) {\r\n  const ftoc = function (temp) {\r\n    if (typeof temp === \"undefined\" || temp === 960) {\r\n      return temp;\r\n    }\r\n    return Math.floor((temp - 32) / 1.8);\r\n  };\r\n  temps.p1Temp = ftoc(temps.p1Temp);\r\n  temps.p2Temp = ftoc(temps.p2Temp);\r\n  temps.p3Temp = ftoc(temps.p3Temp);\r\n  temps.p4Temp = ftoc(temps.p4Temp);\r\n  temps.grillSetTemp = ftoc(temps.grillSetTemp);\r\n  temps.grillTemp = ftoc(temps.grillTemp);\r\n  temps.smokerActTemp = ftoc(temps.smokerActTemp);\r\n  temps.p1Target = ftoc(temps.p1Target);\r\n}\r\n\r\nreturn temps;",
-      "updated_at": "2023-02-08T09:30:34.000000Z"
+      "temperature_function": "if (!message.startsWith(\"FE0C\")) {\r\n  return null;\r\n}\r\nconst parts = parseHexMessage(message);\r\nif (parts < 24) {\r\n  return null;\r\n}\r\nconst temps = {\r\n /* p1Target: convertTemperature(parts, 2), */\r\n  p1Temp: convertTemperature(parts, 5),\r\n  p2Temp: convertTemperature(parts, 8),\r\n  p3Temp: convertTemperature(parts, 11),\r\n  p4Temp: convertTemperature(parts, 14),\r\n  grillSetTemp: convertTemperature(parts, 17),\r\n  grillTemp: convertTemperature(parts, 20),\r\n  smokerActTemp: convertTemperature(parts, 17),\r\n  isFahrenheit: parts[23] === 1,\r\n};\r\n\r\nif (!temps.isFahrenheit) {\r\n  const ftoc = function (temp) {\r\n    if (typeof temp === \"undefined\" || temp === 960) {\r\n      return temp;\r\n    }\r\n    return Math.floor((temp - 32) / 1.8);\r\n  };\r\n  temps.p1Temp = ftoc(temps.p1Temp);\r\n  temps.p2Temp = ftoc(temps.p2Temp);\r\n  temps.p3Temp = ftoc(temps.p3Temp);\r\n  temps.p4Temp = ftoc(temps.p4Temp);\r\n  temps.grillSetTemp = ftoc(temps.grillSetTemp);\r\n  temps.grillTemp = ftoc(temps.grillTemp);\r\n  temps.smokerActTemp = ftoc(temps.smokerActTemp);\r\n  temps.p1Target = ftoc(temps.p1Target);\r\n}\r\n\r\nreturn temps;"
     },
     "PBA": {
       "control_board_commands": [
         {
-          "control_board_id": 10,
-          "created_at": null,
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0B01FF",
           "id": 71,
           "name": "Get Grill Status",
-          "slug": "get-status",
-          "updated_at": null
+          "slug": "get-status"
         },
         {
-          "control_board_id": 10,
-          "created_at": null,
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0C01FF",
           "id": 72,
           "name": "Get Grill/Probes Temperatures",
-          "slug": "get-temperatures",
-          "updated_at": null
+          "slug": "get-temperatures"
         },
         {
-          "control_board_id": 10,
-          "created_at": null,
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0902FF",
           "id": 73,
           "name": "Set Temperature to Celsius",
-          "slug": "set-celsius",
-          "updated_at": null
+          "slug": "set-celsius"
         },
         {
-          "control_board_id": 10,
-          "created_at": null,
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0901FF",
           "id": 74,
           "name": "Set Temperature to Fahrenheit",
-          "slug": "set-fahrenheit",
-          "updated_at": null
+          "slug": "set-fahrenheit"
         },
         {
-          "control_board_id": 10,
-          "created_at": null,
-          "deleted_at": null,
           "description": null,
           "function": "let temp = arguments[1] === false ? Math.round(((arguments[0] * 1.8)+ 32)/5) * 5 : arguments[0]; let _hundreds = Math.floor(temp/100); let _tens = Math.floor((temp % 100) / 10); let _ones = Math.floor(temp % 10); return 'FE0502'+formatHex(_hundreds)+formatHex(_tens)+formatHex(_ones) + 'FF';",
           "hexadecimal": null,
           "id": 75,
           "name": "Set Probe 1 Temperature",
-          "slug": "set-probe-1-temperature",
-          "updated_at": "2024-09-17T15:16:23.000000Z"
+          "slug": "set-probe-1-temperature"
         },
         {
-          "control_board_id": 10,
-          "created_at": null,
-          "deleted_at": null,
           "description": null,
           "function": "let temp = arguments[1] === false ? Math.round(((arguments[0] * 1.8)+ 32)/5) * 5 : arguments[0]; let _hundreds = Math.floor(temp/100); let _tens = Math.floor((temp % 100) / 10); let _ones = Math.floor(temp % 10); return 'FE0501'+formatHex(_hundreds)+formatHex(_tens)+formatHex(_ones) + 'FF';",
           "hexadecimal": null,
           "id": 76,
           "name": "Set Grill Temperature",
-          "slug": "set-temperature",
-          "updated_at": "2024-09-17T15:16:50.000000Z"
+          "slug": "set-temperature"
         },
         {
-          "control_board_id": 10,
-          "created_at": null,
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0200FF",
           "id": 77,
           "name": "Turn Light Off",
-          "slug": "turn-light-off",
-          "updated_at": null
+          "slug": "turn-light-off"
         },
         {
-          "control_board_id": 10,
-          "created_at": null,
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0201FF",
           "id": 78,
           "name": "Turn Light On",
-          "slug": "turn-light-on",
-          "updated_at": null
+          "slug": "turn-light-on"
         },
         {
-          "control_board_id": 10,
-          "created_at": null,
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0102FF",
           "id": 79,
           "name": "Turn Grill Off",
-          "slug": "turn-off",
-          "updated_at": null
+          "slug": "turn-off"
         },
         {
-          "control_board_id": 10,
-          "created_at": null,
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0800FF",
           "id": 81,
           "name": "Turn Primer Motor Off",
-          "slug": "turn-primer-motor-off",
-          "updated_at": null
+          "slug": "turn-primer-motor-off"
         },
         {
-          "control_board_id": 10,
-          "created_at": null,
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0801FF",
           "id": 82,
           "name": "Turn Primer Motor On",
-          "slug": "turn-primer-motor-on",
-          "updated_at": null
+          "slug": "turn-primer-motor-on"
         },
         {
-          "control_board_id": 10,
-          "created_at": "2022-12-22T09:05:29.000000Z",
-          "deleted_at": null,
           "description": "set the target temperature of probe #2",
           "function": "let temp = arguments[1] === false ? Math.round(((arguments[0] * 1.8)+ 32)/5) * 5 : arguments[0]; let _hundreds = Math.floor(temp/100); let _tens = Math.floor((temp % 100) / 10); let _ones = Math.floor(temp % 10); return 'FE0503'+formatHex(_hundreds)+formatHex(_tens)+formatHex(_ones) + 'FF';",
           "hexadecimal": null,
           "id": 115,
           "name": "Set Probe 2 Temperature",
-          "slug": "set-probe-2-temperature",
-          "updated_at": "2024-09-17T15:17:07.000000Z"
+          "slug": "set-probe-2-temperature"
         }
       ],
-      "created_at": "2022-06-27T00:00:00.000000Z",
-      "deleted_at": null,
       "device_status_function": null,
       "id": 10,
       "name": "PBA",
       "platform_id": 5,
       "site_id": 1,
       "status_function": "if (!message.startsWith(\"FE0B\")) {\r\n  return null;\r\n}\r\nconst parts = parseHexMessage(message);\r\nif (parts.length < 47) {\r\n  return null;\r\n}\r\n//const p1Target = convertTemperature(parts, 2);\r\n//const p2Target = convertTemperature(parts, 5);\r\n\r\nconst status = {\r\n//  p1Target: p1Target !== 000 && p1Target !== 960 ? p1Target : null,\r\n//  p2Target: p2Target !== 000 && p2Target !== 960 ? p2Target : null,\r\n//  p1Temp: convertTemperature(parts, 8),\r\n//  p2Temp: convertTemperature(parts, 11),\r\n//  p3Temp: convertTemperature(parts, 14),\r\n//  p4Temp: convertTemperature(parts, 17),\r\n//  smokerActTemp: convertTemperature(parts, 20),\r\n  moduleIsOn: parts[27] === 1,\r\n  err1: parts[28] === 1,\r\n  err2: parts[29] === 1,\r\n  err3: parts[30] === 1,\r\n  highTempErr: parts[31] === 1,\r\n  fanErr: parts[32] === 1,\r\n  hotErr: parts[33] === 1,\r\n  motorErr: parts[34] === 1,\r\n  noPellets: parts[35] === 1,\r\n  erL: parts[36] === 1,\r\n  fanState: parts[37] === 1,\r\n  hotState: parts[38] === 1,\r\n  motorState: parts[39] === 1,\r\n  lightState: parts[40] === 1,\r\n  primeState: parts[41] === 1,\r\n//  isFahrenheit: parts[42] === 1,\r\n  recipeStep: parts[43],\r\n  recipeTime: parts[44] * 3600 + parts[45] * 60 + parts[46],\r\n};\r\n/*switch (parts[26]) {\r\n  case 1:\r\n    status.grillSetTemp = convertTemperature(parts, 23);\r\n    break;\r\n  case 2:\r\n    status.grillTemp = convertTemperature(parts, 23);\r\n    break;\r\n}\r\nif (!status.isFahrenheit) {\r\n  const ftoc = function (temp) {\r\n    if ((typeof temp === \"undefined\") || (temp === 960)) {\r\n      return temp;\r\n    }\r\n    return Math.floor((temp - 32) / 1.8);\r\n  };\r\n  status.p1Temp = ftoc(status.p1Temp);\r\n  status.p2Temp = ftoc(status.p2Temp);\r\n  status.p3Temp = ftoc(status.p3Temp);\r\n  status.grillSetTemp = ftoc(status.grillSetTemp);\r\n  status.grillTemp = ftoc(status.grillTemp);\r\n  status.p1Target =  ftoc(status.p1Target);\r\n  status.p2Target =  ftoc(status.p2Target);\r\n}*/\r\nreturn status;",
-      "temperature_function": "if (!message.startsWith(\"FE0C\")) {\r\n  return null;\r\n}\r\nconst parts = parseHexMessage(message);\r\nif (parts.length < 30) {\r\n  return null;\r\n}\r\n\r\nconst p1Target = convertTemperature(parts, 2);\r\nconst p2Target = convertTemperature(parts, 5);\r\nconst status = {\r\n  p1Target: p1Target !== 000 && p1Target !== 960 ? p1Target : null,\r\n  p2Target: p2Target !== 000 && p2Target !== 960 ? p2Target : null,\r\n  p1Temp: convertTemperature(parts, 8),\r\n  p2Temp: convertTemperature(parts, 11),\r\n  p3Temp: convertTemperature(parts, 14),\r\n  p4Temp: convertTemperature(parts, 17),\r\n  grillSetTemp: convertTemperature(parts, 23),\r\n  grillTemp: convertTemperature(parts, 26),\r\n  smokerActTemp: convertTemperature(parts, 20),\r\n  isFahrenheit: parts[29] === 1,\r\n};\r\nif (!status.isFahrenheit) {\r\n  const ftoc = function (temp) {\r\n    if ((typeof temp === \"undefined\") || (temp === 960)) {\r\n      return temp;\r\n    }\r\n    return Math.floor((temp - 32) / 1.8);\r\n  };\r\n  status.p1Temp = ftoc(status.p1Temp);\r\n  status.p2Temp = ftoc(status.p2Temp);\r\n  status.p3Temp = ftoc(status.p3Temp);\r\n  status.grillSetTemp = ftoc(status.grillSetTemp);\r\n  status.grillTemp = ftoc(status.grillTemp);\r\n  status.p1Target =  ftoc(status.p1Target);\r\n  status.p2Target =  ftoc(status.p2Target);\r\n}\r\n\r\nreturn status;",
-      "updated_at": "2025-09-17T20:48:53.000000Z"
+      "temperature_function": "if (!message.startsWith(\"FE0C\")) {\r\n  return null;\r\n}\r\nconst parts = parseHexMessage(message);\r\nif (parts.length < 30) {\r\n  return null;\r\n}\r\n\r\nconst p1Target = convertTemperature(parts, 2);\r\nconst p2Target = convertTemperature(parts, 5);\r\nconst status = {\r\n  p1Target: p1Target !== 000 && p1Target !== 960 ? p1Target : null,\r\n  p2Target: p2Target !== 000 && p2Target !== 960 ? p2Target : null,\r\n  p1Temp: convertTemperature(parts, 8),\r\n  p2Temp: convertTemperature(parts, 11),\r\n  p3Temp: convertTemperature(parts, 14),\r\n  p4Temp: convertTemperature(parts, 17),\r\n  grillSetTemp: convertTemperature(parts, 23),\r\n  grillTemp: convertTemperature(parts, 26),\r\n  smokerActTemp: convertTemperature(parts, 20),\r\n  isFahrenheit: parts[29] === 1,\r\n};\r\nif (!status.isFahrenheit) {\r\n  const ftoc = function (temp) {\r\n    if ((typeof temp === \"undefined\") || (temp === 960)) {\r\n      return temp;\r\n    }\r\n    return Math.floor((temp - 32) / 1.8);\r\n  };\r\n  status.p1Temp = ftoc(status.p1Temp);\r\n  status.p2Temp = ftoc(status.p2Temp);\r\n  status.p3Temp = ftoc(status.p3Temp);\r\n  status.grillSetTemp = ftoc(status.grillSetTemp);\r\n  status.grillTemp = ftoc(status.grillTemp);\r\n  status.p1Target =  ftoc(status.p1Target);\r\n  status.p2Target =  ftoc(status.p2Target);\r\n}\r\n\r\nreturn status;"
     },
     "PBB": {
       "control_board_commands": [
         {
-          "control_board_id": 11,
-          "created_at": null,
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0B01FF",
           "id": 83,
           "name": "Get Grill Status",
-          "slug": "get-status",
-          "updated_at": null
+          "slug": "get-status"
         },
         {
-          "control_board_id": 11,
-          "created_at": null,
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0C01FF",
           "id": 84,
           "name": "Get Grill/Probes Temperatures",
-          "slug": "get-temperatures",
-          "updated_at": null
+          "slug": "get-temperatures"
         },
         {
-          "control_board_id": 11,
-          "created_at": null,
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0902FF",
           "id": 85,
           "name": "Set Temperature to Celsius",
-          "slug": "set-celsius",
-          "updated_at": null
+          "slug": "set-celsius"
         },
         {
-          "control_board_id": 11,
-          "created_at": null,
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0901FF",
           "id": 86,
           "name": "Set Temperature to Fahrenheit",
-          "slug": "set-fahrenheit",
-          "updated_at": null
+          "slug": "set-fahrenheit"
         },
         {
-          "control_board_id": 11,
-          "created_at": null,
-          "deleted_at": null,
           "description": null,
           "function": "let _hundreds = Math.floor(arguments[0]/100); let _tens = Math.floor((arguments[0] % 100) / 10); let _ones = Math.floor(arguments[0] % 10); return 'FE0502'+formatHex(_hundreds)+formatHex(_tens)+formatHex(_ones) + 'FF';",
           "hexadecimal": null,
           "id": 87,
           "name": "Set Probe 1 Temperature",
-          "slug": "set-probe-1-temperature",
-          "updated_at": null
+          "slug": "set-probe-1-temperature"
         },
         {
-          "control_board_id": 11,
-          "created_at": null,
-          "deleted_at": null,
           "description": null,
           "function": "let _hundreds = Math.floor(arguments[0]/100); let _tens = Math.floor((arguments[0] % 100) / 10); let _ones = Math.floor(arguments[0] % 10); return 'FE0501'+formatHex(_hundreds)+formatHex(_tens)+formatHex(_ones) + 'FF';",
           "hexadecimal": null,
           "id": 88,
           "name": "Set Grill Temperature",
-          "slug": "set-temperature",
-          "updated_at": null
+          "slug": "set-temperature"
         },
         {
-          "control_board_id": 11,
-          "created_at": null,
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0200FF",
           "id": 89,
           "name": "Turn Light Off",
-          "slug": "turn-light-off",
-          "updated_at": null
+          "slug": "turn-light-off"
         },
         {
-          "control_board_id": 11,
-          "created_at": null,
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0201FF",
           "id": 90,
           "name": "Turn Light On",
-          "slug": "turn-light-on",
-          "updated_at": null
+          "slug": "turn-light-on"
         },
         {
-          "control_board_id": 11,
-          "created_at": null,
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0102FF",
           "id": 91,
           "name": "Turn Grill Off",
-          "slug": "turn-off",
-          "updated_at": null
+          "slug": "turn-off"
         },
         {
-          "control_board_id": 11,
-          "created_at": null,
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0800FF",
           "id": 93,
           "name": "Turn Primer Motor Off",
-          "slug": "turn-primer-motor-off",
-          "updated_at": null
+          "slug": "turn-primer-motor-off"
         },
         {
-          "control_board_id": 11,
-          "created_at": null,
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0801FF",
           "id": 94,
           "name": "Turn Primer Motor On",
-          "slug": "turn-primer-motor-on",
-          "updated_at": null
+          "slug": "turn-primer-motor-on"
         },
         {
-          "control_board_id": 11,
-          "created_at": "2023-01-03T10:03:36.000000Z",
-          "deleted_at": null,
           "description": "set the target temperature of probe #2",
           "function": "let _hundreds = Math.floor(arguments[0]/100); let _tens = Math.floor((arguments[0] % 100) / 10); let _ones = Math.floor(arguments[0] % 10); return 'FE0503'+formatHex(_hundreds)+formatHex(_tens)+formatHex(_ones) + 'FF';",
           "hexadecimal": null,
           "id": 116,
           "name": "Set Probe 2 Temperature",
-          "slug": "set-probe-2-temperature",
-          "updated_at": "2023-01-03T10:03:36.000000Z"
+          "slug": "set-probe-2-temperature"
         }
       ],
-      "created_at": "2022-06-27T00:00:00.000000Z",
-      "deleted_at": null,
       "device_status_function": null,
       "id": 11,
       "name": "PBB",
       "platform_id": 2,
       "site_id": 1,
       "status_function": "if (!message.startsWith(\"FE0B\")) {\r\n  return null;\r\n}\r\nconst parts = parseHexMessage(message);\r\nif (parts.length < 47) {\r\n  return null;\r\n}\r\n//const p1Target = convertTemperature(parts, 2);\r\n//const p2Target = convertTemperature(parts, 5);\r\n\r\nconst status = {\r\n  /*p1Target: p1Target !== 000 && p1Target !== 960 ? p1Target : null,\r\n  p2Target: p2Target !== 000 && p2Target !== 960 ? p2Target : null,\r\n  p1Temp: convertTemperature(parts, 8),\r\n  p2Temp: convertTemperature(parts, 11),\r\n  p3Temp: convertTemperature(parts, 14),\r\n  p4Temp: convertTemperature(parts, 17),\r\n  smokerActTemp: convertTemperature(parts, 20),*/\r\n  moduleIsOn: parts[27] === 1,\r\n  err1: parts[28] === 1,\r\n  err2: parts[29] === 1,\r\n  err3: parts[30] === 1,\r\n  highTempErr: parts[31] === 1,\r\n  fanErr: parts[32] === 1,\r\n  hotErr: parts[33] === 1,\r\n  motorErr: parts[34] === 1,\r\n  noPellets: parts[35] === 1,\r\n  erL: parts[36] === 1,\r\n  fanState: parts[37] === 1,\r\n  hotState: parts[38] === 1,\r\n  motorState: parts[39] === 1,\r\n  lightState: parts[40] === 1,\r\n  primeState: parts[41] === 1,\r\n//  isFahrenheit: parts[42] === 1,\r\n  recipeStep: parts[43],\r\n  recipeTime: parts[44] * 3600 + parts[45] * 60 + parts[46],\r\n};\r\n/*\r\nswitch (parts[26]) {\r\n  case 1:\r\n    status.grillSetTemp = convertTemperature(parts, 23);\r\n    break;\r\n  case 2:\r\n    status.grillTemp = convertTemperature(parts, 23);\r\n    break;\r\n}*/\r\nreturn status;",
-      "temperature_function": "if (!message.startsWith(\"FE0C\")) {\r\n  return null;\r\n}\r\nconst parts = parseHexMessage(message);\r\nif (parts.length < 30) {\r\n  return null;\r\n}\r\n\r\nconst p1Target = convertTemperature(parts, 2);\r\nconst p2Target = convertTemperature(parts, 5);\r\nreturn {\r\n  p1Target: p1Target !== 000 && p1Target !== 960 ? p1Target : null,\r\n  p2Target: p2Target !== 000 && p2Target !== 960 ? p2Target : null,\r\n  p1Temp: convertTemperature(parts, 8),\r\n  p2Temp: convertTemperature(parts, 11),\r\n  p3Temp: convertTemperature(parts, 14),\r\n  p4Temp: convertTemperature(parts, 17),\r\n  grillSetTemp: convertTemperature(parts, 23),\r\n  grillTemp: convertTemperature(parts, 26),\r\n  smokerActTemp: convertTemperature(parts, 20),\r\n  isFahrenheit: parts[29] === 1,\r\n};",
-      "updated_at": "2025-09-17T20:52:53.000000Z"
+      "temperature_function": "if (!message.startsWith(\"FE0C\")) {\r\n  return null;\r\n}\r\nconst parts = parseHexMessage(message);\r\nif (parts.length < 30) {\r\n  return null;\r\n}\r\n\r\nconst p1Target = convertTemperature(parts, 2);\r\nconst p2Target = convertTemperature(parts, 5);\r\nreturn {\r\n  p1Target: p1Target !== 000 && p1Target !== 960 ? p1Target : null,\r\n  p2Target: p2Target !== 000 && p2Target !== 960 ? p2Target : null,\r\n  p1Temp: convertTemperature(parts, 8),\r\n  p2Temp: convertTemperature(parts, 11),\r\n  p3Temp: convertTemperature(parts, 14),\r\n  p4Temp: convertTemperature(parts, 17),\r\n  grillSetTemp: convertTemperature(parts, 23),\r\n  grillTemp: convertTemperature(parts, 26),\r\n  smokerActTemp: convertTemperature(parts, 20),\r\n  isFahrenheit: parts[29] === 1,\r\n};"
     },
     "PBC": {
       "control_board_commands": [
         {
-          "control_board_id": 5,
-          "created_at": null,
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0B01FF",
           "id": 1,
           "name": "Get Grill Status",
-          "slug": "get-status",
-          "updated_at": null
+          "slug": "get-status"
         },
         {
-          "control_board_id": 5,
-          "created_at": null,
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0C01FF",
           "id": 2,
           "name": "Get Grill/Probes Temperatures",
-          "slug": "get-temperatures",
-          "updated_at": null
+          "slug": "get-temperatures"
         },
         {
-          "control_board_id": 5,
-          "created_at": null,
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0902FF",
           "id": 3,
           "name": "Set Temperature to Celsius",
-          "slug": "set-celsius",
-          "updated_at": null
+          "slug": "set-celsius"
         },
         {
-          "control_board_id": 5,
-          "created_at": null,
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0901FF",
           "id": 4,
           "name": "Set Temperature to Fahrenheit",
-          "slug": "set-fahrenheit",
-          "updated_at": null
+          "slug": "set-fahrenheit"
         },
         {
-          "control_board_id": 5,
-          "created_at": null,
-          "deleted_at": null,
           "description": null,
           "function": "let _hundreds = Math.floor(arguments[0]/100); let _tens = Math.floor((arguments[0] % 100) / 10); let _ones = Math.floor(arguments[0] % 10); return 'FE0501'+formatHex(_hundreds)+formatHex(_tens)+formatHex(_ones) + 'FF';",
           "hexadecimal": null,
           "id": 6,
           "name": "Set Grill Temperature",
-          "slug": "set-temperature",
-          "updated_at": null
+          "slug": "set-temperature"
         },
         {
-          "control_board_id": 5,
-          "created_at": null,
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0200FF",
           "id": 7,
           "name": "Turn Light Off",
-          "slug": "turn-light-off",
-          "updated_at": null
+          "slug": "turn-light-off"
         },
         {
-          "control_board_id": 5,
-          "created_at": null,
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0201FF",
           "id": 8,
           "name": "Turn Light On",
-          "slug": "turn-light-on",
-          "updated_at": null
+          "slug": "turn-light-on"
         },
         {
-          "control_board_id": 5,
-          "created_at": null,
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0102FF",
           "id": 9,
           "name": "Turn Grill Off",
-          "slug": "turn-off",
-          "updated_at": null
+          "slug": "turn-off"
         },
         {
-          "control_board_id": 5,
-          "created_at": null,
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0800FF",
           "id": 11,
           "name": "Turn Primer Motor Off",
-          "slug": "turn-primer-motor-off",
-          "updated_at": null
+          "slug": "turn-primer-motor-off"
         },
         {
-          "control_board_id": 5,
-          "created_at": null,
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0801FF",
           "id": 12,
           "name": "Turn Primer Motor On",
-          "slug": "turn-primer-motor-on",
-          "updated_at": null
+          "slug": "turn-primer-motor-on"
         }
       ],
-      "created_at": "2022-06-27T00:00:00.000000Z",
-      "deleted_at": null,
       "device_status_function": null,
       "id": 5,
       "name": "PBC",
       "platform_id": 1,
       "site_id": 1,
       "status_function": "if (!message.startsWith(\"FE0B\")) {\r\n  return null;\r\n}\r\nconst parts = parseHexMessage(message);\r\nif (parts < 44) {\r\n  return null;\r\n}\r\nconst status = {\r\n  /*p1Target: convertTemperature(parts, 2),\r\n  p1Temp: convertTemperature(parts, 5),\r\n  p2Temp: convertTemperature(parts, 8),\r\n  p3Temp: convertTemperature(parts, 11),\r\n  p4Temp: convertTemperature(parts, 14),\r\n  smokerActTemp: convertTemperature(parts, 17),*/\r\n  moduleIsOn: parts[24] === 1,\r\n  err1: parts[25] === 1,\r\n  err2: parts[26] === 1,\r\n  err3: parts[27] === 1,\r\n  highTempErr: parts[28] === 1,\r\n  fanErr: parts[29] === 1,\r\n  hotErr: parts[30] === 1,\r\n  motorErr: parts[31] === 1,\r\n  noPellets: parts[32] === 1,\r\n  erL: parts[33] === 1,\r\n  fanState: parts[34] === 1,\r\n  hotState: parts[35] === 1,\r\n  motorState: parts[36] === 1,\r\n  lightState: parts[37] === 1,\r\n  primeState: parts[38] === 1,\r\n // isFahrenheit: parts[39] === 1,\r\n  recipeStep: parts[40],\r\n  recipeTime: parts[41] * 3600 + parts[42] * 60 + parts[43],\r\n};\r\n/*\r\nswitch (parts[23]) {\r\n  case 1:\r\n    status.grillSetTemp = convertTemperature(parts, 20);\r\n    break;\r\n  case 2:\r\n    status.grillTemp = convertTemperature(parts, 20);\r\n    break;\r\n}*/\r\nreturn status;",
-      "temperature_function": "if (!message.startsWith(\"FE0C\")) {\r\n  return null;\r\n}\r\nconst parts = parseHexMessage(message);\r\nif (parts < 27) {\r\n  return null;\r\n}\r\nreturn {\r\n /* p1Target: convertTemperature(parts, 2),*/\r\n  p1Temp: convertTemperature(parts, 5),\r\n  p2Temp: convertTemperature(parts, 8),\r\n  p3Temp: convertTemperature(parts, 11),\r\n  p4Temp: convertTemperature(parts, 14),\r\n  grillSetTemp: convertTemperature(parts, 20),\r\n  grillTemp: convertTemperature(parts, 23),\r\n  smokerActTemp: convertTemperature(parts, 17),\r\n  isFahrenheit: parts[26] === 1,\r\n};",
-      "updated_at": "2025-09-17T20:50:53.000000Z"
+      "temperature_function": "if (!message.startsWith(\"FE0C\")) {\r\n  return null;\r\n}\r\nconst parts = parseHexMessage(message);\r\nif (parts < 27) {\r\n  return null;\r\n}\r\nreturn {\r\n /* p1Target: convertTemperature(parts, 2),*/\r\n  p1Temp: convertTemperature(parts, 5),\r\n  p2Temp: convertTemperature(parts, 8),\r\n  p3Temp: convertTemperature(parts, 11),\r\n  p4Temp: convertTemperature(parts, 14),\r\n  grillSetTemp: convertTemperature(parts, 20),\r\n  grillTemp: convertTemperature(parts, 23),\r\n  smokerActTemp: convertTemperature(parts, 17),\r\n  isFahrenheit: parts[26] === 1,\r\n};"
     },
     "PBC2": {
       "control_board_commands": [
         {
-          "control_board_id": 17,
-          "created_at": "2024-09-12T18:07:46.000000Z",
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0B01FF",
           "id": 166,
           "name": "Get Grill Status",
-          "slug": "get-status",
-          "updated_at": "2024-09-12T18:07:46.000000Z"
+          "slug": "get-status"
         },
         {
-          "control_board_id": 17,
-          "created_at": "2024-09-12T18:08:36.000000Z",
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0C01FF",
           "id": 167,
           "name": "Get Grill/Probes Temperatures",
-          "slug": "get-temperatures",
-          "updated_at": "2024-09-12T18:08:36.000000Z"
+          "slug": "get-temperatures"
         },
         {
-          "control_board_id": 17,
-          "created_at": "2024-09-12T18:09:20.000000Z",
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0902FF",
           "id": 168,
           "name": "Set Temperature to Celsius",
-          "slug": "set-celsius",
-          "updated_at": "2024-09-12T18:09:20.000000Z"
+          "slug": "set-celsius"
         },
         {
-          "control_board_id": 17,
-          "created_at": "2024-09-12T18:10:00.000000Z",
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0901FF",
           "id": 169,
           "name": "Set Temperature to Fahrenheit",
-          "slug": "set-fahrenheit",
-          "updated_at": "2024-09-12T18:10:00.000000Z"
+          "slug": "set-fahrenheit"
         },
         {
-          "control_board_id": 17,
-          "created_at": "2024-09-12T18:10:41.000000Z",
-          "deleted_at": null,
           "description": null,
           "function": "let _hundreds = Math.floor(arguments[0]/100); let _tens = Math.floor((arguments[0] % 100) / 10); let _ones = Math.floor(arguments[0] % 10); return 'FE0501'+formatHex(_hundreds)+formatHex(_tens)+formatHex(_ones) + 'FF';",
           "hexadecimal": null,
           "id": 170,
           "name": "Set Grill Temperature",
-          "slug": "set-temperature",
-          "updated_at": "2024-09-12T18:10:41.000000Z"
+          "slug": "set-temperature"
         },
         {
-          "control_board_id": 17,
-          "created_at": "2024-09-12T18:11:41.000000Z",
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0200FF",
           "id": 171,
           "name": "Turn Light Off",
-          "slug": "turn-light-off",
-          "updated_at": "2024-09-12T18:11:41.000000Z"
+          "slug": "turn-light-off"
         },
         {
-          "control_board_id": 17,
-          "created_at": "2024-09-12T18:12:21.000000Z",
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0201FF",
           "id": 172,
           "name": "Turn Light On",
-          "slug": "turn-light-on",
-          "updated_at": "2024-09-12T18:12:21.000000Z"
+          "slug": "turn-light-on"
         },
         {
-          "control_board_id": 17,
-          "created_at": "2024-09-12T18:13:02.000000Z",
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0102FF",
           "id": 173,
           "name": "Turn Grill Off",
-          "slug": "turn-off",
-          "updated_at": "2024-09-12T18:13:02.000000Z"
+          "slug": "turn-off"
         },
         {
-          "control_board_id": 17,
-          "created_at": "2024-09-12T18:13:44.000000Z",
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0800FF",
           "id": 174,
           "name": "Turn Primer Motor Off",
-          "slug": "turn-primer-motor-off",
-          "updated_at": "2024-09-12T18:13:44.000000Z"
+          "slug": "turn-primer-motor-off"
         },
         {
-          "control_board_id": 17,
-          "created_at": "2024-09-12T18:14:23.000000Z",
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0801FF",
           "id": 175,
           "name": "Turn Primer Motor On",
-          "slug": "turn-primer-motor-on",
-          "updated_at": "2024-09-12T18:14:23.000000Z"
+          "slug": "turn-primer-motor-on"
         }
       ],
-      "created_at": "2024-09-10T15:21:29.000000Z",
-      "deleted_at": null,
       "device_status_function": null,
       "id": 17,
       "name": "PBC2",
       "platform_id": 8,
       "site_id": 1,
       "status_function": "if (!message.startsWith(\"FE0B\")) {\r\n  return null;\r\n}\r\nconst parts = parseHexMessage(message);\r\nif (parts < 44) {\r\n  return null;\r\n}\r\nconst status = {\r\n  /*p1Target: convertTemperature(parts, 2),\r\n  p1Temp: convertTemperature(parts, 5),\r\n  p2Temp: convertTemperature(parts, 8),\r\n  p3Temp: convertTemperature(parts, 11),\r\n  p4Temp: convertTemperature(parts, 14),\r\n  smokerActTemp: convertTemperature(parts, 17),*/\r\n  moduleIsOn: parts[24] === 1,\r\n  err1: parts[25] === 1,\r\n  err2: parts[26] === 1,\r\n  err3: parts[27] === 1,\r\n  highTempErr: parts[28] === 1,\r\n  fanErr: parts[29] === 1,\r\n  hotErr: parts[30] === 1,\r\n  motorErr: parts[31] === 1,\r\n  noPellets: parts[32] === 1,\r\n  erL: parts[33] === 1,\r\n  fanState: parts[34] === 1,\r\n  hotState: parts[35] === 1,\r\n  motorState: parts[36] === 1,\r\n  lightState: parts[37] === 1,\r\n  primeState: parts[38] === 1,\r\n // isFahrenheit: parts[39] === 1,\r\n  recipeStep: parts[40],\r\n  recipeTime: parts[41] * 3600 + parts[42] * 60 + parts[43],\r\n};\r\n/*\r\nswitch (parts[23]) {\r\n  case 1:\r\n    status.grillSetTemp = convertTemperature(parts, 20);\r\n    break;\r\n  case 2:\r\n    status.grillTemp = convertTemperature(parts, 20);\r\n    break;\r\n}*/\r\nreturn status;",
-      "temperature_function": "if (!message.startsWith(\"FE0C\")) {\r\n  return null;\r\n}\r\nconst parts = parseHexMessage(message);\r\nif (parts < 27) {\r\n  return null;\r\n}\r\nreturn {\r\n /* p1Target: convertTemperature(parts, 2),*/\r\n  p1Temp: convertTemperature(parts, 5),\r\n  p2Temp: convertTemperature(parts, 8),\r\n  p3Temp: convertTemperature(parts, 11),\r\n  p4Temp: convertTemperature(parts, 14),\r\n  grillSetTemp: convertTemperature(parts, 20),\r\n  grillTemp: convertTemperature(parts, 23),\r\n  smokerActTemp: convertTemperature(parts, 17),\r\n  isFahrenheit: parts[26] === 1,\r\n};",
-      "updated_at": "2025-09-17T20:56:39.000000Z"
+      "temperature_function": "if (!message.startsWith(\"FE0C\")) {\r\n  return null;\r\n}\r\nconst parts = parseHexMessage(message);\r\nif (parts < 27) {\r\n  return null;\r\n}\r\nreturn {\r\n /* p1Target: convertTemperature(parts, 2),*/\r\n  p1Temp: convertTemperature(parts, 5),\r\n  p2Temp: convertTemperature(parts, 8),\r\n  p3Temp: convertTemperature(parts, 11),\r\n  p4Temp: convertTemperature(parts, 14),\r\n  grillSetTemp: convertTemperature(parts, 20),\r\n  grillTemp: convertTemperature(parts, 23),\r\n  smokerActTemp: convertTemperature(parts, 17),\r\n  isFahrenheit: parts[26] === 1,\r\n};"
     },
     "PBD": {
       "control_board_commands": [
         {
-          "control_board_id": 12,
-          "created_at": "2023-01-25T12:03:14.000000Z",
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0B01FF",
           "id": 118,
           "name": "Get Grill Status",
-          "slug": "get-status",
-          "updated_at": "2023-01-25T12:03:14.000000Z"
+          "slug": "get-status"
         },
         {
-          "control_board_id": 12,
-          "created_at": "2023-01-25T12:03:34.000000Z",
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0C01FF",
           "id": 119,
           "name": "Get Grill/Probes Temperatures",
-          "slug": "get-temperatures",
-          "updated_at": "2023-01-25T12:03:34.000000Z"
+          "slug": "get-temperatures"
         },
         {
-          "control_board_id": 12,
-          "created_at": "2023-01-25T12:03:55.000000Z",
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0902FF",
           "id": 120,
           "name": "Set Temperature to Celsius",
-          "slug": "set-celsius",
-          "updated_at": "2023-01-25T12:03:55.000000Z"
+          "slug": "set-celsius"
         },
         {
-          "control_board_id": 12,
-          "created_at": "2023-01-25T12:04:30.000000Z",
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0901FF",
           "id": 121,
           "name": "Set Temperature to Fahrenheit",
-          "slug": "set-fahrenheit",
-          "updated_at": "2023-01-25T12:04:30.000000Z"
+          "slug": "set-fahrenheit"
         },
         {
-          "control_board_id": 12,
-          "created_at": "2023-01-25T12:05:05.000000Z",
-          "deleted_at": null,
           "description": null,
           "function": "let _hundreds = Math.floor(arguments[0]/100); let _tens = Math.floor((arguments[0] % 100) / 10); let _ones = Math.floor(arguments[0] % 10); return 'FE0502'+formatHex(_hundreds)+formatHex(_tens)+formatHex(_ones) + 'FF';",
           "hexadecimal": null,
           "id": 122,
           "name": "Set Probe 1 Temperature",
-          "slug": "set-probe-1-temperature",
-          "updated_at": "2023-01-25T12:05:05.000000Z"
+          "slug": "set-probe-1-temperature"
         },
         {
-          "control_board_id": 12,
-          "created_at": "2023-01-25T12:05:28.000000Z",
-          "deleted_at": null,
           "description": null,
           "function": "let _hundreds = Math.floor(arguments[0]/100); let _tens = Math.floor((arguments[0] % 100) / 10); let _ones = Math.floor(arguments[0] % 10); return 'FE0501'+formatHex(_hundreds)+formatHex(_tens)+formatHex(_ones) + 'FF';",
           "hexadecimal": null,
           "id": 123,
           "name": "Set Grill Temperature",
-          "slug": "set-temperature",
-          "updated_at": "2023-01-25T12:05:28.000000Z"
+          "slug": "set-temperature"
         },
         {
-          "control_board_id": 12,
-          "created_at": "2023-01-25T12:06:00.000000Z",
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0200FF",
           "id": 124,
           "name": "Turn Light Off",
-          "slug": "turn-light-off",
-          "updated_at": "2023-01-25T12:06:00.000000Z"
+          "slug": "turn-light-off"
         },
         {
-          "control_board_id": 12,
-          "created_at": "2023-01-25T12:06:19.000000Z",
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0201FF",
           "id": 125,
           "name": "Turn Light On",
-          "slug": "turn-light-on",
-          "updated_at": "2023-01-25T12:06:19.000000Z"
+          "slug": "turn-light-on"
         },
         {
-          "control_board_id": 12,
-          "created_at": "2023-01-25T12:06:48.000000Z",
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0102FF",
           "id": 126,
           "name": "Turn Grill Off",
-          "slug": "turn-off",
-          "updated_at": "2023-01-25T12:06:48.000000Z"
+          "slug": "turn-off"
         },
         {
-          "control_board_id": 12,
-          "created_at": "2023-01-25T12:07:10.000000Z",
-          "deleted_at": null,
           "description": null,
           "function": "let _hundreds = Math.floor(arguments[0]/100); let _tens = Math.floor((arguments[0] % 100) / 10); let _ones = Math.floor(arguments[0] % 10); return 'FE0503'+formatHex(_hundreds)+formatHex(_tens)+formatHex(_ones) + 'FF';",
           "hexadecimal": null,
           "id": 127,
           "name": "Set Probe 2 Temperature",
-          "slug": "set-probe-2-temperature",
-          "updated_at": "2023-01-25T12:07:10.000000Z"
+          "slug": "set-probe-2-temperature"
         }
       ],
-      "created_at": "2023-01-25T11:59:54.000000Z",
-      "deleted_at": null,
       "device_status_function": null,
       "id": 12,
       "name": "PBD",
       "platform_id": 3,
       "site_id": 1,
       "status_function": "if (!message.startsWith(\"FE0B\")) {\r\n  return null;\r\n}\r\nconst parts = parseHexMessage(message);\r\nif (parts.length < 47) {\r\n  return null;\r\n}\r\n//const p1Target = convertTemperature(parts, 2);\r\n//const p2Target = convertTemperature(parts, 5);\r\n\r\nconst status = {\r\n  /*p1Target: p1Target !== 000 && p1Target !== 960 ? p1Target : null,\r\n  p2Target: p2Target !== 000 && p2Target !== 960 ? p2Target : null,\r\n  p1Temp: convertTemperature(parts, 8),\r\n  p2Temp: convertTemperature(parts, 11),\r\n  p3Temp: convertTemperature(parts, 14),\r\n  p4Temp: convertTemperature(parts, 17),\r\n  smokerActTemp: convertTemperature(parts, 20),*/\r\n  moduleIsOn: parts[27] === 1,\r\n  err1: parts[28] === 1,\r\n  err2: parts[29] === 1,\r\n  err3: parts[30] === 1,\r\n  highTempErr: parts[31] === 1,\r\n  fanErr: parts[32] === 1,\r\n  hotErr: parts[33] === 1,\r\n  motorErr: parts[34] === 1,\r\n  noPellets: parts[35] === 1,\r\n  erL: parts[36] === 1,\r\n  fanState: parts[37] === 1,\r\n  hotState: parts[38] === 1,\r\n  motorState: parts[39] === 1,\r\n  lightState: parts[40] === 1,\r\n  primeState: parts[41] === 1,\r\n // isFahrenheit: parts[42] === 1,\r\n  recipeStep: parts[43],\r\n  recipeTime: parts[44] * 3600 + parts[45] * 60 + parts[46],\r\n};\r\n/*\r\nswitch (parts[26]) {\r\n  case 1:\r\n    status.grillSetTemp = convertTemperature(parts, 23);\r\n    break;\r\n  case 2:\r\n    status.grillTemp = convertTemperature(parts, 23);\r\n    break;\r\n}*/\r\nreturn status;",
-      "temperature_function": "if (!message.startsWith(\"FE0C\")) {\r\n  return null;\r\n}\r\nconst parts = parseHexMessage(message);\r\nif (parts.length < 30) {\r\n  return null;\r\n}\r\n\r\nconst p1Target = convertTemperature(parts, 2);\r\nconst p2Target = convertTemperature(parts, 5);\r\nreturn {\r\n  p1Target: p1Target !== 000 && p1Target !== 960 ? p1Target : null,\r\n  p2Target: p2Target !== 000 && p2Target !== 960 ? p2Target : null,\r\n  p1Temp: convertTemperature(parts, 8),\r\n  p2Temp: convertTemperature(parts, 11),\r\n  p3Temp: convertTemperature(parts, 14),\r\n  p4Temp: convertTemperature(parts, 17),\r\n  grillSetTemp: convertTemperature(parts, 23),\r\n  grillTemp: convertTemperature(parts, 26),\r\n  smokerActTemp: convertTemperature(parts, 20),\r\n  isFahrenheit: parts[29] === 1,\r\n};",
-      "updated_at": "2025-09-17T20:53:27.000000Z"
+      "temperature_function": "if (!message.startsWith(\"FE0C\")) {\r\n  return null;\r\n}\r\nconst parts = parseHexMessage(message);\r\nif (parts.length < 30) {\r\n  return null;\r\n}\r\n\r\nconst p1Target = convertTemperature(parts, 2);\r\nconst p2Target = convertTemperature(parts, 5);\r\nreturn {\r\n  p1Target: p1Target !== 000 && p1Target !== 960 ? p1Target : null,\r\n  p2Target: p2Target !== 000 && p2Target !== 960 ? p2Target : null,\r\n  p1Temp: convertTemperature(parts, 8),\r\n  p2Temp: convertTemperature(parts, 11),\r\n  p3Temp: convertTemperature(parts, 14),\r\n  p4Temp: convertTemperature(parts, 17),\r\n  grillSetTemp: convertTemperature(parts, 23),\r\n  grillTemp: convertTemperature(parts, 26),\r\n  smokerActTemp: convertTemperature(parts, 20),\r\n  isFahrenheit: parts[29] === 1,\r\n};"
     },
     "PBE": {
       "control_board_commands": [
         {
-          "control_board_id": 15,
-          "created_at": "2023-12-08T16:04:48.000000Z",
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0B01FF",
           "id": 145,
           "name": "Get Grill Status",
-          "slug": "get-status",
-          "updated_at": "2023-12-08T16:04:48.000000Z"
+          "slug": "get-status"
         },
         {
-          "control_board_id": 15,
-          "created_at": "2023-12-08T16:07:27.000000Z",
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0C01FF",
           "id": 146,
           "name": "Get Grill/Probes Temperatures",
-          "slug": "get-temperatures",
-          "updated_at": "2023-12-08T16:07:27.000000Z"
+          "slug": "get-temperatures"
         },
         {
-          "control_board_id": 15,
-          "created_at": "2023-12-08T16:46:58.000000Z",
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0902FF",
           "id": 147,
           "name": "Set Temperature to Celsius",
-          "slug": "set-celsius",
-          "updated_at": "2023-12-08T16:46:58.000000Z"
+          "slug": "set-celsius"
         },
         {
-          "control_board_id": 15,
-          "created_at": "2023-12-08T16:47:44.000000Z",
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0901FF",
           "id": 148,
           "name": "Set Temperature to Fahrenheit",
-          "slug": "set-fahrenheit",
-          "updated_at": "2023-12-08T16:48:05.000000Z"
+          "slug": "set-fahrenheit"
         },
         {
-          "control_board_id": 15,
-          "created_at": "2023-12-08T16:49:13.000000Z",
-          "deleted_at": null,
           "description": null,
           "function": "let temp = arguments[1] === false ? Math.round(((arguments[0] * 1.8)+ 32)/5) * 5 : arguments[0]; let _hundreds = Math.floor(temp/100); let _tens = Math.floor((temp % 100) / 10); let _ones = Math.floor(temp % 10); return 'FE0502'+formatHex(_hundreds)+formatHex(_tens)+formatHex(_ones) + 'FF';",
           "hexadecimal": null,
           "id": 149,
           "name": "Set Probe 1 Temperature",
-          "slug": "set-probe-1-temperature",
-          "updated_at": "2023-12-19T18:48:47.000000Z"
+          "slug": "set-probe-1-temperature"
         },
         {
-          "control_board_id": 15,
-          "created_at": "2023-12-08T16:54:10.000000Z",
-          "deleted_at": null,
           "description": null,
           "function": "let temp = arguments[1] === false ? Math.round(((arguments[0] * 1.8)+ 32)/5) * 5 : arguments[0]; let _hundreds = Math.floor(temp/100); let _tens = Math.floor((temp % 100) / 10); let _ones = Math.floor(temp % 10); return 'FE0501'+formatHex(_hundreds)+formatHex(_tens)+formatHex(_ones) + 'FF';",
           "hexadecimal": null,
           "id": 150,
           "name": "Set Grill Temperature",
-          "slug": "set-temperature",
-          "updated_at": "2023-12-19T18:49:10.000000Z"
+          "slug": "set-temperature"
         },
         {
-          "control_board_id": 15,
-          "created_at": "2023-12-08T16:55:16.000000Z",
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0200FF",
           "id": 151,
           "name": "Turn Light Off",
-          "slug": "turn-light-off",
-          "updated_at": "2023-12-08T16:55:16.000000Z"
+          "slug": "turn-light-off"
         },
         {
-          "control_board_id": 15,
-          "created_at": "2023-12-08T16:56:58.000000Z",
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0201FF",
           "id": 152,
           "name": "Turn Light On",
-          "slug": "turn-light-on",
-          "updated_at": "2023-12-08T16:56:58.000000Z"
+          "slug": "turn-light-on"
         },
         {
-          "control_board_id": 15,
-          "created_at": "2023-12-08T16:58:59.000000Z",
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0102FF",
           "id": 153,
           "name": "Turn Grill Off",
-          "slug": "turn-off",
-          "updated_at": "2023-12-08T16:58:59.000000Z"
+          "slug": "turn-off"
         },
         {
-          "control_board_id": 15,
-          "created_at": "2023-12-08T16:59:44.000000Z",
-          "deleted_at": null,
           "description": null,
           "function": "let temp = arguments[1] === false ? Math.round(((arguments[0] * 1.8)+ 32)/5) * 5 : arguments[0]; let _hundreds = Math.floor(temp/100); let _tens = Math.floor((temp % 100) / 10); let _ones = Math.floor(temp % 10); return 'FE0503'+formatHex(_hundreds)+formatHex(_tens)+formatHex(_ones) + 'FF';",
           "hexadecimal": null,
           "id": 154,
           "name": "Set Probe 2 Temperature",
-          "slug": "set-probe-2-temperature",
-          "updated_at": "2023-12-19T18:50:34.000000Z"
+          "slug": "set-probe-2-temperature"
         }
       ],
-      "created_at": "2023-12-08T16:03:51.000000Z",
-      "deleted_at": null,
       "device_status_function": null,
       "id": 15,
       "name": "PBE",
       "platform_id": 8,
       "site_id": 1,
       "status_function": "if (!message.startsWith(\"FE0B\")) {\r\n  return null;\r\n}\r\nconst parts = parseHexMessage(message);\r\nif (parts.length < 47) {\r\n  return null;\r\n}\r\n//const p1Target = convertTemperature(parts, 2);\r\n//const p2Target = convertTemperature(parts, 5);\r\nconst status = {\r\n /* p1Target: p1Target !== 0 && p1Target !== 960 ? p1Target : null,\r\n  p2Target: p2Target !== 0 && p2Target !== 960 ? p2Target : null,\r\n  p1Temp: convertTemperature(parts, 8),\r\n  p2Temp: convertTemperature(parts, 11),\r\n  p3Temp: convertTemperature(parts, 14),\r\n  p4Temp: convertTemperature(parts, 17),\r\n  smokerActTemp: convertTemperature(parts, 20),*/\r\n  moduleIsOn: parts[27] === 1,\r\n  err1: parts[28] === 1,\r\n  err2: parts[29] === 1,\r\n  err3: parts[30] === 1,\r\n  highTempErr: parts[31] === 1,\r\n  fanErr: parts[32] === 1,\r\n  hotErr: parts[33] === 1,\r\n  motorErr: parts[34] === 1,\r\n  noPellets: parts[35] === 1,\r\n  erL: parts[36] === 1,\r\n  fanState: parts[37] === 1,\r\n  hotState: parts[38] === 1,\r\n  motorState: parts[39] === 1,\r\n  lightState: parts[40] === 1,\r\n  primeState: parts[41] === 1,\r\n // isFahrenheit: parts[42] === 1,\r\n  recipeStep: parts[43],\r\n  recipeTime: parts[44] * 3600 + parts[45] * 60 + parts[46],\r\n};\r\n/*\r\nswitch (parts[26]) {\r\n  case 1:\r\n    status.grillSetTemp = convertTemperature(parts, 23);\r\n    break;\r\n  case 2:\r\n    status.grillTemp = convertTemperature(parts, 23);\r\n    break;\r\n}\r\nif (!status.isFahrenheit) {\r\n  const ftoc = function (temp) {\r\n    if ((typeof temp === \"undefined\") || (temp === 960)) {\r\n      return temp;\r\n    }\r\n    return Math.floor((temp - 32) / 1.8);\r\n  };\r\n  status.p1Temp = ftoc(status.p1Temp);\r\n  status.p2Temp = ftoc(status.p2Temp);\r\n  status.p3Temp = ftoc(status.p3Temp);\r\n  status.grillSetTemp = ftoc(status.grillSetTemp);\r\n  status.grillTemp = ftoc(status.grillTemp);\r\n  status.p1Target =  ftoc(status.p1Target);\r\n  status.p2Target =  ftoc(status.p2Target);\r\n}*/\r\n\r\nreturn status;",
-      "temperature_function": "if (!message.startsWith(\"FE0C\")) {\r\n  return null;\r\n}\r\nconst parts = parseHexMessage(message);\r\nif (parts.length < 30) {\r\n  return null;\r\n}\r\nconst p1Target = convertTemperature(parts, 2);\r\nconst p2Target = convertTemperature(parts, 5);\r\nconst  status = {\r\n  p1Target: p1Target !== 0 && p1Target !== 960 ? p1Target : null,\r\n  p2Target: p2Target !== 0 && p2Target !== 960 ? p2Target : null,\r\n  p1Temp: convertTemperature(parts, 8),\r\n  p2Temp: convertTemperature(parts, 11),\r\n  p3Temp: convertTemperature(parts, 14),\r\n  p4Temp: convertTemperature(parts, 17),\r\n  grillSetTemp: convertTemperature(parts, 23),\r\n  grillTemp: convertTemperature(parts, 26),\r\n  smokerActTemp: convertTemperature(parts, 20),\r\n  isFahrenheit: parts[29] === 1,\r\n};\r\n\r\nif (!status.isFahrenheit) {\r\n  const ftoc = function (temp) {\r\n    if ((typeof temp === \"undefined\") || (temp === 960)) {\r\n      return temp;\r\n    }\r\n    return Math.floor((temp - 32) / 1.8);\r\n  };\r\n  status.p1Temp = ftoc(status.p1Temp);\r\n  status.p2Temp = ftoc(status.p2Temp);\r\n  status.p3Temp = ftoc(status.p3Temp);\r\n  status.grillSetTemp = ftoc(status.grillSetTemp);\r\n  status.grillTemp = ftoc(status.grillTemp);\r\n  status.p1Target =  ftoc(status.p1Target);\r\n  status.p2Target =  ftoc(status.p2Target);\r\n}\r\n\r\nreturn status;",
-      "updated_at": "2026-03-19T15:42:24.000000Z"
+      "temperature_function": "if (!message.startsWith(\"FE0C\")) {\r\n  return null;\r\n}\r\nconst parts = parseHexMessage(message);\r\nif (parts.length < 30) {\r\n  return null;\r\n}\r\nconst p1Target = convertTemperature(parts, 2);\r\nconst p2Target = convertTemperature(parts, 5);\r\nconst  status = {\r\n  p1Target: p1Target !== 0 && p1Target !== 960 ? p1Target : null,\r\n  p2Target: p2Target !== 0 && p2Target !== 960 ? p2Target : null,\r\n  p1Temp: convertTemperature(parts, 8),\r\n  p2Temp: convertTemperature(parts, 11),\r\n  p3Temp: convertTemperature(parts, 14),\r\n  p4Temp: convertTemperature(parts, 17),\r\n  grillSetTemp: convertTemperature(parts, 23),\r\n  grillTemp: convertTemperature(parts, 26),\r\n  smokerActTemp: convertTemperature(parts, 20),\r\n  isFahrenheit: parts[29] === 1,\r\n};\r\n\r\nif (!status.isFahrenheit) {\r\n  const ftoc = function (temp) {\r\n    if ((typeof temp === \"undefined\") || (temp === 960)) {\r\n      return temp;\r\n    }\r\n    return Math.floor((temp - 32) / 1.8);\r\n  };\r\n  status.p1Temp = ftoc(status.p1Temp);\r\n  status.p2Temp = ftoc(status.p2Temp);\r\n  status.p3Temp = ftoc(status.p3Temp);\r\n  status.grillSetTemp = ftoc(status.grillSetTemp);\r\n  status.grillTemp = ftoc(status.grillTemp);\r\n  status.p1Target =  ftoc(status.p1Target);\r\n  status.p2Target =  ftoc(status.p2Target);\r\n}\r\n\r\nreturn status;"
     },
     "PBG": {
       "control_board_commands": [
         {
-          "control_board_id": 3,
-          "created_at": null,
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0B01FF",
           "id": 13,
           "name": "Get Grill Status",
-          "slug": "get-status",
-          "updated_at": null
+          "slug": "get-status"
         },
         {
-          "control_board_id": 3,
-          "created_at": null,
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0C01FF",
           "id": 14,
           "name": "Get Grill/Probes Temperatures",
-          "slug": "get-temperatures",
-          "updated_at": null
+          "slug": "get-temperatures"
         },
         {
-          "control_board_id": 3,
-          "created_at": null,
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0902FF",
           "id": 15,
           "name": "Set Temperature to Celsius",
-          "slug": "set-celsius",
-          "updated_at": null
+          "slug": "set-celsius"
         },
         {
-          "control_board_id": 3,
-          "created_at": null,
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0901FF",
           "id": 16,
           "name": "Set Temperature to Fahrenheit",
-          "slug": "set-fahrenheit",
-          "updated_at": null
+          "slug": "set-fahrenheit"
         },
         {
-          "control_board_id": 3,
-          "created_at": null,
-          "deleted_at": null,
           "description": null,
           "function": "let _hundreds = Math.floor(arguments[0]/100); let _tens = Math.floor((arguments[0] % 100) / 10); let _ones = Math.floor(arguments[0] % 10); return 'FE0501'+formatHex(_hundreds)+formatHex(_tens)+formatHex(_ones) + 'FF';",
           "hexadecimal": null,
           "id": 18,
           "name": "Set Grill Temperature",
-          "slug": "set-temperature",
-          "updated_at": null
+          "slug": "set-temperature"
         },
         {
-          "control_board_id": 3,
-          "created_at": null,
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0200FF",
           "id": 19,
           "name": "Turn Light Off",
-          "slug": "turn-light-off",
-          "updated_at": null
+          "slug": "turn-light-off"
         },
         {
-          "control_board_id": 3,
-          "created_at": null,
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0201FF",
           "id": 20,
           "name": "Turn Light On",
-          "slug": "turn-light-on",
-          "updated_at": null
+          "slug": "turn-light-on"
         },
         {
-          "control_board_id": 3,
-          "created_at": null,
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0102FF",
           "id": 21,
           "name": "Turn Grill Off",
-          "slug": "turn-off",
-          "updated_at": null
+          "slug": "turn-off"
         },
         {
-          "control_board_id": 3,
-          "created_at": null,
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0800FF",
           "id": 23,
           "name": "Turn Primer Motor Off",
-          "slug": "turn-primer-motor-off",
-          "updated_at": null
+          "slug": "turn-primer-motor-off"
         },
         {
-          "control_board_id": 3,
-          "created_at": null,
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0801FF",
           "id": 24,
           "name": "Turn Primer Motor On",
-          "slug": "turn-primer-motor-on",
-          "updated_at": null
+          "slug": "turn-primer-motor-on"
         }
       ],
-      "created_at": "2022-06-27T00:00:00.000000Z",
-      "deleted_at": null,
       "device_status_function": null,
       "id": 3,
       "name": "PBG",
       "platform_id": 5,
       "site_id": 1,
       "status_function": "if (!message.startsWith(\"FE0B\")) {\r\n  return null;\r\n}\r\nconst parts = parseHexMessage(message);\r\nif (parts < 44) {\r\n  return null;\r\n}\r\nconst status = {\r\n  /*p1Target: convertTemperature(parts, 2),\r\n  p1Temp: convertTemperature(parts, 5),\r\n  p2Temp: convertTemperature(parts, 8),\r\n  p3Temp: convertTemperature(parts, 11),\r\n  p4Temp: convertTemperature(parts, 14),\r\n  smokerActTemp: convertTemperature(parts, 17),*/\r\n  moduleIsOn: parts[24] === 1,\r\n  err1: parts[25] === 1,\r\n  err2: parts[26] === 1,\r\n  err3: parts[27] === 1,\r\n  highTempErr: parts[28] === 1,\r\n  fanErr: parts[29] === 1,\r\n  hotErr: parts[30] === 1,\r\n  motorErr: parts[31] === 1,\r\n  noPellets: parts[32] === 1,\r\n  erL: parts[33] === 1,\r\n  fanState: parts[34] === 1,\r\n  hotState: parts[35] === 1,\r\n  motorState: parts[36] === 1,\r\n  lightState: parts[37] === 1,\r\n  primeState: parts[38] === 1,\r\n//  isFahrenheit: parts[39] === 1,\r\n  recipeStep: parts[40],\r\n  recipeTime: parts[41] * 3600 + parts[42] * 60 + parts[43],\r\n};\r\n/*switch (parts[23]) {\r\n  case 1:\r\n    status.grillSetTemp = convertTemperature(parts, 20);\r\n    break;\r\n  case 2:\r\n    status.grillTemp = convertTemperature(parts, 20);\r\n    break;\r\n}*/\r\nreturn status;",
-      "temperature_function": "if (!message.startsWith(\"FE0C\")) {\r\n  return null;\r\n}\r\nconst parts = parseHexMessage(message);\r\nif (parts < 27) {\r\n  return null;\r\n}\r\nreturn {\r\n  /*p1Target: convertTemperature(parts, 2),*/\r\n  p1Temp: convertTemperature(parts, 5),\r\n  p2Temp: convertTemperature(parts, 8),\r\n  p3Temp: convertTemperature(parts, 11),\r\n  p4Temp: convertTemperature(parts, 14),\r\n  grillSetTemp: convertTemperature(parts, 20),\r\n  grillTemp: convertTemperature(parts, 23),\r\n  smokerActTemp: convertTemperature(parts, 17),\r\n  isFahrenheit: parts[26] === 1,\r\n};",
-      "updated_at": "2025-09-17T20:50:05.000000Z"
+      "temperature_function": "if (!message.startsWith(\"FE0C\")) {\r\n  return null;\r\n}\r\nconst parts = parseHexMessage(message);\r\nif (parts < 27) {\r\n  return null;\r\n}\r\nreturn {\r\n  /*p1Target: convertTemperature(parts, 2),*/\r\n  p1Temp: convertTemperature(parts, 5),\r\n  p2Temp: convertTemperature(parts, 8),\r\n  p3Temp: convertTemperature(parts, 11),\r\n  p4Temp: convertTemperature(parts, 14),\r\n  grillSetTemp: convertTemperature(parts, 20),\r\n  grillTemp: convertTemperature(parts, 23),\r\n  smokerActTemp: convertTemperature(parts, 17),\r\n  isFahrenheit: parts[26] === 1,\r\n};"
     },
     "PBL": {
       "control_board_commands": [
         {
-          "control_board_id": 1,
-          "created_at": null,
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0B01FF",
           "id": 25,
           "name": "Get Grill Status",
-          "slug": "get-status",
-          "updated_at": null
+          "slug": "get-status"
         },
         {
-          "control_board_id": 1,
-          "created_at": null,
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0C01FF",
           "id": 26,
           "name": "Get Grill/Probes Temperatures",
-          "slug": "get-temperatures",
-          "updated_at": null
+          "slug": "get-temperatures"
         },
         {
-          "control_board_id": 1,
-          "created_at": null,
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0902FF",
           "id": 27,
           "name": "Set Temperature to Celsius",
-          "slug": "set-celsius",
-          "updated_at": null
+          "slug": "set-celsius"
         },
         {
-          "control_board_id": 1,
-          "created_at": null,
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0901FF",
           "id": 28,
           "name": "Set Temperature to Fahrenheit",
-          "slug": "set-fahrenheit",
-          "updated_at": null
+          "slug": "set-fahrenheit"
         },
         {
-          "control_board_id": 1,
-          "created_at": null,
-          "deleted_at": null,
           "description": null,
           "function": "let _hundreds = Math.floor(arguments[0]/100); let _tens = Math.floor((arguments[0] % 100) / 10); let _ones = Math.floor(arguments[0] % 10); return 'FE0502'+formatHex(_hundreds)+formatHex(_tens)+formatHex(_ones) + 'FF';",
           "hexadecimal": null,
           "id": 29,
           "name": "Set Probe 1 Temperature",
-          "slug": "set-probe-1-temperature",
-          "updated_at": null
+          "slug": "set-probe-1-temperature"
         },
         {
-          "control_board_id": 1,
-          "created_at": null,
-          "deleted_at": null,
           "description": null,
           "function": "let _hundreds = Math.floor(arguments[0]/100); let _tens = Math.floor((arguments[0] % 100) / 10); let _ones = Math.floor(arguments[0] % 10); return 'FE0501'+formatHex(_hundreds)+formatHex(_tens)+formatHex(_ones) + 'FF';",
           "hexadecimal": null,
           "id": 30,
           "name": "Set Grill Temperature",
-          "slug": "set-temperature",
-          "updated_at": null
+          "slug": "set-temperature"
         },
         {
-          "control_board_id": 1,
-          "created_at": null,
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0202FF",
           "id": 31,
           "name": "Turn Light Off",
-          "slug": "turn-light-off",
-          "updated_at": null
+          "slug": "turn-light-off"
         },
         {
-          "control_board_id": 1,
-          "created_at": null,
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0201FF",
           "id": 32,
           "name": "Turn Light On",
-          "slug": "turn-light-on",
-          "updated_at": null
+          "slug": "turn-light-on"
         },
         {
-          "control_board_id": 1,
-          "created_at": null,
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0102FF",
           "id": 33,
           "name": "Turn Grill Off",
-          "slug": "turn-off",
-          "updated_at": null
+          "slug": "turn-off"
         },
         {
-          "control_board_id": 1,
-          "created_at": null,
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0800FF",
           "id": 35,
           "name": "Turn Primer Motor Off",
-          "slug": "turn-primer-motor-off",
-          "updated_at": null
+          "slug": "turn-primer-motor-off"
         },
         {
-          "control_board_id": 1,
-          "created_at": null,
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0801FF",
           "id": 36,
           "name": "Turn Primer Motor On",
-          "slug": "turn-primer-motor-on",
-          "updated_at": null
+          "slug": "turn-primer-motor-on"
         }
       ],
-      "created_at": "2022-06-27T00:00:00.000000Z",
-      "deleted_at": null,
       "device_status_function": null,
       "id": 1,
       "name": "PBL",
       "platform_id": 5,
       "site_id": 1,
       "status_function": "if (!message.startsWith(\"FE0B\")) {\r\n  return null;\r\n}\r\nconst parts = parseHexMessage(message);\r\nif (parts < 44) {\r\n  return null;\r\n}\r\nconst status = {\r\n//  p1Target: convertTemperature(parts, 2),\r\n//  p1Temp: convertTemperature(parts, 5),\r\n//  p2Temp: convertTemperature(parts, 8),\r\n//  p3Temp: convertTemperature(parts, 11),\r\n//  p4Temp: convertTemperature(parts, 14),\r\n//  smokerActTemp: convertTemperature(parts, 17),\r\n  moduleIsOn: parts[24] === 1,\r\n  err1: parts[25] === 1,\r\n  err2: parts[26] === 1,\r\n  err3: parts[27] === 1,\r\n  highTempErr: parts[28] === 1,\r\n  fanErr: parts[29] === 1,\r\n  hotErr: parts[30] === 1,\r\n  motorErr: parts[31] === 1,\r\n  noPellets: parts[32] === 1,\r\n  erL: parts[33] === 1,\r\n  fanState: parts[34] === 1,\r\n  hotState: parts[35] === 1,\r\n  motorState: parts[36] === 1,\r\n  lightState: parts[37] === 1,\r\n  primeState: parts[38] === 1,\r\n//  isFahrenheit: parts[39] === 1,\r\n  recipeStep: parts[40],\r\n  recipeTime: parts[41] * 3600 + parts[42] * 60 + parts[43],\r\n};\r\n/*switch (parts[23]) {\r\n  case 1:\r\n    status.grillSetTemp = convertTemperature(parts, 20);\r\n    break;\r\n  case 2:\r\n    status.grillTemp = convertTemperature(parts, 20);\r\n    break;\r\n}*/\r\nreturn status;",
-      "temperature_function": "if (!message.startsWith(\"FE0C\")) {\r\n  return null;\r\n}\r\nconst parts = parseHexMessage(message);\r\nif (parts < 27) {\r\n  return null;\r\n}\r\nreturn {\r\n  p1Target: convertTemperature(parts, 2),\r\n  p1Temp: convertTemperature(parts, 5),\r\n  p2Temp: convertTemperature(parts, 8),\r\n  p3Temp: convertTemperature(parts, 11),\r\n  p4Temp: convertTemperature(parts, 14),\r\n  grillSetTemp: convertTemperature(parts, 20),\r\n  grillTemp: convertTemperature(parts, 23),\r\n  smokerActTemp: convertTemperature(parts, 17),\r\n  isFahrenheit: parts[26] === 1,\r\n};",
-      "updated_at": "2025-09-17T20:49:33.000000Z"
+      "temperature_function": "if (!message.startsWith(\"FE0C\")) {\r\n  return null;\r\n}\r\nconst parts = parseHexMessage(message);\r\nif (parts < 27) {\r\n  return null;\r\n}\r\nreturn {\r\n  p1Target: convertTemperature(parts, 2),\r\n  p1Temp: convertTemperature(parts, 5),\r\n  p2Temp: convertTemperature(parts, 8),\r\n  p3Temp: convertTemperature(parts, 11),\r\n  p4Temp: convertTemperature(parts, 14),\r\n  grillSetTemp: convertTemperature(parts, 20),\r\n  grillTemp: convertTemperature(parts, 23),\r\n  smokerActTemp: convertTemperature(parts, 17),\r\n  isFahrenheit: parts[26] === 1,\r\n};"
     },
     "PBL2": {
       "control_board_commands": [
         {
-          "control_board_id": 16,
-          "created_at": "2024-05-20T20:50:46.000000Z",
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0B01FF",
           "id": 155,
           "name": "Get Grill Status",
-          "slug": "get-status",
-          "updated_at": "2024-05-20T20:50:46.000000Z"
+          "slug": "get-status"
         },
         {
-          "control_board_id": 16,
-          "created_at": "2024-05-20T20:51:23.000000Z",
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0C01FF",
           "id": 156,
           "name": "Get Grill/Probes Temperatures",
-          "slug": "get-temperatures",
-          "updated_at": "2024-05-20T20:51:23.000000Z"
+          "slug": "get-temperatures"
         },
         {
-          "control_board_id": 16,
-          "created_at": "2024-05-20T20:51:56.000000Z",
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0902FF",
           "id": 157,
           "name": "Set Temperature to Celsius",
-          "slug": "set-celsius",
-          "updated_at": "2024-05-20T20:51:56.000000Z"
+          "slug": "set-celsius"
         },
         {
-          "control_board_id": 16,
-          "created_at": "2024-05-20T20:56:08.000000Z",
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0901FF",
           "id": 158,
           "name": "Set Temperature to Fahrenheit",
-          "slug": "set-fahrenheit",
-          "updated_at": "2024-05-20T20:56:08.000000Z"
+          "slug": "set-fahrenheit"
         },
         {
-          "control_board_id": 16,
-          "created_at": "2024-05-20T20:56:43.000000Z",
-          "deleted_at": null,
           "description": null,
           "function": "let _hundreds = Math.floor(arguments[0]/100); let _tens = Math.floor((arguments[0] % 100) / 10); let _ones = Math.floor(arguments[0] % 10); return 'FE0502'+formatHex(_hundreds)+formatHex(_tens)+formatHex(_ones) + 'FF';",
           "hexadecimal": null,
           "id": 159,
           "name": "Set Probe 1 Temperature",
-          "slug": "set-probe-1-temperature",
-          "updated_at": "2024-05-20T20:57:50.000000Z"
+          "slug": "set-probe-1-temperature"
         },
         {
-          "control_board_id": 16,
-          "created_at": "2024-05-20T20:57:28.000000Z",
-          "deleted_at": null,
           "description": null,
           "function": "let _hundreds = Math.floor(arguments[0]/100); let _tens = Math.floor((arguments[0] % 100) / 10); let _ones = Math.floor(arguments[0] % 10); return 'FE0501'+formatHex(_hundreds)+formatHex(_tens)+formatHex(_ones) + 'FF';",
           "hexadecimal": null,
           "id": 160,
           "name": "Set Grill Temperature",
-          "slug": "set-temperature",
-          "updated_at": "2024-05-20T20:57:28.000000Z"
+          "slug": "set-temperature"
         },
         {
-          "control_board_id": 16,
-          "created_at": "2024-05-20T20:58:38.000000Z",
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0202FF",
           "id": 161,
           "name": "Turn Light Off",
-          "slug": "turn-light-off",
-          "updated_at": "2024-05-20T20:58:38.000000Z"
+          "slug": "turn-light-off"
         },
         {
-          "control_board_id": 16,
-          "created_at": "2024-05-20T21:02:35.000000Z",
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0201FF",
           "id": 162,
           "name": "Turn Light On",
-          "slug": "turn-light-on",
-          "updated_at": "2024-05-20T21:02:35.000000Z"
+          "slug": "turn-light-on"
         },
         {
-          "control_board_id": 16,
-          "created_at": "2024-05-20T21:03:14.000000Z",
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0102FF",
           "id": 163,
           "name": "Turn Grill Off",
-          "slug": "turn-off",
-          "updated_at": "2024-05-20T21:03:14.000000Z"
+          "slug": "turn-off"
         },
         {
-          "control_board_id": 16,
-          "created_at": "2024-05-20T21:03:49.000000Z",
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0800FF",
           "id": 164,
           "name": "Turn Primer Motor Off",
-          "slug": "turn-primer-motor-off",
-          "updated_at": "2024-05-20T21:03:49.000000Z"
+          "slug": "turn-primer-motor-off"
         },
         {
-          "control_board_id": 16,
-          "created_at": "2024-05-20T21:04:29.000000Z",
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0801FF",
           "id": 165,
           "name": "Turn Primer Motor On",
-          "slug": "turn-primer-motor-on",
-          "updated_at": "2024-05-20T21:04:29.000000Z"
+          "slug": "turn-primer-motor-on"
         }
       ],
-      "created_at": "2024-05-20T20:49:31.000000Z",
-      "deleted_at": null,
       "device_status_function": null,
       "id": 16,
       "name": "PBL2",
       "platform_id": 7,
       "site_id": 1,
       "status_function": "if (!message.startsWith(\"FE0B\")) {\r\n  return null;\r\n}\r\nconst parts = parseHexMessage(message);\r\nif (parts < 44) {\r\n  return null;\r\n}\r\nconst status = {\r\n/*  p1Target: convertTemperature(parts, 2),\r\n  p1Temp: convertTemperature(parts, 5),\r\n  p2Temp: convertTemperature(parts, 8),\r\n  p3Temp: convertTemperature(parts, 11),\r\n  p4Temp: convertTemperature(parts, 14),\r\n  smokerActTemp: convertTemperature(parts, 17),*/\r\n  moduleIsOn: parts[24] === 1,\r\n  err1: parts[25] === 1,\r\n  err2: parts[26] === 1,\r\n  err3: parts[27] === 1,\r\n  highTempErr: parts[28] === 1,\r\n  fanErr: parts[29] === 1,\r\n  hotErr: parts[30] === 1,\r\n  motorErr: parts[31] === 1,\r\n  noPellets: parts[32] === 1,\r\n  erL: parts[33] === 1,\r\n  fanState: parts[34] === 1,\r\n  hotState: parts[35] === 1,\r\n  motorState: parts[36] === 1,\r\n  lightState: parts[37] === 1,\r\n  primeState: parts[38] === 1,\r\n//  isFahrenheit: parts[39] === 1,\r\n  recipeStep: parts[40],\r\n  recipeTime: parts[41] * 3600 + parts[42] * 60 + parts[43],\r\n};\r\n/*switch (parts[23]) {\r\n  case 1:\r\n    status.grillSetTemp = convertTemperature(parts, 20);\r\n    break;\r\n  case 2:\r\n    status.grillTemp = convertTemperature(parts, 20);\r\n    break;\r\n}*/\r\nreturn status;",
-      "temperature_function": "if (!message.startsWith(\"FE0C\")) {\r\n  return null;\r\n}\r\nconst parts = parseHexMessage(message);\r\nif (parts < 27) {\r\n  return null;\r\n}\r\nconst temps = {\r\n  p1Target: convertTemperature(parts, 2),\r\n  p1Temp: convertTemperature(parts, 5),\r\n  p2Temp: convertTemperature(parts, 8),\r\n  p3Temp: convertTemperature(parts, 11),\r\n  p4Temp: convertTemperature(parts, 14),\r\n  grillSetTemp: convertTemperature(parts, 20),\r\n  grillTemp: convertTemperature(parts, 23),\r\n  smokerActTemp: convertTemperature(parts, 17),\r\n  isFahrenheit: parts[26] === 1,\r\n};\r\n/*\r\nif (!temps.isFahrenheit) {\r\n  const ftoc = function (temp) {\r\n    if (typeof temp === \"undefined\" || temp === 960) {\r\n      return temp;\r\n    }\r\n    return Math.floor((temp - 32) / 1.8);\r\n  };\r\n  temps.p1Temp = ftoc(temps.p1Temp);\r\n  temps.p2Temp = ftoc(temps.p2Temp);\r\n  temps.p3Temp = ftoc(temps.p3Temp);\r\n  temps.p4Temp = ftoc(temps.p4Temp);\r\n  temps.p1Target = ftoc(temps.p1Target);\r\n  temps.smokerActTemp = ftoc(temps.smokerActTemp);\r\n  temps.grillSetTemp = ftoc(temps.grillSetTemp);\r\n  temps.grillTemp = ftoc(temps.grillTemp);\r\n}\r\n*/\r\nreturn temps;",
-      "updated_at": "2025-09-17T20:55:47.000000Z"
+      "temperature_function": "if (!message.startsWith(\"FE0C\")) {\r\n  return null;\r\n}\r\nconst parts = parseHexMessage(message);\r\nif (parts < 27) {\r\n  return null;\r\n}\r\nconst temps = {\r\n  p1Target: convertTemperature(parts, 2),\r\n  p1Temp: convertTemperature(parts, 5),\r\n  p2Temp: convertTemperature(parts, 8),\r\n  p3Temp: convertTemperature(parts, 11),\r\n  p4Temp: convertTemperature(parts, 14),\r\n  grillSetTemp: convertTemperature(parts, 20),\r\n  grillTemp: convertTemperature(parts, 23),\r\n  smokerActTemp: convertTemperature(parts, 17),\r\n  isFahrenheit: parts[26] === 1,\r\n};\r\n/*\r\nif (!temps.isFahrenheit) {\r\n  const ftoc = function (temp) {\r\n    if (typeof temp === \"undefined\" || temp === 960) {\r\n      return temp;\r\n    }\r\n    return Math.floor((temp - 32) / 1.8);\r\n  };\r\n  temps.p1Temp = ftoc(temps.p1Temp);\r\n  temps.p2Temp = ftoc(temps.p2Temp);\r\n  temps.p3Temp = ftoc(temps.p3Temp);\r\n  temps.p4Temp = ftoc(temps.p4Temp);\r\n  temps.p1Target = ftoc(temps.p1Target);\r\n  temps.smokerActTemp = ftoc(temps.smokerActTemp);\r\n  temps.grillSetTemp = ftoc(temps.grillSetTemp);\r\n  temps.grillTemp = ftoc(temps.grillTemp);\r\n}\r\n*/\r\nreturn temps;"
     },
     "PBL3": {
       "control_board_commands": [
         {
-          "control_board_id": 21,
-          "created_at": "2025-06-26T21:27:12.000000Z",
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0B01FF",
           "id": 198,
           "name": "Get Grill Status",
-          "slug": "get-status",
-          "updated_at": "2025-06-26T21:27:12.000000Z"
+          "slug": "get-status"
         },
         {
-          "control_board_id": 21,
-          "created_at": "2025-06-26T21:27:12.000000Z",
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0C01FF",
           "id": 199,
           "name": "Get Grill/Probes Temperatures",
-          "slug": "get-temperatures",
-          "updated_at": "2025-06-26T21:27:12.000000Z"
+          "slug": "get-temperatures"
         },
         {
-          "control_board_id": 21,
-          "created_at": "2025-06-26T21:27:12.000000Z",
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0902FF",
           "id": 200,
           "name": "Set Temperature to Celsius",
-          "slug": "set-celsius",
-          "updated_at": "2025-06-26T21:27:12.000000Z"
+          "slug": "set-celsius"
         },
         {
-          "control_board_id": 21,
-          "created_at": "2025-06-26T21:27:12.000000Z",
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0901FF",
           "id": 201,
           "name": "Set Temperature to Fahrenheit",
-          "slug": "set-fahrenheit",
-          "updated_at": "2025-06-26T21:27:12.000000Z"
+          "slug": "set-fahrenheit"
         },
         {
-          "control_board_id": 21,
-          "created_at": "2025-06-26T21:27:12.000000Z",
-          "deleted_at": null,
           "description": null,
           "function": "let temp = arguments[1] === false ? Math.round(((arguments[0] * 1.8)+ 32)/5) * 5 : arguments[0]; let _hundreds = Math.floor(temp/100); let _tens = Math.floor((temp % 100) / 10); let _ones = Math.floor(temp % 10); return 'FE0502'+formatHex(_hundreds)+formatHex(_tens)+formatHex(_ones) + 'FF';",
           "hexadecimal": null,
           "id": 202,
           "name": "Set Probe 1 Temperature",
-          "slug": "set-probe-1-temperature",
-          "updated_at": "2025-08-14T17:29:11.000000Z"
+          "slug": "set-probe-1-temperature"
         },
         {
-          "control_board_id": 21,
-          "created_at": "2025-06-26T21:27:12.000000Z",
-          "deleted_at": null,
           "description": null,
           "function": "let temp = arguments[1] === false ? Math.round(((arguments[0] * 1.8)+ 32)/5) * 5 : arguments[0]; let _hundreds = Math.floor(temp/100); let _tens = Math.floor((temp % 100) / 10); let _ones = Math.floor(temp % 10); return 'FE0501'+formatHex(_hundreds)+formatHex(_tens)+formatHex(_ones) + 'FF';",
           "hexadecimal": null,
           "id": 203,
           "name": "Set Grill Temperature",
-          "slug": "set-temperature",
-          "updated_at": "2025-08-14T17:29:34.000000Z"
+          "slug": "set-temperature"
         },
         {
-          "control_board_id": 21,
-          "created_at": "2025-06-26T21:27:12.000000Z",
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0202FF",
           "id": 204,
           "name": "Turn Light Off",
-          "slug": "turn-light-off",
-          "updated_at": "2025-06-26T21:27:12.000000Z"
+          "slug": "turn-light-off"
         },
         {
-          "control_board_id": 21,
-          "created_at": "2025-06-26T21:27:12.000000Z",
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0201FF",
           "id": 205,
           "name": "Turn Light On",
-          "slug": "turn-light-on",
-          "updated_at": "2025-06-26T21:27:12.000000Z"
+          "slug": "turn-light-on"
         },
         {
-          "control_board_id": 21,
-          "created_at": "2025-06-26T21:27:12.000000Z",
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0102FF",
           "id": 206,
           "name": "Turn Grill Off",
-          "slug": "turn-off",
-          "updated_at": "2025-06-26T21:27:12.000000Z"
+          "slug": "turn-off"
         },
         {
-          "control_board_id": 21,
-          "created_at": "2025-06-26T21:27:12.000000Z",
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0800FF",
           "id": 207,
           "name": "Turn Primer Motor Off",
-          "slug": "turn-primer-motor-off",
-          "updated_at": "2025-06-26T21:27:12.000000Z"
+          "slug": "turn-primer-motor-off"
         },
         {
-          "control_board_id": 21,
-          "created_at": "2025-06-26T21:27:12.000000Z",
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0801FF",
           "id": 208,
           "name": "Turn Primer Motor On",
-          "slug": "turn-primer-motor-on",
-          "updated_at": "2025-06-26T21:27:12.000000Z"
+          "slug": "turn-primer-motor-on"
         }
       ],
-      "created_at": "2025-06-26T21:27:12.000000Z",
-      "deleted_at": null,
       "device_status_function": null,
       "id": 21,
       "name": "PBL3",
       "platform_id": 8,
       "site_id": 1,
       "status_function": "if (!message.startsWith(\"FE0B\")) {\r\n  return null;\r\n}\r\nconst parts = parseHexMessage(message);\r\nif (parts < 44) {\r\n  return null;\r\n}\r\nconst status = {\r\n  /*p1Target: convertTemperature(parts, 2),\r\n  p1Temp: convertTemperature(parts, 5),\r\n  p2Temp: convertTemperature(parts, 8),\r\n  p3Temp: convertTemperature(parts, 11),\r\n  p4Temp: convertTemperature(parts, 14),\r\n  smokerActTemp: convertTemperature(parts, 17),*/\r\n  moduleIsOn: parts[24] === 1,\r\n  err1: parts[25] === 1,\r\n  err2: parts[26] === 1,\r\n  err3: parts[27] === 1,\r\n  highTempErr: parts[28] === 1,\r\n  fanErr: parts[29] === 1,\r\n  hotErr: parts[30] === 1,\r\n  motorErr: parts[31] === 1,\r\n  noPellets: parts[32] === 1,\r\n  erL: parts[33] === 1,\r\n  fanState: parts[34] === 1,\r\n  hotState: parts[35] === 1,\r\n  motorState: parts[36] === 1,\r\n  lightState: parts[37] === 1,\r\n  primeState: parts[38] === 1,\r\n//  isFahrenheit: parts[39] === 1,\r\n  recipeStep: parts[40],\r\n  recipeTime: parts[41] * 3600 + parts[42] * 60 + parts[43],\r\n};\r\n/*\r\nswitch (parts[23]) {\r\n  case 1:\r\n    status.grillSetTemp = convertTemperature(parts, 20);\r\n    break;\r\n  case 2:\r\n    status.grillTemp = convertTemperature(parts, 20);\r\n    break;\r\n} */\r\nreturn status;",
-      "temperature_function": "if (!message.startsWith(\"FE0C\")) {\r\n  return null;\r\n}\r\nconst parts = parseHexMessage(message);\r\nif (parts < 27) {\r\n  return null;\r\n}\r\nconst temps = {\r\n  p1Target: convertTemperature(parts, 2),\r\n  p1Temp: convertTemperature(parts, 5),\r\n  p2Temp: convertTemperature(parts, 8),\r\n  p3Temp: convertTemperature(parts, 11),\r\n  p4Temp: convertTemperature(parts, 14),\r\n  grillSetTemp: convertTemperature(parts, 20),\r\n  grillTemp: convertTemperature(parts, 23),\r\n  smokerActTemp: convertTemperature(parts, 17),\r\n  isFahrenheit: parts[26] === 1,\r\n};\r\nconsole.log(\"Temp function\", temps, temps.isFahrenheit);\r\nif (!temps.isFahrenheit) {\r\n  const ftoc = function (temp) {\r\n    if (typeof temp === \"undefined\" || temp === 960) {\r\n      return temp;\r\n    }\r\n    return Math.floor((temp - 32) / 1.8);\r\n  };\r\n  temps.p1Temp = ftoc(temps.p1Temp);\r\n  temps.p2Temp = ftoc(temps.p2Temp);\r\n  temps.p3Temp = ftoc(temps.p3Temp);\r\n  temps.p4Temp = ftoc(temps.p4Temp);\r\n  temps.p1Target = ftoc(temps.p1Target);\r\n  temps.smokerActTemp = ftoc(temps.smokerActTemp);\r\n  temps.grillSetTemp = ftoc(temps.grillSetTemp);\r\n  temps.grillTemp = ftoc(temps.grillTemp);\r\n  console.log(\"Temp function - converted\", temps);\r\n\r\n}\r\n\r\nreturn temps;",
-      "updated_at": "2026-03-16T20:36:21.000000Z"
+      "temperature_function": "if (!message.startsWith(\"FE0C\")) {\r\n  return null;\r\n}\r\nconst parts = parseHexMessage(message);\r\nif (parts < 27) {\r\n  return null;\r\n}\r\nconst temps = {\r\n  p1Target: convertTemperature(parts, 2),\r\n  p1Temp: convertTemperature(parts, 5),\r\n  p2Temp: convertTemperature(parts, 8),\r\n  p3Temp: convertTemperature(parts, 11),\r\n  p4Temp: convertTemperature(parts, 14),\r\n  grillSetTemp: convertTemperature(parts, 20),\r\n  grillTemp: convertTemperature(parts, 23),\r\n  smokerActTemp: convertTemperature(parts, 17),\r\n  isFahrenheit: parts[26] === 1,\r\n};\r\nconsole.log(\"Temp function\", temps, temps.isFahrenheit);\r\nif (!temps.isFahrenheit) {\r\n  const ftoc = function (temp) {\r\n    if (typeof temp === \"undefined\" || temp === 960) {\r\n      return temp;\r\n    }\r\n    return Math.floor((temp - 32) / 1.8);\r\n  };\r\n  temps.p1Temp = ftoc(temps.p1Temp);\r\n  temps.p2Temp = ftoc(temps.p2Temp);\r\n  temps.p3Temp = ftoc(temps.p3Temp);\r\n  temps.p4Temp = ftoc(temps.p4Temp);\r\n  temps.p1Target = ftoc(temps.p1Target);\r\n  temps.smokerActTemp = ftoc(temps.smokerActTemp);\r\n  temps.grillSetTemp = ftoc(temps.grillSetTemp);\r\n  temps.grillTemp = ftoc(temps.grillTemp);\r\n  console.log(\"Temp function - converted\", temps);\r\n\r\n}\r\n\r\nreturn temps;"
     },
     "PBM": {
       "control_board_commands": [
         {
-          "control_board_id": 6,
-          "created_at": null,
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0B01FF",
           "id": 37,
           "name": "Get Grill Status",
-          "slug": "get-status",
-          "updated_at": null
+          "slug": "get-status"
         },
         {
-          "control_board_id": 6,
-          "created_at": null,
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0C01FF",
           "id": 38,
           "name": "Get Grill/Probes Temperatures",
-          "slug": "get-temperatures",
-          "updated_at": null
+          "slug": "get-temperatures"
         },
         {
-          "control_board_id": 6,
-          "created_at": null,
-          "deleted_at": null,
           "description": null,
           "function": "let temp = arguments[1] === false ? Math.round(((arguments[0] * 1.8)+ 32)/5) * 5 : arguments[0]; let _hundreds = Math.floor(temp/100); let _tens = Math.floor((temp % 100) / 10); let _ones = Math.floor(temp % 10); return 'FE0501'+formatHex(_hundreds)+formatHex(_tens)+formatHex(_ones) + 'FF';",
           "hexadecimal": null,
           "id": 40,
           "name": "Set Grill Temperature",
-          "slug": "set-temperature",
-          "updated_at": null
+          "slug": "set-temperature"
         },
         {
-          "control_board_id": 6,
-          "created_at": null,
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0200FF",
           "id": 41,
           "name": "Turn Light Off",
-          "slug": "turn-light-off",
-          "updated_at": null
+          "slug": "turn-light-off"
         },
         {
-          "control_board_id": 6,
-          "created_at": null,
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0201FF",
           "id": 42,
           "name": "Turn Light On",
-          "slug": "turn-light-on",
-          "updated_at": null
+          "slug": "turn-light-on"
         },
         {
-          "control_board_id": 6,
-          "created_at": null,
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0102FF",
           "id": 43,
           "name": "Turn Grill Off",
-          "slug": "turn-off",
-          "updated_at": null
+          "slug": "turn-off"
         },
         {
-          "control_board_id": 6,
-          "created_at": null,
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0902FF",
           "id": 45,
           "name": "Set Temperature to Celsius",
-          "slug": "set-celsius",
-          "updated_at": null
+          "slug": "set-celsius"
         },
         {
-          "control_board_id": 6,
-          "created_at": null,
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0901FF",
           "id": 46,
           "name": "Set Temperature to Fahrenheit",
-          "slug": "set-fahrenheit",
-          "updated_at": null
+          "slug": "set-fahrenheit"
         }
       ],
-      "created_at": "2022-06-27T00:00:00.000000Z",
-      "deleted_at": null,
       "device_status_function": null,
       "id": 6,
       "name": "PBM",
       "platform_id": 1,
       "site_id": 1,
       "status_function": "if (!message.startsWith(\"FE0B\")) {\r\n  //not a grill status messasge\r\n  return null;\r\n}\r\n\r\nconst parts = parseHexMessage(message);\r\nif (parts < 36) {\r\n  return null;\r\n}\r\nconst status = {\r\n // p1Target: convertTemperature(parts, 2),\r\n // p1Temp: convertTemperature(parts, 5),\r\n // p2Temp: convertTemperature(parts, 8),\r\n // p3Temp: convertTemperature(parts, 11),\r\n  moduleIsOn: parts[18] === 1,\r\n  err1: parts[19] === 1,\r\n  err2: parts[20] === 1,\r\n  err3: parts[21] === 1,\r\n  highTempErr: parts[22] === 1,\r\n  fanErr: parts[23] === 1,\r\n  hotErr: parts[24] === 1,\r\n  motorErr: parts[25] === 1,\r\n  noPellets: parts[26] === 1,\r\n  fanState: parts[27] === 1,\r\n  hotState: parts[28] === 1,\r\n  motorState: parts[29] === 1,\r\n  lightState: parts[30] === 1,\r\n // isFahrenheit: parts[31] === 1,\r\n  recipeStep: parts[32],\r\n  recipeTime: parts[33] * 3600 + parts[34] * 60 + parts[35],\r\n};\r\n/*\r\nswitch (parts[17]) {\r\n  case 1:\r\n    status.grillSetTemp = convertTemperature(parts, 14);\r\n    break;\r\n  case 2:\r\n    status.grillTemp = convertTemperature(parts, 14);\r\n    break;\r\n}\r\n\r\nif (!status.isFahrenheit) {\r\n  const ftoc = function (temp) {\r\n    if ((typeof temp === \"undefined\") || (temp === 960)) {\r\n      return temp;\r\n    }\r\n    return Math.floor((temp - 32) / 1.8);\r\n  };\r\n  status.p1Temp = ftoc(status.p1Temp);\r\n  status.p2Temp = ftoc(status.p2Temp);\r\n  status.p3Temp = ftoc(status.p3Temp);\r\n  status.grillSetTemp = ftoc(status.grillSetTemp);\r\n  status.grillTemp = ftoc(status.grillTemp);\r\n}\r\n*/\r\nreturn status;",
-      "temperature_function": "if (!message.startsWith(\"FE0C\")) {\r\n  //not a grill temperature messasge\r\n  return null;\r\n}\r\n\r\nconst parts = parseHexMessage(message);\r\nif (parts < 21) {\r\n  return null;\r\n}\r\n\r\nconst temps = {\r\n  //  p1Target: convertTemperature(parts, 2),\r\n  p1Temp: convertTemperature(parts, 5),\r\n  p2Temp: convertTemperature(parts, 8),\r\n  p3Temp: convertTemperature(parts, 11),\r\n  grillSetTemp: convertTemperature(parts, 14),\r\n  grillTemp: convertTemperature(parts, 17),\r\n  isFahrenheit: parts[20] === 1,\r\n};\r\n\r\nif (!temps.isFahrenheit) {\r\n  const ftoc = function (temp) {\r\n    if ((typeof temp === \"undefined\") || (temp === 960)) {\r\n      return temp;\r\n    }\r\n    return Math.floor((temp - 32) / 1.8);\r\n  };\r\n  temps.p1Temp = ftoc(temps.p1Temp);\r\n  temps.p2Temp = ftoc(temps.p2Temp);\r\n  temps.p3Temp = ftoc(temps.p3Temp);\r\n  temps.grillSetTemp = ftoc(temps.grillSetTemp);\r\n  temps.grillTemp = ftoc(temps.grillTemp);\r\n}\r\n\r\nreturn temps;",
-      "updated_at": "2025-09-17T20:51:42.000000Z"
+      "temperature_function": "if (!message.startsWith(\"FE0C\")) {\r\n  //not a grill temperature messasge\r\n  return null;\r\n}\r\n\r\nconst parts = parseHexMessage(message);\r\nif (parts < 21) {\r\n  return null;\r\n}\r\n\r\nconst temps = {\r\n  //  p1Target: convertTemperature(parts, 2),\r\n  p1Temp: convertTemperature(parts, 5),\r\n  p2Temp: convertTemperature(parts, 8),\r\n  p3Temp: convertTemperature(parts, 11),\r\n  grillSetTemp: convertTemperature(parts, 14),\r\n  grillTemp: convertTemperature(parts, 17),\r\n  isFahrenheit: parts[20] === 1,\r\n};\r\n\r\nif (!temps.isFahrenheit) {\r\n  const ftoc = function (temp) {\r\n    if ((typeof temp === \"undefined\") || (temp === 960)) {\r\n      return temp;\r\n    }\r\n    return Math.floor((temp - 32) / 1.8);\r\n  };\r\n  temps.p1Temp = ftoc(temps.p1Temp);\r\n  temps.p2Temp = ftoc(temps.p2Temp);\r\n  temps.p3Temp = ftoc(temps.p3Temp);\r\n  temps.grillSetTemp = ftoc(temps.grillSetTemp);\r\n  temps.grillTemp = ftoc(temps.grillTemp);\r\n}\r\n\r\nreturn temps;"
     },
     "PBM2": {
       "control_board_commands": [
         {
-          "control_board_id": 20,
-          "created_at": "2025-05-27T22:39:50.000000Z",
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0B01FF",
           "id": 190,
           "name": "Get Grill Status",
-          "slug": "get-status",
-          "updated_at": "2025-05-27T22:39:50.000000Z"
+          "slug": "get-status"
         },
         {
-          "control_board_id": 20,
-          "created_at": "2025-05-27T22:43:48.000000Z",
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0C01FF",
           "id": 191,
           "name": "Get Grill/Probes Temperatures",
-          "slug": "get-temperatures",
-          "updated_at": "2025-05-27T22:43:48.000000Z"
+          "slug": "get-temperatures"
         },
         {
-          "control_board_id": 20,
-          "created_at": "2025-05-27T22:44:21.000000Z",
-          "deleted_at": null,
           "description": null,
           "function": "let temp = arguments[1] === false ? Math.round(((arguments[0] * 1.8)+ 32)/5) * 5 : arguments[0]; let _hundreds = Math.floor(temp/100); let _tens = Math.floor((temp % 100) / 10); let _ones = Math.floor(temp % 10); return 'FE0501'+formatHex(_hundreds)+formatHex(_tens)+formatHex(_ones) + 'FF';",
           "hexadecimal": null,
           "id": 192,
           "name": "Set Grill Temperature",
-          "slug": "set-temperature",
-          "updated_at": "2025-05-27T22:44:21.000000Z"
+          "slug": "set-temperature"
         },
         {
-          "control_board_id": 20,
-          "created_at": "2025-05-27T22:45:26.000000Z",
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0200FF",
           "id": 193,
           "name": "Turn Light Off",
-          "slug": "turn-light-off",
-          "updated_at": "2025-05-27T22:45:26.000000Z"
+          "slug": "turn-light-off"
         },
         {
-          "control_board_id": 20,
-          "created_at": "2025-05-27T22:45:59.000000Z",
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0201FF",
           "id": 194,
           "name": "Turn Light On",
-          "slug": "turn-light-on",
-          "updated_at": "2025-05-27T22:45:59.000000Z"
+          "slug": "turn-light-on"
         },
         {
-          "control_board_id": 20,
-          "created_at": "2025-05-27T22:46:39.000000Z",
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0102FF",
           "id": 195,
           "name": "Turn Grill Off",
-          "slug": "turn-off",
-          "updated_at": "2025-05-27T22:46:39.000000Z"
+          "slug": "turn-off"
         },
         {
-          "control_board_id": 20,
-          "created_at": "2025-05-27T22:47:26.000000Z",
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0902FF",
           "id": 196,
           "name": "Set Temperature to Celsius",
-          "slug": "set-celsius",
-          "updated_at": "2025-05-27T22:47:26.000000Z"
+          "slug": "set-celsius"
         },
         {
-          "control_board_id": 20,
-          "created_at": "2025-05-27T22:48:02.000000Z",
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0901FF",
           "id": 197,
           "name": "Set Temperature to Fahrenheit",
-          "slug": "set-fahrenheit",
-          "updated_at": "2025-05-27T22:48:02.000000Z"
+          "slug": "set-fahrenheit"
         }
       ],
-      "created_at": "2025-05-27T22:38:29.000000Z",
-      "deleted_at": null,
       "device_status_function": null,
       "id": 20,
       "name": "PBM2",
       "platform_id": 8,
       "site_id": 1,
       "status_function": "if (!message.startsWith(\"FE0B\")) {\r\n  //not a grill status messasge\r\n  return null;\r\n}\r\n\r\nconst parts = parseHexMessage(message);\r\nif (parts < 36) {\r\n  return null;\r\n}\r\nconst status = {\r\n // p1Target: convertTemperature(parts, 2),\r\n // p1Temp: convertTemperature(parts, 5),\r\n // p2Temp: convertTemperature(parts, 8),\r\n // p3Temp: convertTemperature(parts, 11),\r\n  moduleIsOn: parts[18] === 1,\r\n  err1: parts[19] === 1,\r\n  err2: parts[20] === 1,\r\n  err3: parts[21] === 1,\r\n  highTempErr: parts[22] === 1,\r\n  fanErr: parts[23] === 1,\r\n  hotErr: parts[24] === 1,\r\n  motorErr: parts[25] === 1,\r\n  noPellets: parts[26] === 1,\r\n  fanState: parts[27] === 1,\r\n  hotState: parts[28] === 1,\r\n  motorState: parts[29] === 1,\r\n  lightState: parts[30] === 1,\r\n // isFahrenheit: parts[31] === 1,\r\n  recipeStep: parts[32],\r\n  recipeTime: parts[33] * 3600 + parts[34] * 60 + parts[35],\r\n};\r\n/*\r\nswitch (parts[17]) {\r\n  case 1:\r\n    status.grillSetTemp = convertTemperature(parts, 14);\r\n    break;\r\n  case 2:\r\n    status.grillTemp = convertTemperature(parts, 14);\r\n    break;\r\n}\r\n\r\nif (!status.isFahrenheit) {\r\n  const ftoc = function (temp) {\r\n    if ((typeof temp === \"undefined\") || (temp === 960)) {\r\n      return temp;\r\n    }\r\n    return Math.floor((temp - 32) / 1.8);\r\n  };\r\n  status.p1Temp = ftoc(status.p1Temp);\r\n  status.p2Temp = ftoc(status.p2Temp);\r\n  status.p3Temp = ftoc(status.p3Temp);\r\n  status.grillSetTemp = ftoc(status.grillSetTemp);\r\n  status.grillTemp = ftoc(status.grillTemp);\r\n}*/\r\n\r\nreturn status;",
-      "temperature_function": "if (!message.startsWith(\"FE0C\")) {\r\n  //not a grill temperature messasge\r\n  return null;\r\n}\r\n\r\nconst parts = parseHexMessage(message);\r\nif (parts < 21) {\r\n  return null;\r\n}\r\n\r\nconst temps = {\r\n  //  p1Target: convertTemperature(parts, 2),\r\n  p1Temp: convertTemperature(parts, 5),\r\n  p2Temp: convertTemperature(parts, 8),\r\n  p3Temp: convertTemperature(parts, 11),\r\n  grillSetTemp: convertTemperature(parts, 14),\r\n  grillTemp: convertTemperature(parts, 17),\r\n  isFahrenheit: parts[20] === 1,\r\n};\r\n\r\nif (!temps.isFahrenheit) {\r\n  const ftoc = function (temp) {\r\n    if ((typeof temp === \"undefined\") || (temp === 960)) {\r\n      return temp;\r\n    }\r\n    return Math.floor((temp - 32) / 1.8);\r\n  };\r\n  temps.p1Temp = ftoc(temps.p1Temp);\r\n  temps.p2Temp = ftoc(temps.p2Temp);\r\n  temps.p3Temp = ftoc(temps.p3Temp);\r\n  temps.grillSetTemp = ftoc(temps.grillSetTemp);\r\n  temps.grillTemp = ftoc(temps.grillTemp);\r\n}\r\n\r\nreturn temps;",
-      "updated_at": "2025-09-17T20:57:56.000000Z"
+      "temperature_function": "if (!message.startsWith(\"FE0C\")) {\r\n  //not a grill temperature messasge\r\n  return null;\r\n}\r\n\r\nconst parts = parseHexMessage(message);\r\nif (parts < 21) {\r\n  return null;\r\n}\r\n\r\nconst temps = {\r\n  //  p1Target: convertTemperature(parts, 2),\r\n  p1Temp: convertTemperature(parts, 5),\r\n  p2Temp: convertTemperature(parts, 8),\r\n  p3Temp: convertTemperature(parts, 11),\r\n  grillSetTemp: convertTemperature(parts, 14),\r\n  grillTemp: convertTemperature(parts, 17),\r\n  isFahrenheit: parts[20] === 1,\r\n};\r\n\r\nif (!temps.isFahrenheit) {\r\n  const ftoc = function (temp) {\r\n    if ((typeof temp === \"undefined\") || (temp === 960)) {\r\n      return temp;\r\n    }\r\n    return Math.floor((temp - 32) / 1.8);\r\n  };\r\n  temps.p1Temp = ftoc(temps.p1Temp);\r\n  temps.p2Temp = ftoc(temps.p2Temp);\r\n  temps.p3Temp = ftoc(temps.p3Temp);\r\n  temps.grillSetTemp = ftoc(temps.grillSetTemp);\r\n  temps.grillTemp = ftoc(temps.grillTemp);\r\n}\r\n\r\nreturn temps;"
     },
     "PBP": {
       "control_board_commands": [
         {
-          "control_board_id": 13,
-          "created_at": "2023-03-20T11:48:19.000000Z",
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0B01FF",
           "id": 128,
           "name": "Get Grill Status",
-          "slug": "get-status",
-          "updated_at": "2023-03-20T11:48:19.000000Z"
+          "slug": "get-status"
         },
         {
-          "control_board_id": 13,
-          "created_at": "2023-03-20T11:49:37.000000Z",
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0C01FF",
           "id": 129,
           "name": "Get Grill/Probes Temperatures",
-          "slug": "get-temperatures",
-          "updated_at": "2023-03-20T11:49:37.000000Z"
+          "slug": "get-temperatures"
         },
         {
-          "control_board_id": 13,
-          "created_at": "2023-03-20T11:50:37.000000Z",
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0902FF",
           "id": 130,
           "name": "Set Temperature to Celsius",
-          "slug": "set-celsius",
-          "updated_at": "2023-03-20T11:50:37.000000Z"
+          "slug": "set-celsius"
         },
         {
-          "control_board_id": 13,
-          "created_at": "2023-03-20T11:51:32.000000Z",
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0901FF",
           "id": 131,
           "name": "Set Temperature to Fahrenheit",
-          "slug": "set-fahrenheit",
-          "updated_at": "2023-03-20T11:51:32.000000Z"
+          "slug": "set-fahrenheit"
         },
         {
-          "control_board_id": 13,
-          "created_at": "2023-03-20T11:52:27.000000Z",
-          "deleted_at": null,
           "description": null,
           "function": "let _hundreds = Math.floor(arguments[0]/100); let _tens = Math.floor((arguments[0] % 100) / 10); let _ones = Math.floor(arguments[0] % 10); return 'FE0502'+formatHex(_hundreds)+formatHex(_tens)+formatHex(_ones) + 'FF';",
           "hexadecimal": null,
           "id": 132,
           "name": "Set Probe 1 Temperature",
-          "slug": "set-probe-1-temperature",
-          "updated_at": "2023-03-20T11:52:27.000000Z"
+          "slug": "set-probe-1-temperature"
         },
         {
-          "control_board_id": 13,
-          "created_at": "2023-03-20T11:54:16.000000Z",
-          "deleted_at": null,
           "description": null,
           "function": "let _hundreds = Math.floor(arguments[0]/100); let _tens = Math.floor((arguments[0] % 100) / 10); let _ones = Math.floor(arguments[0] % 10); return 'FE0501'+formatHex(_hundreds)+formatHex(_tens)+formatHex(_ones) + 'FF';",
           "hexadecimal": null,
           "id": 133,
           "name": "Set Grill Temperature",
-          "slug": "set-temperature",
-          "updated_at": "2023-03-20T11:54:16.000000Z"
+          "slug": "set-temperature"
         },
         {
-          "control_board_id": 13,
-          "created_at": "2023-03-20T11:55:17.000000Z",
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0202FF",
           "id": 134,
           "name": "Turn Light Off",
-          "slug": "turn-light-off",
-          "updated_at": "2023-03-20T11:55:17.000000Z"
+          "slug": "turn-light-off"
         },
         {
-          "control_board_id": 13,
-          "created_at": "2023-03-20T11:56:32.000000Z",
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0201FF",
           "id": 135,
           "name": "Turn Light On",
-          "slug": "turn-light-on",
-          "updated_at": "2023-03-20T11:56:32.000000Z"
+          "slug": "turn-light-on"
         },
         {
-          "control_board_id": 13,
-          "created_at": "2023-03-20T11:57:37.000000Z",
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0102FF",
           "id": 136,
           "name": "Turn Grill Off",
-          "slug": "turn-off",
-          "updated_at": "2023-03-20T11:57:37.000000Z"
+          "slug": "turn-off"
         },
         {
-          "control_board_id": 13,
-          "created_at": "2023-03-20T11:58:26.000000Z",
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0800FF",
           "id": 137,
           "name": "Turn Primer Motor Off",
-          "slug": "turn-primer-motor-off",
-          "updated_at": "2023-03-20T11:58:26.000000Z"
+          "slug": "turn-primer-motor-off"
         },
         {
-          "control_board_id": 13,
-          "created_at": "2023-03-20T11:59:11.000000Z",
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0801FF",
           "id": 138,
           "name": "Turn Primer Motor On",
-          "slug": "turn-primer-motor-on",
-          "updated_at": "2023-03-20T11:59:11.000000Z"
+          "slug": "turn-primer-motor-on"
         }
       ],
-      "created_at": "2023-03-20T11:44:59.000000Z",
-      "deleted_at": null,
       "device_status_function": null,
       "id": 13,
       "name": "PBP",
       "platform_id": 1,
       "site_id": 1,
       "status_function": "if (!message.startsWith(\"FE0B\")) {\r\n  return null;\r\n}\r\nconst parts = parseHexMessage(message);\r\nif (parts < 44) {\r\n  return null;\r\n}\r\nconst status = {\r\n /* p1Target: convertTemperature(parts, 2),\r\n  p1Temp: convertTemperature(parts, 5),\r\n  p2Temp: convertTemperature(parts, 8),\r\n  p3Temp: convertTemperature(parts, 11),\r\n  p4Temp: convertTemperature(parts, 14),\r\n  smokerActTemp: convertTemperature(parts, 17),*/\r\n  moduleIsOn: parts[24] === 1,\r\n  err1: parts[25] === 1,\r\n  err2: parts[26] === 1,\r\n  err3: parts[27] === 1,\r\n  highTempErr: parts[28] === 1,\r\n  fanErr: parts[29] === 1,\r\n  hotErr: parts[30] === 1,\r\n  motorErr: parts[31] === 1,\r\n  noPellets: parts[32] === 1,\r\n  erL: parts[33] === 1,\r\n  fanState: parts[34] === 1,\r\n  hotState: parts[35] === 1,\r\n  motorState: parts[36] === 1,\r\n  lightState: parts[37] === 1,\r\n  primeState: parts[38] === 1,\r\n//  isFahrenheit: parts[39] === 1,\r\n  recipeStep: parts[40],\r\n  recipeTime: parts[41] * 3600 + parts[42] * 60 + parts[43],\r\n};\r\n/*\r\nswitch (parts[23]) {\r\n  case 1:\r\n    status.grillSetTemp = convertTemperature(parts, 20);\r\n    break;\r\n  case 2:\r\n    status.grillTemp = convertTemperature(parts, 20);\r\n    break;\r\n}*/\r\nreturn status;",
-      "temperature_function": "if (!message.startsWith(\"FE0C\")) {\r\n  return null;\r\n}\r\nconst parts = parseHexMessage(message);\r\nif (parts < 27) {\r\n  return null;\r\n}\r\nreturn {\r\n  p1Target: convertTemperature(parts, 2),\r\n  p1Temp: convertTemperature(parts, 5),\r\n  p2Temp: convertTemperature(parts, 8),\r\n  p3Temp: convertTemperature(parts, 11),\r\n  p4Temp: convertTemperature(parts, 14),\r\n  grillSetTemp: convertTemperature(parts, 20),\r\n  grillTemp: convertTemperature(parts, 23),\r\n  smokerActTemp: convertTemperature(parts, 17),\r\n  isFahrenheit: parts[26] === 1,\r\n};",
-      "updated_at": "2025-09-17T20:53:56.000000Z"
+      "temperature_function": "if (!message.startsWith(\"FE0C\")) {\r\n  return null;\r\n}\r\nconst parts = parseHexMessage(message);\r\nif (parts < 27) {\r\n  return null;\r\n}\r\nreturn {\r\n  p1Target: convertTemperature(parts, 2),\r\n  p1Temp: convertTemperature(parts, 5),\r\n  p2Temp: convertTemperature(parts, 8),\r\n  p3Temp: convertTemperature(parts, 11),\r\n  p4Temp: convertTemperature(parts, 14),\r\n  grillSetTemp: convertTemperature(parts, 20),\r\n  grillTemp: convertTemperature(parts, 23),\r\n  smokerActTemp: convertTemperature(parts, 17),\r\n  isFahrenheit: parts[26] === 1,\r\n};"
     },
     "PBT": {
       "control_board_commands": [
         {
-          "control_board_id": 7,
-          "created_at": null,
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0B01FF",
           "id": 59,
           "name": "Get Grill Status",
-          "slug": "get-status",
-          "updated_at": null
+          "slug": "get-status"
         },
         {
-          "control_board_id": 7,
-          "created_at": null,
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0C01FF",
           "id": 60,
           "name": "Get Grill/Probes Temperatures",
-          "slug": "get-temperatures",
-          "updated_at": null
+          "slug": "get-temperatures"
         },
         {
-          "control_board_id": 7,
-          "created_at": null,
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0902FF",
           "id": 61,
           "name": "Set Temperature to Celsius",
-          "slug": "set-celsius",
-          "updated_at": null
+          "slug": "set-celsius"
         },
         {
-          "control_board_id": 7,
-          "created_at": null,
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0901FF",
           "id": 62,
           "name": "Set Temperature to Fahrenheit",
-          "slug": "set-fahrenheit",
-          "updated_at": null
+          "slug": "set-fahrenheit"
         },
         {
-          "control_board_id": 7,
-          "created_at": null,
-          "deleted_at": null,
           "description": null,
           "function": "let temp = arguments[1] === false ? Math.round(((arguments[0] * 1.8)+ 32)/5) * 5 : arguments[0]; let _hundreds = Math.floor(temp/100); let _tens = Math.floor((temp % 100) / 10); let _ones = Math.floor(temp % 10); return 'FE0502'+formatHex(_hundreds)+formatHex(_tens)+formatHex(_ones) + 'FF';",
           "hexadecimal": null,
           "id": 63,
           "name": "Set Probe 1 Temperature",
-          "slug": "set-probe-1-temperature",
-          "updated_at": "2023-01-11T15:20:42.000000Z"
+          "slug": "set-probe-1-temperature"
         },
         {
-          "control_board_id": 7,
-          "created_at": null,
-          "deleted_at": null,
           "description": null,
           "function": "let temp = arguments[1] === false ? Math.round(((arguments[0] * 1.8)+ 32)/5) * 5 : arguments[0]; let _hundreds = Math.floor(temp/100); let _tens = Math.floor((temp % 100) / 10); let _ones = Math.floor(temp % 10); return 'FE0501'+formatHex(_hundreds)+formatHex(_tens)+formatHex(_ones) + 'FF';",
           "hexadecimal": null,
           "id": 64,
           "name": "Set Grill Temperature",
-          "slug": "set-temperature",
-          "updated_at": "2023-01-11T15:21:06.000000Z"
+          "slug": "set-temperature"
         },
         {
-          "control_board_id": 7,
-          "created_at": null,
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0200FF",
           "id": 65,
           "name": "Turn Light Off",
-          "slug": "turn-light-off",
-          "updated_at": null
+          "slug": "turn-light-off"
         },
         {
-          "control_board_id": 7,
-          "created_at": null,
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0201FF",
           "id": 66,
           "name": "Turn Light On",
-          "slug": "turn-light-on",
-          "updated_at": null
+          "slug": "turn-light-on"
         },
         {
-          "control_board_id": 7,
-          "created_at": null,
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0102FF",
           "id": 67,
           "name": "Turn Grill Off",
-          "slug": "turn-off",
-          "updated_at": null
+          "slug": "turn-off"
         },
         {
-          "control_board_id": 7,
-          "created_at": null,
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0800FF",
           "id": 69,
           "name": "Turn Primer Motor Off",
-          "slug": "turn-primer-motor-off",
-          "updated_at": null
+          "slug": "turn-primer-motor-off"
         },
         {
-          "control_board_id": 7,
-          "created_at": null,
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0801FF",
           "id": 70,
           "name": "Turn Primer Motor On",
-          "slug": "turn-primer-motor-on",
-          "updated_at": null
+          "slug": "turn-primer-motor-on"
         },
         {
-          "control_board_id": 7,
-          "created_at": "2023-01-11T15:20:22.000000Z",
-          "deleted_at": null,
           "description": "Set Probe 2 temperature",
           "function": "let temp = arguments[1] === false ? Math.round(((arguments[0] * 1.8)+ 32)/5) * 5 : arguments[0]; let _hundreds = Math.floor(temp/100); let _tens = Math.floor((temp % 100) / 10); let _ones = Math.floor(temp % 10); return 'FE0503'+formatHex(_hundreds)+formatHex(_tens)+formatHex(_ones) + 'FF';",
           "hexadecimal": null,
           "id": 117,
           "name": "Set Probe 2 Temperature",
-          "slug": "set-probe-2-temperature",
-          "updated_at": "2023-01-11T15:20:22.000000Z"
+          "slug": "set-probe-2-temperature"
         }
       ],
-      "created_at": "2022-06-27T00:00:00.000000Z",
-      "deleted_at": null,
       "device_status_function": null,
       "id": 7,
       "name": "PBT",
       "platform_id": 8,
       "site_id": 1,
       "status_function": "if (!message.startsWith(\"FE0B\")) {\r\n  return null;\r\n}\r\nconst parts = parseHexMessage(message);\r\nif (parts.length < 47) {\r\n  return null;\r\n}\r\n//const p1Target = convertTemperature(parts, 2);\r\n//const p2Target = convertTemperature(parts, 5);\r\n\r\nconst status = {\r\n/*  p1Target: p1Target !== 000 && p1Target !== 960 ? p1Target : null,\r\n  p2Target: p2Target !== 000 && p2Target !== 960 ? p2Target : null,\r\n  p1Temp: convertTemperature(parts, 8),\r\n  p2Temp: convertTemperature(parts, 11),\r\n  p3Temp: convertTemperature(parts, 14),\r\n  p4Temp: convertTemperature(parts, 17),\r\n  smokerActTemp: convertTemperature(parts, 20), */\r\n  moduleIsOn: parts[27] === 1,\r\n  err1: parts[28] === 1,\r\n  err2: parts[29] === 1,\r\n  err3: parts[30] === 1,\r\n  highTempErr: parts[31] === 1,\r\n  fanErr: parts[32] === 1,\r\n  hotErr: parts[33] === 1,\r\n  motorErr: parts[34] === 1,\r\n  noPellets: parts[35] === 1,\r\n  erL: parts[36] === 1,\r\n  fanState: parts[37] === 1,\r\n  hotState: parts[38] === 1,\r\n  motorState: parts[39] === 1,\r\n  lightState: parts[40] === 1,\r\n  primeState: parts[41] === 1,\r\n // isFahrenheit: parts[42] === 1,\r\n  recipeStep: parts[43],\r\n  recipeTime: parts[44] * 3600 + parts[45] * 60 + parts[46],\r\n};\r\n/*switch (parts[26]) {\r\n  case 1:\r\n    status.grillSetTemp = convertTemperature(parts, 23);\r\n    break;\r\n  case 2:\r\n    status.grillTemp = convertTemperature(parts, 23);\r\n    break;\r\n}\r\n\r\nif (!status.isFahrenheit) {\r\n  const ftoc = function (temp) {\r\n    if ((typeof temp === \"undefined\") || (temp === 960)) {\r\n      return temp;\r\n    }\r\n    return Math.floor((temp - 32) / 1.8);\r\n  };\r\n  status.p1Temp = ftoc(status.p1Temp);\r\n  status.p2Temp = ftoc(status.p2Temp);\r\n  status.p3Temp = ftoc(status.p3Temp);\r\n  status.grillSetTemp = ftoc(status.grillSetTemp);\r\n  status.grillTemp = ftoc(status.grillTemp);\r\n  status.p1Target =  ftoc(status.p1Target);\r\n  status.p2Target =  ftoc(status.p2Target);\r\n}*/\r\n\r\nreturn status;",
-      "temperature_function": "if (!message.startsWith(\"FE0C\")) {\r\n  return null;\r\n}\r\nconst parts = parseHexMessage(message);\r\nif (parts.length < 30) {\r\n  return null;\r\n}\r\n\r\nconst p1Target = convertTemperature(parts, 2);\r\nconst p2Target = convertTemperature(parts, 5);\r\n\r\nconst temps = {\r\n  p1Target: p1Target !== 000 && p1Target !== 960 ? p1Target : null,\r\n  p2Target: p2Target !== 000 && p2Target !== 960 ? p2Target : null,\r\n  p1Temp: convertTemperature(parts, 8),\r\n  p2Temp: convertTemperature(parts, 11),\r\n  p3Temp: convertTemperature(parts, 14),\r\n  p4Temp: convertTemperature(parts, 17),\r\n  grillSetTemp: convertTemperature(parts, 23),\r\n  grillTemp: convertTemperature(parts, 26),\r\n  smokerActTemp: convertTemperature(parts, 20),\r\n  isFahrenheit: parts[29] === 1,\r\n};\r\n\r\nif (!temps.isFahrenheit) {\r\n  const ftoc = function (temp) {\r\n    if ((typeof temp === \"undefined\") || (temp === 960)) {\r\n      return temp;\r\n    }\r\n    return Math.floor((temp - 32) / 1.8);\r\n  };\r\n  temps.p1Target =  ftoc(temps.p1Target);\r\n  temps.p2Target =  ftoc(temps.p2Target);\r\n  temps.p1Temp = ftoc(temps.p1Temp);\r\n  temps.p2Temp = ftoc(temps.p2Temp);\r\n  temps.p3Temp = ftoc(temps.p3Temp);\r\n  temps.grillSetTemp = ftoc(temps.grillSetTemp);\r\n  temps.grillTemp = ftoc(temps.grillTemp);\r\n}\r\n\r\nreturn temps;",
-      "updated_at": "2025-11-03T18:56:09.000000Z"
+      "temperature_function": "if (!message.startsWith(\"FE0C\")) {\r\n  return null;\r\n}\r\nconst parts = parseHexMessage(message);\r\nif (parts.length < 30) {\r\n  return null;\r\n}\r\n\r\nconst p1Target = convertTemperature(parts, 2);\r\nconst p2Target = convertTemperature(parts, 5);\r\n\r\nconst temps = {\r\n  p1Target: p1Target !== 000 && p1Target !== 960 ? p1Target : null,\r\n  p2Target: p2Target !== 000 && p2Target !== 960 ? p2Target : null,\r\n  p1Temp: convertTemperature(parts, 8),\r\n  p2Temp: convertTemperature(parts, 11),\r\n  p3Temp: convertTemperature(parts, 14),\r\n  p4Temp: convertTemperature(parts, 17),\r\n  grillSetTemp: convertTemperature(parts, 23),\r\n  grillTemp: convertTemperature(parts, 26),\r\n  smokerActTemp: convertTemperature(parts, 20),\r\n  isFahrenheit: parts[29] === 1,\r\n};\r\n\r\nif (!temps.isFahrenheit) {\r\n  const ftoc = function (temp) {\r\n    if ((typeof temp === \"undefined\") || (temp === 960)) {\r\n      return temp;\r\n    }\r\n    return Math.floor((temp - 32) / 1.8);\r\n  };\r\n  temps.p1Target =  ftoc(temps.p1Target);\r\n  temps.p2Target =  ftoc(temps.p2Target);\r\n  temps.p1Temp = ftoc(temps.p1Temp);\r\n  temps.p2Temp = ftoc(temps.p2Temp);\r\n  temps.p3Temp = ftoc(temps.p3Temp);\r\n  temps.grillSetTemp = ftoc(temps.grillSetTemp);\r\n  temps.grillTemp = ftoc(temps.grillTemp);\r\n}\r\n\r\nreturn temps;"
     },
     "PBV": {
       "control_board_commands": [
         {
-          "control_board_id": 4,
-          "created_at": null,
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0B01FF",
           "id": 47,
           "name": "Get Grill Status",
-          "slug": "get-status",
-          "updated_at": null
+          "slug": "get-status"
         },
         {
-          "control_board_id": 4,
-          "created_at": null,
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0C01FF",
           "id": 48,
           "name": "Get Grill/Probes Temperatures",
-          "slug": "get-temperatures",
-          "updated_at": null
+          "slug": "get-temperatures"
         },
         {
-          "control_board_id": 4,
-          "created_at": null,
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0902FF",
           "id": 49,
           "name": "Set Temperature to Celsius",
-          "slug": "set-celsius",
-          "updated_at": null
+          "slug": "set-celsius"
         },
         {
-          "control_board_id": 4,
-          "created_at": null,
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0901FF",
           "id": 50,
           "name": "Set Temperature to Fahrenheit",
-          "slug": "set-fahrenheit",
-          "updated_at": null
+          "slug": "set-fahrenheit"
         },
         {
-          "control_board_id": 4,
-          "created_at": null,
-          "deleted_at": null,
           "description": null,
           "function": "let temp = arguments[1] === false ? Math.round(((arguments[0] * 1.8)+ 32)/5) * 5 : arguments[0]; let _hundreds = Math.floor(temp/100); let _tens = Math.floor((temp % 100) / 10); let _ones = Math.floor(temp % 10); return 'FE0501'+formatHex(_hundreds)+formatHex(_tens)+formatHex(_ones) + 'FF';",
           "hexadecimal": null,
           "id": 52,
           "name": "Set Grill Temperature",
-          "slug": "set-temperature",
-          "updated_at": null
+          "slug": "set-temperature"
         },
         {
-          "control_board_id": 4,
-          "created_at": null,
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0200FF",
           "id": 53,
           "name": "Turn Light Off",
-          "slug": "turn-light-off",
-          "updated_at": null
+          "slug": "turn-light-off"
         },
         {
-          "control_board_id": 4,
-          "created_at": null,
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0201FF",
           "id": 54,
           "name": "Turn Light On",
-          "slug": "turn-light-on",
-          "updated_at": null
+          "slug": "turn-light-on"
         },
         {
-          "control_board_id": 4,
-          "created_at": null,
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0102FF",
           "id": 55,
           "name": "Turn Grill Off",
-          "slug": "turn-off",
-          "updated_at": null
+          "slug": "turn-off"
         },
         {
-          "control_board_id": 4,
-          "created_at": null,
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0800FF",
           "id": 57,
           "name": "Turn Primer Motor Off",
-          "slug": "turn-primer-motor-off",
-          "updated_at": null
+          "slug": "turn-primer-motor-off"
         },
         {
-          "control_board_id": 4,
-          "created_at": null,
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0801FF",
           "id": 58,
           "name": "Turn Primer Motor On",
-          "slug": "turn-primer-motor-on",
-          "updated_at": null
+          "slug": "turn-primer-motor-on"
         }
       ],
-      "created_at": "2022-06-27T00:00:00.000000Z",
-      "deleted_at": null,
       "device_status_function": null,
       "id": 4,
       "name": "PBV",
       "platform_id": 5,
       "site_id": 1,
       "status_function": "if (!message.startsWith(\"FE0B\")) {\r\n  //not a grill status messasge\r\n  return null;\r\n}\r\n\r\nconst parts = parseHexMessage(message);\r\nif (parts < 44) {\r\n  return null;\r\n}\r\nconst status = {\r\n  /*p1Target: convertTemperature(parts, 2),\r\n  p1Temp: convertTemperature(parts, 5),\r\n  p2Temp: convertTemperature(parts, 8),\r\n  p3Temp: convertTemperature(parts, 11),\r\n  p4Temp: convertTemperature(parts, 14),\r\n  smokerActTemp: convertTemperature(parts, 17),*/\r\n  moduleIsOn: parts[24] === 1,\r\n  err1: parts[25] === 1,\r\n  err2: parts[26] === 1,\r\n  err3: parts[27] === 1,\r\n  highTempErr: parts[28] === 1,\r\n  fanErr: parts[29] === 1,\r\n  hotErr: parts[30] === 1,\r\n  motorErr: parts[31] === 1,\r\n  noPellets: parts[32] === 1,\r\n  erL: parts[33] === 1,\r\n  fanState: parts[34] === 1,\r\n  hotState: parts[35] === 1,\r\n  motorState: parts[36] === 1,\r\n  lightState: parts[37] === 1,\r\n  primeState: parts[38] === 1,\r\n//  isFahrenheit: parts[39] === 1,\r\n  recipeStep: parts[40],\r\n  recipeTime: parts[41] * 3600 + parts[42] * 60 + parts[43],\r\n};\r\n/*switch (parts[23]) {\r\n  case 1:\r\n    status.grillSetTemp = convertTemperature(parts, 20);\r\n    break;\r\n  case 2:\r\n    status.grillTemp = convertTemperature(parts, 20);\r\n    break;\r\n}\r\nif (!status.isFahrenheit) {\r\n  const ftoc = function (temp) {\r\n    if (typeof temp === \"undefined\" || temp === 960) {\r\n      return temp;\r\n    }\r\n    return Math.floor((temp - 32) / 1.8);\r\n  };\r\n  status.p1Target = ftoc(status.p1Target);\r\n  status.p1Temp = ftoc(status.p1Temp);\r\n  status.p2Temp = ftoc(status.p2Temp);\r\n  status.p3Temp = ftoc(status.p3Temp);\r\n  status.p4Temp = ftoc(status.p4Temp);\r\n  status.grillSetTemp = ftoc(status.grillSetTemp);\r\n  status.grillTemp = ftoc(status.grillTemp);\r\n  status.smokerActTemp = ftoc(status.smokerActTemp);\r\n}*/\r\n\r\nreturn status;",
-      "temperature_function": "if (!message.startsWith(\"FE0C\")) {\r\n  //not a grill temperature messasge\r\n  return null;\r\n}\r\n\r\nconst parts = parseHexMessage(message);\r\nif (parts < 27) {\r\n  return null;\r\n}\r\n\r\nconst temps = {\r\n /* p1Target: convertTemperature(parts, 2),*/\r\n  p1Temp: convertTemperature(parts, 5),\r\n  p2Temp: convertTemperature(parts, 8),\r\n  p3Temp: convertTemperature(parts, 11),\r\n  p4Temp: convertTemperature(parts, 14),\r\n  grillSetTemp: convertTemperature(parts, 20),\r\n  grillTemp: convertTemperature(parts, 23),\r\n  smokerActTemp: convertTemperature(parts, 17),\r\n  isFahrenheit: parts[26] === 1,\r\n};\r\n\r\nif (!temps.isFahrenheit) {\r\n  const ftoc = function (temp) {\r\n    if (typeof temp === \"undefined\" || temp === 960) {\r\n      return temp;\r\n    }\r\n    return Math.floor((temp - 32) / 1.8);\r\n  };\r\n  temps.p1Temp = ftoc(temps.p1Temp);\r\n  temps.p2Temp = ftoc(temps.p2Temp);\r\n  temps.p3Temp = ftoc(temps.p3Temp);\r\n  temps.p4Temp = ftoc(temps.p4Temp);\r\n  temps.grillSetTemp = ftoc(temps.grillSetTemp);\r\n  temps.grillTemp = ftoc(temps.grillTemp);\r\n  temps.smokerActTemp = ftoc(temps.smokerActTemp);\r\n  temps.p1Target = ftoc(temps.p1Target);\r\n}\r\n\r\nreturn temps;",
-      "updated_at": "2025-09-17T20:50:32.000000Z"
+      "temperature_function": "if (!message.startsWith(\"FE0C\")) {\r\n  //not a grill temperature messasge\r\n  return null;\r\n}\r\n\r\nconst parts = parseHexMessage(message);\r\nif (parts < 27) {\r\n  return null;\r\n}\r\n\r\nconst temps = {\r\n /* p1Target: convertTemperature(parts, 2),*/\r\n  p1Temp: convertTemperature(parts, 5),\r\n  p2Temp: convertTemperature(parts, 8),\r\n  p3Temp: convertTemperature(parts, 11),\r\n  p4Temp: convertTemperature(parts, 14),\r\n  grillSetTemp: convertTemperature(parts, 20),\r\n  grillTemp: convertTemperature(parts, 23),\r\n  smokerActTemp: convertTemperature(parts, 17),\r\n  isFahrenheit: parts[26] === 1,\r\n};\r\n\r\nif (!temps.isFahrenheit) {\r\n  const ftoc = function (temp) {\r\n    if (typeof temp === \"undefined\" || temp === 960) {\r\n      return temp;\r\n    }\r\n    return Math.floor((temp - 32) / 1.8);\r\n  };\r\n  temps.p1Temp = ftoc(temps.p1Temp);\r\n  temps.p2Temp = ftoc(temps.p2Temp);\r\n  temps.p3Temp = ftoc(temps.p3Temp);\r\n  temps.p4Temp = ftoc(temps.p4Temp);\r\n  temps.grillSetTemp = ftoc(temps.grillSetTemp);\r\n  temps.grillTemp = ftoc(temps.grillTemp);\r\n  temps.smokerActTemp = ftoc(temps.smokerActTemp);\r\n  temps.p1Target = ftoc(temps.p1Target);\r\n}\r\n\r\nreturn temps;"
     },
     "PBV2": {
       "control_board_commands": [
         {
-          "control_board_id": 18,
-          "created_at": "2025-04-24T17:11:26.000000Z",
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0B01FF",
           "id": 176,
           "name": "Get Grill Status",
-          "slug": "get-status",
-          "updated_at": "2025-04-24T17:11:26.000000Z"
+          "slug": "get-status"
         },
         {
-          "control_board_id": 18,
-          "created_at": "2025-04-24T17:12:04.000000Z",
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0C01FF",
           "id": 177,
           "name": "Get Grill/Probes Temperatures",
-          "slug": "get-temperatures",
-          "updated_at": "2025-04-24T17:12:04.000000Z"
+          "slug": "get-temperatures"
         },
         {
-          "control_board_id": 18,
-          "created_at": "2025-04-24T17:13:49.000000Z",
-          "deleted_at": null,
           "description": null,
           "function": "let temp = arguments[1] === false ? Math.round(((arguments[0] * 1.8)+ 32)/5) * 5 : arguments[0]; let _hundreds = Math.floor(temp/100); let _tens = Math.floor((temp % 100) / 10); let _ones = Math.floor(temp % 10); return 'FE0501'+formatHex(_hundreds)+formatHex(_tens)+formatHex(_ones) + 'FF';",
           "hexadecimal": null,
           "id": 178,
           "name": "Set Grill Temperature",
-          "slug": "set-temperature",
-          "updated_at": "2025-04-24T17:13:49.000000Z"
+          "slug": "set-temperature"
         },
         {
-          "control_board_id": 18,
-          "created_at": "2025-04-24T17:14:44.000000Z",
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0102FF",
           "id": 179,
           "name": "Turn Grill Off",
-          "slug": "turn-off",
-          "updated_at": "2025-04-24T17:14:44.000000Z"
+          "slug": "turn-off"
         },
         {
-          "control_board_id": 18,
-          "created_at": "2025-04-24T17:15:24.000000Z",
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0902FF",
           "id": 180,
           "name": "Set Temperature to Celsius",
-          "slug": "set-celsius",
-          "updated_at": "2025-04-24T17:15:24.000000Z"
+          "slug": "set-celsius"
         },
         {
-          "control_board_id": 18,
-          "created_at": "2025-04-24T17:16:02.000000Z",
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0901FF",
           "id": 181,
           "name": "Set Temperature to Fahrenheit",
-          "slug": "set-fahrenheit",
-          "updated_at": "2025-04-24T17:16:02.000000Z"
+          "slug": "set-fahrenheit"
         }
       ],
-      "created_at": "2025-04-24T17:09:50.000000Z",
-      "deleted_at": null,
       "device_status_function": null,
       "id": 18,
       "name": "PBV2",
       "platform_id": 8,
       "site_id": 1,
       "status_function": "if (!message.startsWith(\"FE0B\")) {\r\n  //not a grill status messasge\r\n  return null;\r\n}\r\n\r\nconst parts = parseHexMessage(message);\r\nif (parts < 44) {\r\n  return null;\r\n}\r\nconst status = {\r\n  /*p1Target: convertTemperature(parts, 2),\r\n  p1Temp: convertTemperature(parts, 5),\r\n  p2Temp: convertTemperature(parts, 8),\r\n  p3Temp: convertTemperature(parts, 11),\r\n  p4Temp: convertTemperature(parts, 14),\r\n  smokerActTemp: convertTemperature(parts, 17), */\r\n  moduleIsOn: parts[24] === 1,\r\n  err1: parts[25] === 1,\r\n  err2: parts[26] === 1,\r\n  err3: parts[27] === 1,\r\n  highTempErr: parts[28] === 1,\r\n  fanErr: parts[29] === 1,\r\n  hotErr: parts[30] === 1,\r\n  motorErr: parts[31] === 1,\r\n  noPellets: parts[32] === 1,\r\n  erL: parts[33] === 1,\r\n  fanState: parts[34] === 1,\r\n  hotState: parts[35] === 1,\r\n  motorState: parts[36] === 1,\r\n  lightState: parts[37] === 1,\r\n  primeState: parts[38] === 1,\r\n // isFahrenheit: parts[39] === 1,\r\n  recipeStep: parts[40],\r\n  recipeTime: parts[41] * 3600 + parts[42] * 60 + parts[43],\r\n};\r\n/*\r\nswitch (parts[23]) {\r\n  case 1:\r\n    status.grillSetTemp = convertTemperature(parts, 20);\r\n    break;\r\n  case 2:\r\n    status.grillTemp = convertTemperature(parts, 20);\r\n    break;\r\n}\r\nif (!status.isFahrenheit) {\r\n  const ftoc = function (temp) {\r\n    if (typeof temp === \"undefined\" || temp === 960) {\r\n      return temp;\r\n    }\r\n    return Math.floor((temp - 32) / 1.8);\r\n  };\r\n  status.p1Target = ftoc(status.p1Target);\r\n  status.p1Temp = ftoc(status.p1Temp);\r\n  status.p2Temp = ftoc(status.p2Temp);\r\n  status.p3Temp = ftoc(status.p3Temp);\r\n  status.p4Temp = ftoc(status.p4Temp);\r\n  status.grillSetTemp = ftoc(status.grillSetTemp);\r\n  status.grillTemp = ftoc(status.grillTemp);\r\n  status.smokerActTemp = ftoc(status.smokerActTemp);\r\n}\r\n*/\r\nreturn status;",
-      "temperature_function": "if (!message.startsWith(\"FE0C\")) {\r\n  //not a grill temperature messasge\r\n  return null;\r\n}\r\n\r\nconst parts = parseHexMessage(message);\r\nif (parts < 27) {\r\n  return null;\r\n}\r\n\r\nconst temps = {\r\n /* p1Target: convertTemperature(parts, 2),*/\r\n  p1Temp: convertTemperature(parts, 5),\r\n  p2Temp: convertTemperature(parts, 8),\r\n  p3Temp: convertTemperature(parts, 11),\r\n  p4Temp: convertTemperature(parts, 14),\r\n  grillSetTemp: convertTemperature(parts, 20),\r\n  grillTemp: convertTemperature(parts, 23),\r\n  smokerActTemp: convertTemperature(parts, 17),\r\n  isFahrenheit: parts[26] === 1,\r\n};\r\n\r\nif (!temps.isFahrenheit) {\r\n  const ftoc = function (temp) {\r\n    if (typeof temp === \"undefined\" || temp === 960) {\r\n      return temp;\r\n    }\r\n    return Math.floor((temp - 32) / 1.8);\r\n  };\r\n  temps.p1Temp = ftoc(temps.p1Temp);\r\n  temps.p2Temp = ftoc(temps.p2Temp);\r\n  temps.p3Temp = ftoc(temps.p3Temp);\r\n  temps.p4Temp = ftoc(temps.p4Temp);\r\n  temps.grillSetTemp = ftoc(temps.grillSetTemp);\r\n  temps.grillTemp = ftoc(temps.grillTemp);\r\n  temps.smokerActTemp = ftoc(temps.smokerActTemp);\r\n  temps.p1Target = ftoc(temps.p1Target);\r\n}\r\n\r\nreturn temps;",
-      "updated_at": "2025-09-17T20:57:04.000000Z"
+      "temperature_function": "if (!message.startsWith(\"FE0C\")) {\r\n  //not a grill temperature messasge\r\n  return null;\r\n}\r\n\r\nconst parts = parseHexMessage(message);\r\nif (parts < 27) {\r\n  return null;\r\n}\r\n\r\nconst temps = {\r\n /* p1Target: convertTemperature(parts, 2),*/\r\n  p1Temp: convertTemperature(parts, 5),\r\n  p2Temp: convertTemperature(parts, 8),\r\n  p3Temp: convertTemperature(parts, 11),\r\n  p4Temp: convertTemperature(parts, 14),\r\n  grillSetTemp: convertTemperature(parts, 20),\r\n  grillTemp: convertTemperature(parts, 23),\r\n  smokerActTemp: convertTemperature(parts, 17),\r\n  isFahrenheit: parts[26] === 1,\r\n};\r\n\r\nif (!temps.isFahrenheit) {\r\n  const ftoc = function (temp) {\r\n    if (typeof temp === \"undefined\" || temp === 960) {\r\n      return temp;\r\n    }\r\n    return Math.floor((temp - 32) / 1.8);\r\n  };\r\n  temps.p1Temp = ftoc(temps.p1Temp);\r\n  temps.p2Temp = ftoc(temps.p2Temp);\r\n  temps.p3Temp = ftoc(temps.p3Temp);\r\n  temps.p4Temp = ftoc(temps.p4Temp);\r\n  temps.grillSetTemp = ftoc(temps.grillSetTemp);\r\n  temps.grillTemp = ftoc(temps.grillTemp);\r\n  temps.smokerActTemp = ftoc(temps.smokerActTemp);\r\n  temps.p1Target = ftoc(temps.p1Target);\r\n}\r\n\r\nreturn temps;"
     },
     "PBVA": {
       "control_board_commands": [
         {
-          "control_board_id": 19,
-          "created_at": "2025-05-12T21:42:11.000000Z",
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0B01FF",
           "id": 182,
           "name": "Get Grill Status",
-          "slug": "get-status",
-          "updated_at": "2025-05-12T21:42:11.000000Z"
+          "slug": "get-status"
         },
         {
-          "control_board_id": 19,
-          "created_at": "2025-05-12T21:43:01.000000Z",
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0C01FF",
           "id": 183,
           "name": "Get Grill/Probes Temperatures",
-          "slug": "get-temperatures",
-          "updated_at": "2025-05-12T21:43:01.000000Z"
+          "slug": "get-temperatures"
         },
         {
-          "control_board_id": 19,
-          "created_at": "2025-05-12T21:43:50.000000Z",
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0902FF",
           "id": 184,
           "name": "Set Temperature to Celsius",
-          "slug": "set-celsius",
-          "updated_at": "2025-05-12T21:43:50.000000Z"
+          "slug": "set-celsius"
         },
         {
-          "control_board_id": 19,
-          "created_at": "2025-05-12T21:45:49.000000Z",
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0901FF",
           "id": 185,
           "name": "Set Temperature to Fahrenheit",
-          "slug": "set-fahrenheit",
-          "updated_at": "2025-05-12T21:45:49.000000Z"
+          "slug": "set-fahrenheit"
         },
         {
-          "control_board_id": 19,
-          "created_at": "2025-05-12T21:47:18.000000Z",
-          "deleted_at": null,
           "description": null,
           "function": "let temp = arguments[0];\r\nconst cval = [40, 45, 50, 55, 60, 65, 70, 75, 80, 85, 90, 95, 100, 105, 110, 115, 120, 125, 130, 135, 140, 145, 150, 155, 160];\r\nconst fval = [100, 115, 125, 135, 145, 150, 160, 170, 180, 190, 195, 205, 215, 225, 235, 240, 250, 260, 270, 280, 285, 290, 300, 310, 320];\r\n\r\nif (arguments[1] === false) {\r\n\tconst i = cval.indexOf(temp);\r\n  if (i < 0) {\r\n\t\ttemp = temp * 1.8 + 32;\r\n  } else {\r\n\t\ttemp = fval[i];\r\n  }\r\n}\r\n\r\nlet _hundreds = Math.floor(temp/100); \r\nlet _tens = Math.floor((temp % 100) / 10); \r\nlet _ones = Math.floor(temp % 10); \r\nreturn 'FE0501'+formatHex(_hundreds)+formatHex(_tens)+formatHex(_ones) + 'FF';",
           "hexadecimal": null,
           "id": 186,
           "name": "Set Grill Temperature",
-          "slug": "set-temperature",
-          "updated_at": "2025-11-05T18:53:19.000000Z"
+          "slug": "set-temperature"
         },
         {
-          "control_board_id": 19,
-          "created_at": "2025-05-12T21:47:58.000000Z",
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0200FF",
           "id": 187,
           "name": "Turn Light Off",
-          "slug": "turn-light-off",
-          "updated_at": "2025-05-12T21:47:58.000000Z"
+          "slug": "turn-light-off"
         },
         {
-          "control_board_id": 19,
-          "created_at": "2025-05-12T21:48:33.000000Z",
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0201FF",
           "id": 188,
           "name": "Turn Light On",
-          "slug": "turn-light-on",
-          "updated_at": "2025-05-12T21:48:33.000000Z"
+          "slug": "turn-light-on"
         },
         {
-          "control_board_id": 19,
-          "created_at": "2025-05-12T21:49:12.000000Z",
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0102FF",
           "id": 189,
           "name": "Turn Grill Off",
-          "slug": "turn-off",
-          "updated_at": "2025-05-12T21:49:12.000000Z"
+          "slug": "turn-off"
         }
       ],
-      "created_at": "2025-05-12T21:39:48.000000Z",
-      "deleted_at": null,
       "device_status_function": null,
       "id": 19,
       "name": "PBVA",
       "platform_id": 8,
       "site_id": 1,
       "status_function": "if (!message.startsWith(\"FE0B\")) {\r\n  //not a grill status messasge\r\n  return null;\r\n}\r\n\r\nconst parts = parseHexMessage(message);\r\nif (parts < 44) {\r\n  return null;\r\n}\r\nconst status = {\r\n  /*p1Target: convertTemperature(parts, 2),\r\n  p1Temp: convertTemperature(parts, 5),\r\n  p2Temp: convertTemperature(parts, 8),\r\n  p3Temp: convertTemperature(parts, 11),\r\n  p4Temp: convertTemperature(parts, 14),\r\n  smokerActTemp: convertTemperature(parts, 17), */\r\n  moduleIsOn: parts[24] === 1,\r\n  err1: parts[25] === 1,\r\n  err2: parts[26] === 1,\r\n  err3: parts[27] === 1,\r\n  highTempErr: parts[28] === 1,\r\n  fanErr: parts[29] === 1,\r\n  hotErr: parts[30] === 1,\r\n  motorErr: parts[31] === 1,\r\n  noPellets: parts[32] === 1,\r\n  erL: parts[33] === 1,\r\n  fanState: parts[34] === 1,\r\n  hotState: parts[35] === 1,\r\n  motorState: parts[36] === 1,\r\n  lightState: parts[37] === 1,\r\n  primeState: parts[38] === 1,\r\n // isFahrenheit: parts[39] === 1,\r\n  recipeStep: parts[40],\r\n  recipeTime: parts[41] * 3600 + parts[42] * 60 + parts[43],\r\n};\r\n/*\r\nswitch (parts[23]) {\r\n  case 1:\r\n    status.grillSetTemp = convertTemperature(parts, 20);\r\n    break;\r\n  case 2:\r\n    status.grillTemp = convertTemperature(parts, 20);\r\n    break;\r\n}\r\nif (!status.isFahrenheit) {\r\n  const ftoc = function (temp) {\r\n    if (typeof temp === \"undefined\" || temp === 960) {\r\n      return temp;\r\n    }\r\n    return Math.floor((temp - 32) / 1.8);\r\n  };\r\n  status.p1Target = ftoc(status.p1Target);\r\n  status.p1Temp = ftoc(status.p1Temp);\r\n  status.p2Temp = ftoc(status.p2Temp);\r\n  status.p3Temp = ftoc(status.p3Temp);\r\n  status.p4Temp = ftoc(status.p4Temp);\r\n  status.grillSetTemp = ftoc(status.grillSetTemp);\r\n  status.grillTemp = ftoc(status.grillTemp);\r\n  status.smokerActTemp = ftoc(status.smokerActTemp);\r\n}\r\n*/\r\nreturn status;",
-      "temperature_function": "if (!message.startsWith(\"FE0C\")) {\r\n  //not a grill temperature messasge\r\n  return null;\r\n}\r\n\r\nconst parts = parseHexMessage(message);\r\nconsole.log('parts', parts, parts.length);\r\nif (parts.length < 22) {\r\n  return null;\r\n}\r\n\r\nconst temps = {\r\n /* p1Target: convertTemperature(parts, 2),*/\r\n  p1Temp: convertTemperature(parts, 5),\r\n  p2Temp: convertTemperature(parts, 8),\r\n  p3Temp: convertTemperature(parts, 11),\r\n  p4Temp: convertTemperature(parts, 14),\r\n  grillSetTemp: convertTemperature(parts, 14),\r\n  grillTemp: convertTemperature(parts, 17),\r\n  //smokerActTemp: convertTemperature(parts, 17),\r\n  isFahrenheit: parts[20] === 1,\r\n};\r\nif (!temps.isFahrenheit) {\r\n  const ftoc = function (temp) {\r\n    if ((typeof temp === \"undefined\") || (temp === 960)) {\r\n      return temp;\r\n    }\r\n    return Math.floor((temp - 32) / 1.8);\r\n  };\r\n  \r\n  const ftocSet = function (temp) { \r\n\t\tconst cval = [40, 45, 50, 55, 60, 65, 70, 75, 80, 85, 90, 95, 100, 105, 110, 115, 120, 125, 130, 135, 140, 145, 150, 155, 160];\r\n  \tconst fval = [100, 115, 125, 135, 145, 150, 160, 170, 180, 190, 195, 205, 215, 225, 235, 240, 250, 260, 270, 280, 285, 290, 300, 310, 320];\r\n\t\tconst i = fval.indexOf(temp);\r\n  \tif (i < 0) {\r\n    \treturn ftoc(temp);\r\n  \t}\r\n  \treturn cval[i];\r\n  }\r\n  \r\n  temps.p1Temp = ftoc(temps.p1Temp);\r\n  temps.p2Temp = ftoc(temps.p2Temp);\r\n  temps.p3Temp = ftoc(temps.p3Temp);\r\n  temps.grillSetTemp = ftocSet(temps.grillSetTemp);\r\n  temps.grillTemp = ftoc(temps.grillTemp);\r\n  temps.p1Target =  ftoc(temps.p1Target);\r\n  temps.p2Target =  ftoc(temps.p2Target);\r\n}\r\n\r\nreturn temps;if (!message.startsWith(\"FE0C\")) {\r\n  //not a grill temperature messasge\r\n  return null;\r\n}\r\n\r\nconst parts = parseHexMessage(message);\r\nconsole.log('parts', parts, parts.length);\r\nif (parts.length < 22) {\r\n  return null;\r\n}\r\n\r\nconst temps = {\r\n /* p1Target: convertTemperature(parts, 2),*/\r\n  p1Temp: convertTemperature(parts, 5),\r\n  p2Temp: convertTemperature(parts, 8),\r\n  p3Temp: convertTemperature(parts, 11),\r\n  p4Temp: convertTemperature(parts, 14),\r\n  grillSetTemp: convertTemperature(parts, 14),\r\n  grillTemp: convertTemperature(parts, 17),\r\n  //smokerActTemp: convertTemperature(parts, 17),\r\n  isFahrenheit: parts[20] === 1,\r\n};\r\nif (!temps.isFahrenheit) {\r\n  const ftoc = function (temp) {\r\n    if ((typeof temp === \"undefined\") || (temp === 960)) {\r\n      return temp;\r\n    }\r\n    return Math.floor((temp - 32) / 1.8);\r\n  };\r\n  \r\n  const ftocSet = function (temp) { \r\n\t\tconst cval = [40, 45, 50, 55, 60, 65, 70, 75, 80, 85, 90, 95, 100, 105, 110, 115, 120, 125, 130, 135, 140, 145, 150, 155, 160];\r\n  \tconst fval = [100, 115, 125, 135, 145, 150, 160, 170, 180, 190, 195, 205, 215, 225, 235, 240, 250, 260, 270, 280, 285, 290, 300, 310, 320];\r\n\t\tconst i = fval.indexOf(temp);\r\n  \tif (i < 0) {\r\n    \treturn ftoc(temp);\r\n  \t}\r\n  \treturn cval[i];\r\n  }\r\n  \r\n  temps.p1Temp = ftoc(temps.p1Temp);\r\n  temps.p2Temp = ftoc(temps.p2Temp);\r\n  temps.p3Temp = ftoc(temps.p3Temp);\r\n  temps.grillSetTemp = ftocSet(temps.grillSetTemp);\r\n  temps.grillTemp = ftoc(temps.grillTemp);\r\n  temps.p1Target =  ftoc(temps.p1Target);\r\n  temps.p2Target =  ftoc(temps.p2Target);\r\n}\r\n\r\nreturn temps;",
-      "updated_at": "2025-11-05T18:52:49.000000Z"
+      "temperature_function": "if (!message.startsWith(\"FE0C\")) {\r\n  //not a grill temperature messasge\r\n  return null;\r\n}\r\n\r\nconst parts = parseHexMessage(message);\r\nconsole.log('parts', parts, parts.length);\r\nif (parts.length < 22) {\r\n  return null;\r\n}\r\n\r\nconst temps = {\r\n /* p1Target: convertTemperature(parts, 2),*/\r\n  p1Temp: convertTemperature(parts, 5),\r\n  p2Temp: convertTemperature(parts, 8),\r\n  p3Temp: convertTemperature(parts, 11),\r\n  p4Temp: convertTemperature(parts, 14),\r\n  grillSetTemp: convertTemperature(parts, 14),\r\n  grillTemp: convertTemperature(parts, 17),\r\n  //smokerActTemp: convertTemperature(parts, 17),\r\n  isFahrenheit: parts[20] === 1,\r\n};\r\nif (!temps.isFahrenheit) {\r\n  const ftoc = function (temp) {\r\n    if ((typeof temp === \"undefined\") || (temp === 960)) {\r\n      return temp;\r\n    }\r\n    return Math.floor((temp - 32) / 1.8);\r\n  };\r\n  \r\n  const ftocSet = function (temp) { \r\n\t\tconst cval = [40, 45, 50, 55, 60, 65, 70, 75, 80, 85, 90, 95, 100, 105, 110, 115, 120, 125, 130, 135, 140, 145, 150, 155, 160];\r\n  \tconst fval = [100, 115, 125, 135, 145, 150, 160, 170, 180, 190, 195, 205, 215, 225, 235, 240, 250, 260, 270, 280, 285, 290, 300, 310, 320];\r\n\t\tconst i = fval.indexOf(temp);\r\n  \tif (i < 0) {\r\n    \treturn ftoc(temp);\r\n  \t}\r\n  \treturn cval[i];\r\n  }\r\n  \r\n  temps.p1Temp = ftoc(temps.p1Temp);\r\n  temps.p2Temp = ftoc(temps.p2Temp);\r\n  temps.p3Temp = ftoc(temps.p3Temp);\r\n  temps.grillSetTemp = ftocSet(temps.grillSetTemp);\r\n  temps.grillTemp = ftoc(temps.grillTemp);\r\n  temps.p1Target =  ftoc(temps.p1Target);\r\n  temps.p2Target =  ftoc(temps.p2Target);\r\n}\r\n\r\nreturn temps;if (!message.startsWith(\"FE0C\")) {\r\n  //not a grill temperature messasge\r\n  return null;\r\n}\r\n\r\nconst parts = parseHexMessage(message);\r\nconsole.log('parts', parts, parts.length);\r\nif (parts.length < 22) {\r\n  return null;\r\n}\r\n\r\nconst temps = {\r\n /* p1Target: convertTemperature(parts, 2),*/\r\n  p1Temp: convertTemperature(parts, 5),\r\n  p2Temp: convertTemperature(parts, 8),\r\n  p3Temp: convertTemperature(parts, 11),\r\n  p4Temp: convertTemperature(parts, 14),\r\n  grillSetTemp: convertTemperature(parts, 14),\r\n  grillTemp: convertTemperature(parts, 17),\r\n  //smokerActTemp: convertTemperature(parts, 17),\r\n  isFahrenheit: parts[20] === 1,\r\n};\r\nif (!temps.isFahrenheit) {\r\n  const ftoc = function (temp) {\r\n    if ((typeof temp === \"undefined\") || (temp === 960)) {\r\n      return temp;\r\n    }\r\n    return Math.floor((temp - 32) / 1.8);\r\n  };\r\n  \r\n  const ftocSet = function (temp) { \r\n\t\tconst cval = [40, 45, 50, 55, 60, 65, 70, 75, 80, 85, 90, 95, 100, 105, 110, 115, 120, 125, 130, 135, 140, 145, 150, 155, 160];\r\n  \tconst fval = [100, 115, 125, 135, 145, 150, 160, 170, 180, 190, 195, 205, 215, 225, 235, 240, 250, 260, 270, 280, 285, 290, 300, 310, 320];\r\n\t\tconst i = fval.indexOf(temp);\r\n  \tif (i < 0) {\r\n    \treturn ftoc(temp);\r\n  \t}\r\n  \treturn cval[i];\r\n  }\r\n  \r\n  temps.p1Temp = ftoc(temps.p1Temp);\r\n  temps.p2Temp = ftoc(temps.p2Temp);\r\n  temps.p3Temp = ftoc(temps.p3Temp);\r\n  temps.grillSetTemp = ftocSet(temps.grillSetTemp);\r\n  temps.grillTemp = ftoc(temps.grillTemp);\r\n  temps.p1Target =  ftoc(temps.p1Target);\r\n  temps.p2Target =  ftoc(temps.p2Target);\r\n}\r\n\r\nreturn temps;"
     },
     "PBX1": {
       "control_board_commands": [
         {
-          "control_board_id": 14,
-          "created_at": "2023-09-21T18:53:14.000000Z",
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0902FF",
           "id": 139,
           "name": "Set Temperature to Celsius",
-          "slug": "set-celsius",
-          "updated_at": "2023-09-21T18:53:14.000000Z"
+          "slug": "set-celsius"
         },
         {
-          "control_board_id": 14,
-          "created_at": "2023-09-21T18:53:36.000000Z",
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0901FF",
           "id": 140,
           "name": "Set Temperature to Fahrenheit",
-          "slug": "set-fahrenheit",
-          "updated_at": "2023-09-21T18:53:36.000000Z"
+          "slug": "set-fahrenheit"
         },
         {
-          "control_board_id": 14,
-          "created_at": "2023-09-21T18:53:59.000000Z",
-          "deleted_at": null,
           "description": null,
           "function": "let temp = arguments[1] === false ? Math.round(((arguments[0] * 1.8)+ 32)/5) * 5 : arguments[0]; let _hundreds = Math.floor(temp/100); let _tens = Math.floor((temp % 100) / 10); let _ones = Math.floor(temp % 10); return 'FE0502'+formatHex(_hundreds)+formatHex(_tens)+formatHex(_ones) + 'FF';",
           "hexadecimal": null,
           "id": 141,
           "name": "Set Probe 1 Temperature",
-          "slug": "set-probe-1-temperature",
-          "updated_at": "2023-09-21T18:53:59.000000Z"
+          "slug": "set-probe-1-temperature"
         },
         {
-          "control_board_id": 14,
-          "created_at": "2023-09-21T18:54:21.000000Z",
-          "deleted_at": null,
           "description": null,
           "function": "let temp = arguments[1] === false ? Math.round(((arguments[0] * 1.8)+ 32)/5) * 5 : arguments[0]; let _hundreds = Math.floor(temp/100); let _tens = Math.floor((temp % 100) / 10); let _ones = Math.floor(temp % 10); return 'FE0501'+formatHex(_hundreds)+formatHex(_tens)+formatHex(_ones) + 'FF';",
           "hexadecimal": null,
           "id": 142,
           "name": "Set Grill Temperature",
-          "slug": "set-temperature",
-          "updated_at": "2023-09-21T18:54:21.000000Z"
+          "slug": "set-temperature"
         },
         {
-          "control_board_id": 14,
-          "created_at": "2023-09-21T18:54:38.000000Z",
-          "deleted_at": null,
           "description": null,
           "function": null,
           "hexadecimal": "FE0102FF",
           "id": 143,
           "name": "Turn Grill Off",
-          "slug": "turn-off",
-          "updated_at": "2023-09-21T18:54:38.000000Z"
+          "slug": "turn-off"
         },
         {
-          "control_board_id": 14,
-          "created_at": "2023-09-21T18:55:03.000000Z",
-          "deleted_at": null,
           "description": null,
           "function": "let temp = arguments[1] === false ? Math.round(((arguments[0] * 1.8)+ 32)/5) * 5 : arguments[0]; let _hundreds = Math.floor(temp/100); let _tens = Math.floor((temp % 100) / 10); let _ones = Math.floor(temp % 10); return 'FE0503'+formatHex(_hundreds)+formatHex(_tens)+formatHex(_ones) + 'FF';",
           "hexadecimal": null,
           "id": 144,
           "name": "Set Probe 2 Temperature",
-          "slug": "set-probe-2-temperature",
-          "updated_at": "2023-09-21T18:55:03.000000Z"
+          "slug": "set-probe-2-temperature"
         }
       ],
-      "created_at": "2023-09-21T18:52:45.000000Z",
-      "deleted_at": null,
       "device_status_function": null,
       "id": 14,
       "name": "PBX1",
       "platform_id": 4,
       "site_id": 1,
       "status_function": "if (!message.startsWith(\"FE1A\")) {\r\n  return null;\r\n}\r\nconst parts = parseHexMessage(message);\r\nif (parts.length < 16) {\r\n  return null;\r\n}\r\n\r\nconst decodeTemp = (data, pos) => { \r\n  const encoded = data[pos] << 7 | (data[pos+1] & 0x7f);\r\n  if (encoded == 0) {\r\n   \treturn undefined;\r\n\t}\r\n\treturn encoded - 8192;\r\n}\r\n\r\nconst status = {\r\n grillTemp: decodeTemp(parts, 2),\r\ngrillSetTemp: decodeTemp(parts, 4),\r\n  p1Target: decodeTemp(parts, 8),\r\n  p2Target: decodeTemp(parts, 12),\r\n  p1Temp: decodeTemp(parts, 6),\r\n  p2Temp: decodeTemp(parts, 10),\r\n  moduleIsOn: (parts[15] & 0x10) !== 0, \r\n  err1: false,\r\n  err2: false,\r\n  err3: false,\r\n  highTempErr: (parts[14] & 0x40) !== 0,\r\n  fanErr: (parts[14] & 0x01) !== 0,\r\n  hotErr: (parts[14] & 0x04) !== 0,\r\n  motorErr: (parts[14] & 0x02) !== 0,\r\n  noPellets: (parts[14] & 0x20) !== 0,\r\n  erL: (parts[14] & 0x08) !== 0,\r\n  fanState: (parts[15] & 0x01) !== 0,\r\n  hotState: (parts[15] & 0x04) !== 0,\r\n  motorState: (parts[15] & 0x02) !== 0,\r\n  lightState: false,\r\n  primeState: false,\r\n  isFahrenheit: (parts[15] & 0x08) === 0,\r\n  recipeStep: 0,\r\n  recipeTime: 0,\r\n};\r\nif (!status.isFahrenheit) {\r\n  const ftoc = function (temp) {\r\n    if ((typeof temp === \"undefined\") || (temp === 960)) {\r\n      return temp;\r\n    }\r\n    return Math.floor((temp - 32) / 1.8);\r\n  };\r\n  status.p1Temp = ftoc(status.p1Temp);\r\n  status.p2Temp = ftoc(status.p2Temp);\r\n  status.p3Temp = ftoc(status.p3Temp);\r\n  status.grillSetTemp = ftoc(status.grillSetTemp);\r\n  status.grillTemp = ftoc(status.grillTemp);\r\n  status.p1Target =  ftoc(status.p1Target);\r\n  status.p2Target =  ftoc(status.p2Target);\r\n}\r\n\r\nreturn status;",
-      "temperature_function": "if (!message.startsWith(\"FE1A\")) {\r\n  return null;\r\n}\r\nconst parts = parseHexMessage(message);\r\nif (parts.length < 16) {\r\n  return null;\r\n}\r\n\r\nconst decodeTemp = (data, pos) => { \r\n  const encoded = data[pos] << 7 | (data[pos+1] & 0x7f);\r\n  if (encoded == 0) {\r\n   \treturn undefined;\r\n\t}\r\n\treturn encoded - 8192;\r\n}\r\n\r\nconst status = {\r\n grillTemp: decodeTemp(parts, 2),\r\ngrillSetTemp: decodeTemp(parts, 4),\r\np1Target: decodeTemp(parts, 8),\r\n  p2Target: decodeTemp(parts, 12),\r\n  p1Temp: decodeTemp(parts, 6),\r\n  p2Temp: decodeTemp(parts, 10),\r\n  isFahrenheit: (parts[15] & 0x08) === 0,\r\n};\r\nif (!status.isFahrenheit) {\r\n  const ftoc = function (temp) {\r\n    if ((typeof temp === \"undefined\") || (temp === 960)) {\r\n      return temp;\r\n    }\r\n    return Math.floor((temp - 32) / 1.8);\r\n  };\r\n  status.p1Temp = ftoc(status.p1Temp);\r\n  status.p2Temp = ftoc(status.p2Temp);\r\n  status.p3Temp = ftoc(status.p3Temp);\r\n  status.grillSetTemp = ftoc(status.grillSetTemp);\r\n  status.grillTemp = ftoc(status.grillTemp);\r\n  status.p1Target =  ftoc(status.p1Target);\r\n  status.p2Target =  ftoc(status.p2Target);\r\n}\r\n\r\nreturn status;",
-      "updated_at": "2024-05-09T17:51:19.000000Z"
+      "temperature_function": "if (!message.startsWith(\"FE1A\")) {\r\n  return null;\r\n}\r\nconst parts = parseHexMessage(message);\r\nif (parts.length < 16) {\r\n  return null;\r\n}\r\n\r\nconst decodeTemp = (data, pos) => { \r\n  const encoded = data[pos] << 7 | (data[pos+1] & 0x7f);\r\n  if (encoded == 0) {\r\n   \treturn undefined;\r\n\t}\r\n\treturn encoded - 8192;\r\n}\r\n\r\nconst status = {\r\n grillTemp: decodeTemp(parts, 2),\r\ngrillSetTemp: decodeTemp(parts, 4),\r\np1Target: decodeTemp(parts, 8),\r\n  p2Target: decodeTemp(parts, 12),\r\n  p1Temp: decodeTemp(parts, 6),\r\n  p2Temp: decodeTemp(parts, 10),\r\n  isFahrenheit: (parts[15] & 0x08) === 0,\r\n};\r\nif (!status.isFahrenheit) {\r\n  const ftoc = function (temp) {\r\n    if ((typeof temp === \"undefined\") || (temp === 960)) {\r\n      return temp;\r\n    }\r\n    return Math.floor((temp - 32) / 1.8);\r\n  };\r\n  status.p1Temp = ftoc(status.p1Temp);\r\n  status.p2Temp = ftoc(status.p2Temp);\r\n  status.p3Temp = ftoc(status.p3Temp);\r\n  status.grillSetTemp = ftoc(status.grillSetTemp);\r\n  status.grillTemp = ftoc(status.grillTemp);\r\n  status.p1Target =  ftoc(status.p1Target);\r\n  status.p2Target =  ftoc(status.p2Target);\r\n}\r\n\r\nreturn status;"
     }
   },
   "grills": {
     "LG0800BL": {
-      "app_layout": "standard",
       "category": null,
       "celsius_temp_increment": null,
       "control_board": "LBL",
       "control_board_id": 8,
-      "created_at": "2022-12-06T22:49:00.000000Z",
-      "deleted_at": null,
       "description": null,
       "enabled": true,
       "friendly_name": "",
@@ -2618,7 +1783,6 @@
       "image": null,
       "image_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/LG0800BL.png",
       "lights": 0,
-      "manual_url": "https://dansons-users-manuals.s3.us-west-2.amazonaws.com/louisiana-grills/Black%20Label%20Series/LG0800BL_LG1000BL_LG1200BL_OwnersManual_110V_EN_FR_ES.PDF",
       "max_temp": "600",
       "meat_probes": 2,
       "min_temp": "180",
@@ -2630,17 +1794,13 @@
       "shopify_product_id": null,
       "site_id": 2,
       "sku": null,
-      "temp_increment": "180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420/425/430/435/440/445/450/455/460/465/470/475/480/485/490/495/500/505/510/515/520/525/530/535/540/545/550/555/560/565/570/575/580/585/590/595/600",
-      "updated_at": "2024-08-12T22:57:50.000000Z"
+      "temp_increment": "180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420/425/430/435/440/445/450/455/460/465/470/475/480/485/490/495/500/505/510/515/520/525/530/535/540/545/550/555/560/565/570/575/580/585/590/595/600"
     },
     "LG1000BL": {
-      "app_layout": "standard",
       "category": null,
       "celsius_temp_increment": null,
       "control_board": "LBL",
       "control_board_id": 8,
-      "created_at": "2022-12-06T15:52:22.000000Z",
-      "deleted_at": null,
       "description": null,
       "enabled": true,
       "friendly_name": "",
@@ -2653,7 +1813,6 @@
       "image": null,
       "image_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/LG1000BL.png",
       "lights": 0,
-      "manual_url": "https://dansons-users-manuals.s3.us-west-2.amazonaws.com/louisiana-grills/Black%20Label%20Series/LG0800BL_LG1000BL_LG1200BL_OwnersManual_110V_EN_FR_ES.PDF",
       "max_temp": "600",
       "meat_probes": 2,
       "min_temp": "180",
@@ -2665,17 +1824,13 @@
       "shopify_product_id": null,
       "site_id": 2,
       "sku": null,
-      "temp_increment": "180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420/425/430/435/440/445/450/455/460/465/470/475/480/485/490/495/500/505/510/515/520/525/530/535/540/545/550/555/560/565/570/575/580/585/590/595/600",
-      "updated_at": "2024-08-12T22:59:26.000000Z"
+      "temp_increment": "180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420/425/430/435/440/445/450/455/460/465/470/475/480/485/490/495/500/505/510/515/520/525/530/535/540/545/550/555/560/565/570/575/580/585/590/595/600"
     },
     "LG1200BL": {
-      "app_layout": "standard",
       "category": null,
       "celsius_temp_increment": null,
       "control_board": "LBL",
       "control_board_id": 8,
-      "created_at": "2022-12-06T15:52:22.000000Z",
-      "deleted_at": null,
       "description": null,
       "enabled": true,
       "friendly_name": "",
@@ -2688,7 +1843,6 @@
       "image": null,
       "image_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/LG1200BL.png",
       "lights": 0,
-      "manual_url": "https://dansons-users-manuals.s3.us-west-2.amazonaws.com/louisiana-grills/Black%20Label%20Series/LG0800BL_LG1000BL_LG1200BL_OwnersManual_110V_EN_FR_ES.PDF",
       "max_temp": "600",
       "meat_probes": 2,
       "min_temp": "180",
@@ -2700,17 +1854,13 @@
       "shopify_product_id": null,
       "site_id": 2,
       "sku": null,
-      "temp_increment": "180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420/425/430/435/440/445/450/455/460/465/470/475/480/485/490/495/500/505/510/515/520/525/530/535/540/545/550/555/560/565/570/575/580/585/590/595/600",
-      "updated_at": "2024-08-12T22:59:44.000000Z"
+      "temp_increment": "180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420/425/430/435/440/445/450/455/460/465/470/475/480/485/490/495/500/505/510/515/520/525/530/535/540/545/550/555/560/565/570/575/580/585/590/595/600"
     },
     "LG1200FL": {
-      "app_layout": "standard",
       "category": null,
       "celsius_temp_increment": null,
       "control_board": "LFS",
       "control_board_id": 9,
-      "created_at": "2022-12-06T15:52:22.000000Z",
-      "deleted_at": null,
       "description": null,
       "enabled": true,
       "friendly_name": "",
@@ -2723,7 +1873,6 @@
       "image": null,
       "image_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/LG1200FL.png",
       "lights": 1,
-      "manual_url": "https://dansons-users-manuals.s3.us-west-2.amazonaws.com/louisiana-grills/Founders%20Series/LG800FL_LG1200FL_OwnersManual_110V_EN_FR_ES.pdf",
       "max_temp": "600",
       "meat_probes": 4,
       "min_temp": "180",
@@ -2735,17 +1884,13 @@
       "shopify_product_id": null,
       "site_id": 2,
       "sku": null,
-      "temp_increment": "180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420/425/430/435/440/445/450/455/460/465/470/475/480/485/490/495/500/505/510/515/520/525/530/535/540/545/550/555/560/565/570/575/580/585/590/595/600",
-      "updated_at": "2024-08-12T23:01:39.000000Z"
+      "temp_increment": "180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420/425/430/435/440/445/450/455/460/465/470/475/480/485/490/495/500/505/510/515/520/525/530/535/540/545/550/555/560/565/570/575/580/585/590/595/600"
     },
     "LG1200FP": {
-      "app_layout": "standard",
       "category": null,
       "celsius_temp_increment": null,
       "control_board": "LFS",
       "control_board_id": 9,
-      "created_at": "2022-12-06T15:52:22.000000Z",
-      "deleted_at": null,
       "description": null,
       "enabled": true,
       "friendly_name": "",
@@ -2758,7 +1903,6 @@
       "image": null,
       "image_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/LG1200FP.png",
       "lights": 0,
-      "manual_url": "https://dansons-users-manuals.s3.us-west-2.amazonaws.com/louisiana-grills/Founders%20Series/LG800FP_LG1200FP_OwnersManual_110V_EN_FR_ES.pdf",
       "max_temp": "600",
       "meat_probes": 4,
       "min_temp": "180",
@@ -2770,17 +1914,13 @@
       "shopify_product_id": null,
       "site_id": 2,
       "sku": null,
-      "temp_increment": "180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420/425/430/435/440/445/450/455/460/465/470/475/480/485/490/495/500/505/510/515/520/525/530/535/540/545/550/555/560/565/570/575/580/585/590/595/600",
-      "updated_at": "2024-08-12T23:03:24.000000Z"
+      "temp_increment": "180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420/425/430/435/440/445/450/455/460/465/470/475/480/485/490/495/500/505/510/515/520/525/530/535/540/545/550/555/560/565/570/575/580/585/590/595/600"
     },
     "LG300BL": {
-      "app_layout": "standard",
       "category": null,
       "celsius_temp_increment": null,
       "control_board": "LBL",
       "control_board_id": 8,
-      "created_at": "2022-12-06T15:52:22.000000Z",
-      "deleted_at": null,
       "description": null,
       "enabled": true,
       "friendly_name": "",
@@ -2793,7 +1933,6 @@
       "image": null,
       "image_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/LG300BL.png",
       "lights": 0,
-      "manual_url": "https://dansons-users-manuals.s3.us-west-2.amazonaws.com/louisiana-grills/Black%20Label%20Series/10838_10850_LG300BL_OwnersManual_110V_EN_FR_ES.pdf",
       "max_temp": "500",
       "meat_probes": 2,
       "min_temp": "180",
@@ -2805,17 +1944,13 @@
       "shopify_product_id": null,
       "site_id": 2,
       "sku": null,
-      "temp_increment": "150/155/160/165/170/175/180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420/425/430/435/440/445/450/455/460/465/470/475/480/485/490/495/500",
-      "updated_at": "2024-08-12T22:59:56.000000Z"
+      "temp_increment": "150/155/160/165/170/175/180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420/425/430/435/440/445/450/455/460/465/470/475/480/485/490/495/500"
     },
     "LG800FL": {
-      "app_layout": "standard",
       "category": null,
       "celsius_temp_increment": null,
       "control_board": "LFS",
       "control_board_id": 9,
-      "created_at": "2022-12-06T15:52:22.000000Z",
-      "deleted_at": null,
       "description": null,
       "enabled": true,
       "friendly_name": "",
@@ -2828,7 +1963,6 @@
       "image": null,
       "image_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/LG800FL.png",
       "lights": 1,
-      "manual_url": "https://dansons-users-manuals.s3.us-west-2.amazonaws.com/louisiana-grills/Founders%20Series/LG800FL_LG1200FL_OwnersManual_110V_EN_FR_ES.pdf",
       "max_temp": "600",
       "meat_probes": 4,
       "min_temp": "180",
@@ -2840,17 +1974,13 @@
       "shopify_product_id": null,
       "site_id": 2,
       "sku": null,
-      "temp_increment": "180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420/425/430/435/440/445/450/455/460/465/470/475/480/485/490/495/500/505/510/515/520/525/530/535/540/545/550/555/560/565/570/575/580/585/590/595/600",
-      "updated_at": "2024-08-12T23:01:14.000000Z"
+      "temp_increment": "180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420/425/430/435/440/445/450/455/460/465/470/475/480/485/490/495/500/505/510/515/520/525/530/535/540/545/550/555/560/565/570/575/580/585/590/595/600"
     },
     "LG800FP": {
-      "app_layout": "standard",
       "category": null,
       "celsius_temp_increment": null,
       "control_board": "LFS",
       "control_board_id": 9,
-      "created_at": "2022-12-06T15:52:22.000000Z",
-      "deleted_at": null,
       "description": null,
       "enabled": true,
       "friendly_name": "",
@@ -2863,7 +1993,6 @@
       "image": null,
       "image_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/LG800FP.png",
       "lights": 0,
-      "manual_url": "https://dansons-users-manuals.s3.us-west-2.amazonaws.com/louisiana-grills/Founders%20Series/LG800FP_LG1200FP_OwnersManual_110V_EN_FR_ES.pdf",
       "max_temp": "600",
       "meat_probes": 4,
       "min_temp": "180",
@@ -2875,17 +2004,13 @@
       "shopify_product_id": null,
       "site_id": 2,
       "sku": null,
-      "temp_increment": "180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420/425/430/435/440/445/450/455/460/465/470/475/480/485/490/495/500/505/510/515/520/525/530/535/540/545/550/555/560/565/570/575/580/585/590/595/600",
-      "updated_at": "2024-08-12T23:01:54.000000Z"
+      "temp_increment": "180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420/425/430/435/440/445/450/455/460/465/470/475/480/485/490/495/500/505/510/515/520/525/530/535/540/545/550/555/560/565/570/575/580/585/590/595/600"
     },
     "LGV4BL": {
-      "app_layout": "standard",
       "category": null,
       "celsius_temp_increment": null,
       "control_board": "LBL",
       "control_board_id": 8,
-      "created_at": "2022-12-06T15:52:22.000000Z",
-      "deleted_at": null,
       "description": null,
       "enabled": true,
       "friendly_name": "",
@@ -2898,7 +2023,6 @@
       "image": null,
       "image_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/LGV4BL.png",
       "lights": 0,
-      "manual_url": "https://dansons-users-manuals.s3.us-west-2.amazonaws.com/louisiana-grills/Black%20Label%20Series/10751_10800_LGV4BL_OwnersManual_110V_EN_FR_ES.pdf",
       "max_temp": "420",
       "meat_probes": 2,
       "min_temp": "130",
@@ -2910,17 +2034,13 @@
       "shopify_product_id": null,
       "site_id": 2,
       "sku": null,
-      "temp_increment": "130/135/140/145/150/155/160/165/170/175/180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420",
-      "updated_at": "2024-08-12T23:00:14.000000Z"
+      "temp_increment": "130/135/140/145/150/155/160/165/170/175/180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420"
     },
     "Lexington Wi-Fi Upgrade": {
-      "app_layout": "standard",
       "category": null,
       "celsius_temp_increment": null,
       "control_board": "PBM",
       "control_board_id": 6,
-      "created_at": "2023-06-13T15:09:01.000000Z",
-      "deleted_at": null,
       "description": null,
       "enabled": true,
       "friendly_name": "",
@@ -2933,7 +2053,6 @@
       "image": null,
       "image_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/ghost%20grill.png",
       "lights": 0,
-      "manual_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-manuals/Onyx/10985_PB500NX_owners_manual.pdf",
       "max_temp": "500",
       "meat_probes": 2,
       "min_temp": "180",
@@ -2945,17 +2064,13 @@
       "shopify_product_id": null,
       "site_id": 1,
       "sku": null,
-      "temp_increment": "180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420/425/430/435/440/445/450/455/460/465/470/475/480/485/490/495/500",
-      "updated_at": "2024-08-12T23:08:17.000000Z"
+      "temp_increment": "180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420/425/430/435/440/445/450/455/460/465/470/475/480/485/490/495/500"
     },
     "PB0500SP": {
-      "app_layout": "standard",
       "category": null,
       "celsius_temp_increment": null,
       "control_board": "PBC",
       "control_board_id": 5,
-      "created_at": "2022-07-13T04:29:24.000000Z",
-      "deleted_at": null,
       "description": null,
       "enabled": true,
       "friendly_name": "",
@@ -2968,7 +2083,6 @@
       "image": null,
       "image_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/500sp-109.png",
       "lights": 0,
-      "manual_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-manuals/Sportsman/PBSP_Owners_Manual_110V_EN_FR.pdf",
       "max_temp": "500",
       "meat_probes": 2,
       "min_temp": "180",
@@ -2980,17 +2094,13 @@
       "shopify_product_id": null,
       "site_id": 1,
       "sku": null,
-      "temp_increment": "180/200/225/250/300/350/400/450/475/500",
-      "updated_at": "2024-08-12T22:34:10.000000Z"
+      "temp_increment": "180/200/225/250/300/350/400/450/475/500"
     },
     "PB0820SP/SPW": {
-      "app_layout": "standard",
       "category": null,
       "celsius_temp_increment": null,
       "control_board": "PBC",
       "control_board_id": 5,
-      "created_at": "2022-07-13T04:29:24.000000Z",
-      "deleted_at": null,
       "description": null,
       "enabled": true,
       "friendly_name": "",
@@ -3003,7 +2113,6 @@
       "image": null,
       "image_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/PB820sp.png",
       "lights": 0,
-      "manual_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-manuals/Sportsman/PBSP_Owners_Manual_110V_EN_FR.pdf",
       "max_temp": "500",
       "meat_probes": 2,
       "min_temp": "180",
@@ -3015,17 +2124,13 @@
       "shopify_product_id": null,
       "site_id": 1,
       "sku": null,
-      "temp_increment": "180/200/225/250/300/350/400/450/475/500",
-      "updated_at": "2024-08-12T22:32:34.000000Z"
+      "temp_increment": "180/200/225/250/300/350/400/450/475/500"
     },
     "PB1000D3": {
-      "app_layout": "standard",
       "category": null,
       "celsius_temp_increment": null,
       "control_board": "PBC",
       "control_board_id": 5,
-      "created_at": "2024-09-10T20:26:48.000000Z",
-      "deleted_at": null,
       "description": null,
       "enabled": true,
       "friendly_name": null,
@@ -3038,7 +2143,6 @@
       "image": null,
       "image_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/ghost%20grill.png",
       "lights": 0,
-      "manual_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-manuals/Standard/11035_PB1000D3_owners_manual.pdf",
       "max_temp": "500",
       "meat_probes": 2,
       "min_temp": "180",
@@ -3050,17 +2154,13 @@
       "shopify_product_id": null,
       "site_id": 1,
       "sku": null,
-      "temp_increment": "180/200/225/250/300/350/400/450/475/500",
-      "updated_at": "2024-09-10T23:20:54.000000Z"
+      "temp_increment": "180/200/225/250/300/350/400/450/475/500"
     },
     "PB1000NC1": {
-      "app_layout": "standard",
       "category": null,
       "celsius_temp_increment": null,
       "control_board": "PBC",
       "control_board_id": 5,
-      "created_at": "2022-07-13T04:29:24.000000Z",
-      "deleted_at": null,
       "description": null,
       "enabled": true,
       "friendly_name": "",
@@ -3073,7 +2173,6 @@
       "image": null,
       "image_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/PB1000NC1.png",
       "lights": 0,
-      "manual_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-manuals/Nascar/10402_PBPEL100010402_manualUSA_EN_FR.pdf",
       "max_temp": "500",
       "meat_probes": 2,
       "min_temp": "180",
@@ -3085,17 +2184,13 @@
       "shopify_product_id": null,
       "site_id": 1,
       "sku": null,
-      "temp_increment": "180/200/225/250/300/350/400/450/475/500",
-      "updated_at": "2024-08-12T22:31:12.000000Z"
+      "temp_increment": "180/200/225/250/300/350/400/450/475/500"
     },
     "PB1000NXW": {
-      "app_layout": "standard",
       "category": null,
       "celsius_temp_increment": null,
       "control_board": "PBM",
       "control_board_id": 6,
-      "created_at": "2023-06-13T14:57:42.000000Z",
-      "deleted_at": null,
       "description": null,
       "enabled": true,
       "friendly_name": null,
@@ -3108,7 +2203,6 @@
       "image": null,
       "image_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/PB1000NX.png",
       "lights": 0,
-      "manual_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-manuals/Onyx/10986_PB1000NX_owners_manual.pdf",
       "max_temp": "500",
       "meat_probes": 2,
       "min_temp": "180",
@@ -3120,17 +2214,13 @@
       "shopify_product_id": null,
       "site_id": 1,
       "sku": null,
-      "temp_increment": "180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420/425/430/435/440/445/450/455/460/465/470/475/480/485/490/495/500",
-      "updated_at": "2024-09-13T16:56:31.000000Z"
+      "temp_increment": "180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420/425/430/435/440/445/450/455/460/465/470/475/480/485/490/495/500"
     },
     "PB1000PL": {
-      "app_layout": "standard",
       "category": "Wood Pellet",
       "celsius_temp_increment": null,
       "control_board": "PBG",
       "control_board_id": 3,
-      "created_at": "2022-07-13T04:29:24.000000Z",
-      "deleted_at": null,
       "description": null,
       "enabled": true,
       "friendly_name": "",
@@ -3143,7 +2233,6 @@
       "image": null,
       "image_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/LAREDO-1000-2020-3-18-103.png",
       "lights": 1,
-      "manual_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-manuals/Platinum-Series/10712_10880_PB1000PL_manual_110V_EN_FR_ES.pdf",
       "max_temp": "High",
       "meat_probes": 2,
       "min_temp": "Smoke",
@@ -3155,17 +2244,13 @@
       "shopify_product_id": "7019607294140",
       "site_id": 1,
       "sku": "10712",
-      "temp_increment": "180/200/225/250/275/300/325/350/375/400/425/450/500",
-      "updated_at": "2024-08-12T19:50:43.000000Z"
+      "temp_increment": "180/200/225/250/275/300/325/350/375/400/425/450/500"
     },
     "PB1000R1": {
-      "app_layout": "standard",
       "category": null,
       "celsius_temp_increment": null,
       "control_board": "PBV",
       "control_board_id": 4,
-      "created_at": "2022-07-13T04:29:24.000000Z",
-      "deleted_at": null,
       "description": null,
       "enabled": true,
       "friendly_name": "",
@@ -3178,7 +2263,6 @@
       "image": null,
       "image_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/PB1000R1.png",
       "lights": 0,
-      "manual_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-manuals/R-Series/72750_PB1000R1_manualUSA_EN.pdf",
       "max_temp": "500",
       "meat_probes": 3,
       "min_temp": "180",
@@ -3190,17 +2274,13 @@
       "shopify_product_id": null,
       "site_id": 1,
       "sku": null,
-      "temp_increment": "180/200/225/250/300/350/400/450/475/500",
-      "updated_at": "2024-08-12T22:21:29.000000Z"
+      "temp_increment": "180/200/225/250/300/350/400/450/475/500"
     },
     "PB1000R2": {
-      "app_layout": "standard",
       "category": null,
       "celsius_temp_increment": null,
       "control_board": "PBV",
       "control_board_id": 4,
-      "created_at": "2022-07-13T04:29:24.000000Z",
-      "deleted_at": null,
       "description": null,
       "enabled": true,
       "friendly_name": "",
@@ -3213,7 +2293,6 @@
       "image": null,
       "image_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/PB1000R2-2019-11-29-abby-112.png",
       "lights": 0,
-      "manual_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-manuals/R-Series/10540_10682_PB1000R2_manual_110V_EN_FR%20%281%29.pdf",
       "max_temp": "500",
       "meat_probes": 3,
       "min_temp": "180",
@@ -3225,17 +2304,13 @@
       "shopify_product_id": null,
       "site_id": 1,
       "sku": null,
-      "temp_increment": "180/200/225/250/300/350/400/450/475/500",
-      "updated_at": "2024-08-12T22:19:30.000000Z"
+      "temp_increment": "180/200/225/250/300/350/400/450/475/500"
     },
     "PB1000S1": {
-      "app_layout": "standard",
       "category": null,
       "celsius_temp_increment": null,
       "control_board": "PBV",
       "control_board_id": 4,
-      "created_at": "2022-07-13T04:29:24.000000Z",
-      "deleted_at": null,
       "description": null,
       "enabled": true,
       "friendly_name": "",
@@ -3248,7 +2323,6 @@
       "image": null,
       "image_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/PB1000S1.png",
       "lights": 0,
-      "manual_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-manuals/Standard/72710_PB1000S1_manual_110V_EN.pdf",
       "max_temp": "500",
       "meat_probes": 3,
       "min_temp": "180",
@@ -3260,17 +2334,13 @@
       "shopify_product_id": null,
       "site_id": 1,
       "sku": null,
-      "temp_increment": "180/200/225/250/300/350/400/450/475/500",
-      "updated_at": "2024-08-12T22:17:52.000000Z"
+      "temp_increment": "180/200/225/250/300/350/400/450/475/500"
     },
     "PB1000SC1": {
-      "app_layout": "standard",
       "category": null,
       "celsius_temp_increment": null,
       "control_board": "PBV",
       "control_board_id": 4,
-      "created_at": "2022-07-13T04:29:24.000000Z",
-      "deleted_at": null,
       "description": null,
       "enabled": true,
       "friendly_name": "",
@@ -3283,7 +2353,6 @@
       "image": null,
       "image_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/PB1000SC-2019-7-4-Abby-34.png",
       "lights": 0,
-      "manual_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-manuals/Standard/72751_PB1000SC1_manualUSA_EN.pdf",
       "max_temp": "500",
       "meat_probes": 3,
       "min_temp": "180",
@@ -3295,17 +2364,13 @@
       "shopify_product_id": null,
       "site_id": 1,
       "sku": null,
-      "temp_increment": "180/200/225/250/300/350/400/450/475/500",
-      "updated_at": "2024-08-12T22:18:46.000000Z"
+      "temp_increment": "180/200/225/250/300/350/400/450/475/500"
     },
     "PB1000SC2": {
-      "app_layout": "standard",
       "category": null,
       "celsius_temp_increment": null,
       "control_board": "PBC",
       "control_board_id": 5,
-      "created_at": "2022-07-13T04:29:24.000000Z",
-      "deleted_at": null,
       "description": null,
       "enabled": true,
       "friendly_name": "",
@@ -3318,7 +2383,6 @@
       "image": null,
       "image_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/pb1000sc2.png",
       "lights": 0,
-      "manual_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-manuals/Standard/72800_PB1000SC2_manual_110V_EN_FR.pdf",
       "max_temp": "500",
       "meat_probes": 2,
       "min_temp": "180",
@@ -3330,17 +2394,13 @@
       "shopify_product_id": null,
       "site_id": 1,
       "sku": null,
-      "temp_increment": "180/200/225/250/300/350/400/450/475/500",
-      "updated_at": "2024-08-12T22:31:32.000000Z"
+      "temp_increment": "180/200/225/250/300/350/400/450/475/500"
     },
     "PB1000SP": {
-      "app_layout": "standard",
       "category": null,
       "celsius_temp_increment": null,
       "control_board": "PBC",
       "control_board_id": 5,
-      "created_at": "2022-07-13T04:29:24.000000Z",
-      "deleted_at": null,
       "description": null,
       "enabled": true,
       "friendly_name": "",
@@ -3353,7 +2413,6 @@
       "image": null,
       "image_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/PB1000sp.png",
       "lights": 0,
-      "manual_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-manuals/Sportsman/PBSP_Owners_Manual_110V_EN_FR.pdf",
       "max_temp": "500",
       "meat_probes": 2,
       "min_temp": "180",
@@ -3365,17 +2424,13 @@
       "shopify_product_id": null,
       "site_id": 1,
       "sku": null,
-      "temp_increment": "180/200/225/250/300/350/400/450/475/500",
-      "updated_at": "2024-08-12T22:32:15.000000Z"
+      "temp_increment": "180/200/225/250/300/350/400/450/475/500"
     },
     "PB1000T1": {
-      "app_layout": "standard",
       "category": null,
       "celsius_temp_increment": null,
       "control_board": "PBV",
       "control_board_id": 4,
-      "created_at": "2022-07-13T04:29:24.000000Z",
-      "deleted_at": null,
       "description": null,
       "enabled": true,
       "friendly_name": "",
@@ -3388,7 +2443,6 @@
       "image": null,
       "image_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/PB1000T1-2019-7-4-abby-35.png",
       "lights": 0,
-      "manual_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-manuals/Standard/72755_PB1000T1_manual_USA_EN.pdf",
       "max_temp": "500",
       "meat_probes": 3,
       "min_temp": "180",
@@ -3400,17 +2454,13 @@
       "shopify_product_id": null,
       "site_id": 1,
       "sku": null,
-      "temp_increment": "180/200/225/250/300/350/400/450/475/500",
-      "updated_at": "2024-08-12T22:18:06.000000Z"
+      "temp_increment": "180/200/225/250/300/350/400/450/475/500"
     },
     "PB1000T2": {
-      "app_layout": "standard",
       "category": null,
       "celsius_temp_increment": null,
       "control_board": "PBV",
       "control_board_id": 4,
-      "created_at": "2022-07-13T04:29:24.000000Z",
-      "deleted_at": null,
       "description": null,
       "enabled": true,
       "friendly_name": "",
@@ -3423,7 +2473,6 @@
       "image": null,
       "image_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/PB1000T2-2018-11-28-abby-36.png",
       "lights": 0,
-      "manual_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-manuals/Traditional/72790_PB1000T2_manualUSA_EN.pdf",
       "max_temp": "500",
       "meat_probes": 3,
       "min_temp": "180",
@@ -3435,17 +2484,13 @@
       "shopify_product_id": null,
       "site_id": 1,
       "sku": null,
-      "temp_increment": "180/200/225/250/300/350/400/450/475/500",
-      "updated_at": "2024-08-12T22:20:41.000000Z"
+      "temp_increment": "180/200/225/250/300/350/400/450/475/500"
     },
     "PB1000T3": {
-      "app_layout": "standard",
       "category": null,
       "celsius_temp_increment": null,
       "control_board": "PBC",
       "control_board_id": 5,
-      "created_at": "2022-07-13T04:29:24.000000Z",
-      "deleted_at": null,
       "description": null,
       "enabled": true,
       "friendly_name": "",
@@ -3458,7 +2503,6 @@
       "image": null,
       "image_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/PB1000T3-117.png",
       "lights": 0,
-      "manual_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-manuals/Traditional/10522_PB1000T3_manual_110V_EN_FR_ES.pdf",
       "max_temp": "500",
       "meat_probes": 2,
       "min_temp": "180",
@@ -3470,17 +2514,13 @@
       "shopify_product_id": null,
       "site_id": 1,
       "sku": null,
-      "temp_increment": "180/200/225/250/300/350/400/450/475/500",
-      "updated_at": "2024-08-12T22:28:39.000000Z"
+      "temp_increment": "180/200/225/250/300/350/400/450/475/500"
     },
     "PB1000T4": {
-      "app_layout": "standard",
       "category": null,
       "celsius_temp_increment": null,
       "control_board": "PBC",
       "control_board_id": 5,
-      "created_at": "2022-07-13T04:29:24.000000Z",
-      "deleted_at": null,
       "description": null,
       "enabled": true,
       "friendly_name": "",
@@ -3493,7 +2533,6 @@
       "image": null,
       "image_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/PB1000t4-115.png",
       "lights": 0,
-      "manual_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-manuals/Traditional/10742_PB1000T4_manual_110V_EN_FR_ES.pdf",
       "max_temp": "500",
       "meat_probes": 2,
       "min_temp": "180",
@@ -3505,17 +2544,13 @@
       "shopify_product_id": null,
       "site_id": 1,
       "sku": null,
-      "temp_increment": "180/200/225/250/300/350/400/450/475/500",
-      "updated_at": "2024-08-12T22:31:59.000000Z"
+      "temp_increment": "180/200/225/250/300/350/400/450/475/500"
     },
     "PB1000XL/PB1000SC3": {
-      "app_layout": "standard",
       "category": null,
       "celsius_temp_increment": null,
       "control_board": "PBC",
       "control_board_id": 5,
-      "created_at": "2022-07-13T04:29:24.000000Z",
-      "deleted_at": null,
       "description": null,
       "enabled": true,
       "friendly_name": "",
@@ -3528,7 +2563,6 @@
       "image": null,
       "image_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/PB1000SC3-Front-101619.png",
       "lights": 0,
-      "manual_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-manuals/Standard/10550_PB1000XL_manual_110V_EN_FR.pdf",
       "max_temp": "500",
       "meat_probes": 2,
       "min_temp": "180",
@@ -3540,17 +2574,13 @@
       "shopify_product_id": null,
       "site_id": 1,
       "sku": null,
-      "temp_increment": "180/200/225/250/300/350/400/450/475/500",
-      "updated_at": "2024-08-12T22:25:32.000000Z"
+      "temp_increment": "180/200/225/250/300/350/400/450/475/500"
     },
     "PB1000XLW1 (Austin XL)": {
-      "app_layout": "standard",
       "category": null,
       "celsius_temp_increment": null,
       "control_board": "PBC",
       "control_board_id": 5,
-      "created_at": "2022-07-13T04:29:24.000000Z",
-      "deleted_at": null,
       "description": null,
       "enabled": true,
       "friendly_name": "",
@@ -3563,7 +2593,6 @@
       "image": null,
       "image_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/austin-xl.png",
       "lights": 0,
-      "manual_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-manuals/Copper/75953_PB1000XLW1_manual_110V_EN_FR.pdf",
       "max_temp": "500",
       "meat_probes": 2,
       "min_temp": "180",
@@ -3575,17 +2604,13 @@
       "shopify_product_id": null,
       "site_id": 1,
       "sku": null,
-      "temp_increment": "180/200/225/250/300/350/400/450/475/500",
-      "updated_at": "2024-08-12T22:41:01.000000Z"
+      "temp_increment": "180/200/225/250/300/350/400/450/475/500"
     },
     "PB1020CS2": {
-      "app_layout": "standard",
       "category": null,
       "celsius_temp_increment": null,
       "control_board": "PBM",
       "control_board_id": 6,
-      "created_at": "2025-04-29T22:52:55.000000Z",
-      "deleted_at": null,
       "description": null,
       "enabled": true,
       "friendly_name": null,
@@ -3598,7 +2623,6 @@
       "image": null,
       "image_url": "https://dansons-mobile.s3.dualstack.us-east-1.amazonaws.com/grill-images/PB1020CS2.1.png",
       "lights": 0,
-      "manual_url": "https://dansons-mobile.s3.dualstack.us-east-1.amazonaws.com/grill-manuals/Competition/11135_PB1020CS2_owners_manual.pdf",
       "max_temp": "500",
       "meat_probes": 2,
       "min_temp": "180",
@@ -3610,17 +2634,13 @@
       "shopify_product_id": null,
       "site_id": 1,
       "sku": null,
-      "temp_increment": "180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420/425/430/435/440/445/450/455/460/465/470/475/480/485/490/495/500",
-      "updated_at": "2025-04-29T22:52:55.000000Z"
+      "temp_increment": "180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420/425/430/435/440/445/450/455/460/465/470/475/480/485/490/495/500"
     },
     "PB1020DX": {
-      "app_layout": "standard",
       "category": null,
       "celsius_temp_increment": null,
       "control_board": "PBL3",
       "control_board_id": 21,
-      "created_at": "2025-09-17T16:51:42.000000Z",
-      "deleted_at": null,
       "description": null,
       "enabled": true,
       "friendly_name": null,
@@ -3633,7 +2653,6 @@
       "image": null,
       "image_url": "Https://dansons-mobile.s3.dualstack.us-east-1.amazonaws.com/grill-images/PB1020DX.png",
       "lights": 0,
-      "manual_url": "https://dansons-mobile.s3.dualstack.us-east-1.amazonaws.com/grill-manuals/DX-Series/11194_PB1020DX_owners_manual.pdf",
       "max_temp": "500",
       "meat_probes": 2,
       "min_temp": "180",
@@ -3645,17 +2664,13 @@
       "shopify_product_id": null,
       "site_id": 1,
       "sku": null,
-      "temp_increment": "180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420/425/430/435/440/445/450/455/460/465/470/475/480/485/490/495/500",
-      "updated_at": "2025-09-17T22:53:44.000000Z"
+      "temp_increment": "180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420/425/430/435/440/445/450/455/460/465/470/475/480/485/490/495/500"
     },
     "PB1020NXW": {
-      "app_layout": "standard",
       "category": null,
       "celsius_temp_increment": null,
       "control_board": "PBM",
       "control_board_id": 6,
-      "created_at": "2025-04-29T22:49:27.000000Z",
-      "deleted_at": null,
       "description": null,
       "enabled": true,
       "friendly_name": null,
@@ -3668,7 +2683,6 @@
       "image": null,
       "image_url": "https://dansons-mobile.s3.dualstack.us-east-1.amazonaws.com/grill-images/PB1020NX.png",
       "lights": 0,
-      "manual_url": "https://dansons-mobile.s3.dualstack.us-east-1.amazonaws.com/grill-manuals/Onyx/11042_PB1020NX_owners_manual.pdf",
       "max_temp": "500",
       "meat_probes": 2,
       "min_temp": "180",
@@ -3680,17 +2694,13 @@
       "shopify_product_id": null,
       "site_id": 1,
       "sku": null,
-      "temp_increment": "180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420/425/430/435/440/445/450/455/460/465/470/475/480/485/490/495/500",
-      "updated_at": "2025-04-29T22:49:27.000000Z"
+      "temp_increment": "180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420/425/430/435/440/445/450/455/460/465/470/475/480/485/490/495/500"
     },
     "PB1100HTC": {
-      "app_layout": "standard",
       "category": null,
       "celsius_temp_increment": null,
       "control_board": "PBE",
       "control_board_id": 15,
-      "created_at": "2024-11-14T21:56:38.000000Z",
-      "deleted_at": null,
       "description": null,
       "enabled": true,
       "friendly_name": null,
@@ -3703,7 +2713,6 @@
       "image": null,
       "image_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/PB1100HTC.M-Line%20Heritage.png",
       "lights": 0,
-      "manual_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-manuals/M-Line/11133_PB1100HTC_owners_manual.pdf",
       "max_temp": "500",
       "meat_probes": 2,
       "min_temp": "150",
@@ -3715,17 +2724,13 @@
       "shopify_product_id": null,
       "site_id": 1,
       "sku": null,
-      "temp_increment": "150/155/160/165/170/175/180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420/425/430/435/440/445/450/455/460/465/470/475/480/485/490/495/500",
-      "updated_at": "2024-11-14T21:56:38.000000Z"
+      "temp_increment": "150/155/160/165/170/175/180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420/425/430/435/440/445/450/455/460/465/470/475/480/485/490/495/500"
     },
     "PB1100PS1": {
-      "app_layout": "standard",
       "category": "WiFi Upgrade /Legacy H1",
       "celsius_temp_increment": null,
       "control_board": "PBC",
       "control_board_id": 5,
-      "created_at": "2022-07-13T04:29:24.000000Z",
-      "deleted_at": null,
       "description": null,
       "enabled": true,
       "friendly_name": "",
@@ -3738,7 +2743,6 @@
       "image": null,
       "image_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/1100ps.png",
       "lights": 0,
-      "manual_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-manuals/Pro-Series/72760_PB1100PS1_manualUSA_EN_FR_ES.pdf",
       "max_temp": "500",
       "meat_probes": 2,
       "min_temp": "180",
@@ -3750,17 +2754,13 @@
       "shopify_product_id": null,
       "site_id": 1,
       "sku": null,
-      "temp_increment": "180/200/225/250/300/350/400/450/475/500",
-      "updated_at": "2024-08-12T22:23:03.000000Z"
+      "temp_increment": "180/200/225/250/300/350/400/450/475/500"
     },
     "PB1100PSC1": {
-      "app_layout": "standard",
       "category": null,
       "celsius_temp_increment": null,
       "control_board": "PBC",
       "control_board_id": 5,
-      "created_at": "2022-07-13T04:29:24.000000Z",
-      "deleted_at": null,
       "description": null,
       "enabled": true,
       "friendly_name": "",
@@ -3773,7 +2773,6 @@
       "image": null,
       "image_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/PB1100PSC.png",
       "lights": 0,
-      "manual_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-manuals/Pro-Series/10002_PB1100PSC1_manualUSA_EN_FR_ES.pdf",
       "max_temp": "500",
       "meat_probes": 2,
       "min_temp": "180",
@@ -3785,17 +2784,13 @@
       "shopify_product_id": null,
       "site_id": 1,
       "sku": null,
-      "temp_increment": "180/200/225/250/300/350/400/450/475/500",
-      "updated_at": "2024-08-12T22:34:53.000000Z"
+      "temp_increment": "180/200/225/250/300/350/400/450/475/500"
     },
     "PB1100PSC2": {
-      "app_layout": "standard",
       "category": null,
       "celsius_temp_increment": null,
       "control_board": "PBL",
       "control_board_id": 1,
-      "created_at": "2022-07-13T04:29:24.000000Z",
-      "deleted_at": null,
       "description": null,
       "enabled": true,
       "friendly_name": "",
@@ -3808,7 +2803,6 @@
       "image": null,
       "image_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/PB1100PSC-126.png",
       "lights": 0,
-      "manual_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-manuals/Pro-Series/10738_10747_PB1100PSC2_manual_110V_EN_FR_ES.pdf",
       "max_temp": "500",
       "meat_probes": 2,
       "min_temp": "180",
@@ -3820,17 +2814,13 @@
       "shopify_product_id": null,
       "site_id": 1,
       "sku": null,
-      "temp_increment": "180/200/225/250/300/350/400/450/475/500",
-      "updated_at": "2024-08-12T20:24:49.000000Z"
+      "temp_increment": "180/200/225/250/300/350/400/450/475/500"
     },
     "PB1100PSC3": {
-      "app_layout": "standard",
       "category": null,
       "celsius_temp_increment": null,
       "control_board": "PBL",
       "control_board_id": 1,
-      "created_at": "2023-10-16T22:32:12.000000Z",
-      "deleted_at": null,
       "description": null,
       "enabled": true,
       "friendly_name": "",
@@ -3843,7 +2833,6 @@
       "image": null,
       "image_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/PB1100PSC3.png",
       "lights": 0,
-      "manual_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-manuals/Pro-Series/11044_PB1100PSC3_owners_manual.pdf",
       "max_temp": "500",
       "meat_probes": 2,
       "min_temp": "180",
@@ -3855,17 +2844,13 @@
       "shopify_product_id": null,
       "site_id": 1,
       "sku": null,
-      "temp_increment": "180/200/225/250/300/350/400/450/475/500",
-      "updated_at": "2024-08-12T23:12:55.000000Z"
+      "temp_increment": "180/200/225/250/300/350/400/450/475/500"
     },
     "PB1100SP/SPW": {
-      "app_layout": "standard",
       "category": null,
       "celsius_temp_increment": null,
       "control_board": "PBC",
       "control_board_id": 5,
-      "created_at": "2022-07-13T04:29:24.000000Z",
-      "deleted_at": null,
       "description": null,
       "enabled": true,
       "friendly_name": "",
@@ -3878,7 +2863,6 @@
       "image": null,
       "image_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/PB1100sp.png",
       "lights": 0,
-      "manual_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-manuals/Sportsman/PBSP_Owners_Manual_110V_EN_FR.pdf",
       "max_temp": "500",
       "meat_probes": 2,
       "min_temp": "180",
@@ -3890,17 +2874,13 @@
       "shopify_product_id": null,
       "site_id": 1,
       "sku": null,
-      "temp_increment": "180/200/225/250/300/350/400/450/475/500",
-      "updated_at": "2024-08-12T22:32:59.000000Z"
+      "temp_increment": "180/200/225/250/300/350/400/450/475/500"
     },
     "PB1100SPW2": {
-      "app_layout": "standard",
       "category": null,
       "celsius_temp_increment": null,
       "control_board": "PBC2",
       "control_board_id": 17,
-      "created_at": "2024-09-10T15:33:41.000000Z",
-      "deleted_at": null,
       "description": null,
       "enabled": true,
       "friendly_name": null,
@@ -3913,7 +2893,6 @@
       "image": null,
       "image_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/PB1100SPW2.png",
       "lights": 0,
-      "manual_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-manuals/Sportsman/11107_PB1100SPW2_owners_manual.pdf",
       "max_temp": "500",
       "meat_probes": 2,
       "min_temp": "180",
@@ -3925,17 +2904,13 @@
       "shopify_product_id": null,
       "site_id": 1,
       "sku": null,
-      "temp_increment": "180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420/425/430/435/440/445/450/455/460/465/470/475/480/485/490/495/500",
-      "updated_at": "2024-09-10T18:25:40.000000Z"
+      "temp_increment": "180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420/425/430/435/440/445/450/455/460/465/470/475/480/485/490/495/500"
     },
     "PB1150 PS3": {
-      "app_layout": "standard",
       "category": null,
       "celsius_temp_increment": null,
       "control_board": "PBT",
       "control_board_id": 7,
-      "created_at": "2023-02-01T16:44:09.000000Z",
-      "deleted_at": null,
       "description": null,
       "enabled": true,
       "friendly_name": "",
@@ -3948,7 +2923,6 @@
       "image": null,
       "image_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/PB1150PS3.png",
       "lights": 0,
-      "manual_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-manuals/Pro-Series/10980%2010983_PB1150PS3_manual_110V_EN_FR_ES.pdf",
       "max_temp": "500",
       "meat_probes": 2,
       "min_temp": "180",
@@ -3960,17 +2934,13 @@
       "shopify_product_id": null,
       "site_id": 1,
       "sku": null,
-      "temp_increment": "180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420/425/430/435/440/445/450/455/460/465/470/475/480/485/490/495/500",
-      "updated_at": "2024-08-12T23:18:50.000000Z"
+      "temp_increment": "180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420/425/430/435/440/445/450/455/460/465/470/475/480/485/490/495/500"
     },
     "PB1150DX": {
-      "app_layout": "standard",
       "category": null,
       "celsius_temp_increment": null,
       "control_board": "PBL3",
       "control_board_id": 21,
-      "created_at": "2025-07-17T19:32:19.000000Z",
-      "deleted_at": null,
       "description": null,
       "enabled": true,
       "friendly_name": null,
@@ -3983,7 +2953,6 @@
       "image": null,
       "image_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/PB1150DX.png",
       "lights": 0,
-      "manual_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-manuals/DX-Series/11078_11081_PB1150DX_owners_manual.pdf",
       "max_temp": "500",
       "meat_probes": 2,
       "min_temp": "180",
@@ -3995,17 +2964,13 @@
       "shopify_product_id": null,
       "site_id": 1,
       "sku": null,
-      "temp_increment": "180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420/425/430/435/440/445/450/455/460/465/470/475/480/485/490/495/500",
-      "updated_at": "2025-07-22T21:33:29.000000Z"
+      "temp_increment": "180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420/425/430/435/440/445/450/455/460/465/470/475/480/485/490/495/500"
     },
     "PB1150DX (PBL2)": {
-      "app_layout": "standard",
       "category": null,
       "celsius_temp_increment": null,
       "control_board": "PBL2",
       "control_board_id": 16,
-      "created_at": "2024-05-20T21:11:18.000000Z",
-      "deleted_at": null,
       "description": null,
       "enabled": true,
       "friendly_name": null,
@@ -4018,7 +2983,6 @@
       "image": null,
       "image_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/PB1150DX.png",
       "lights": 0,
-      "manual_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-manuals/DX-Series/11078_11081_PB1150DX_owners_manual.pdf",
       "max_temp": "500",
       "meat_probes": 2,
       "min_temp": "180",
@@ -4030,17 +2994,13 @@
       "shopify_product_id": null,
       "site_id": 1,
       "sku": null,
-      "temp_increment": "180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420/425/430/435/440/445/450/455/460/465/470/475/480/485/490/495/500",
-      "updated_at": "2024-08-14T21:44:47.000000Z"
+      "temp_increment": "180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420/425/430/435/440/445/450/455/460/465/470/475/480/485/490/495/500"
     },
     "PB1150G/GW": {
-      "app_layout": "standard",
       "category": null,
       "celsius_temp_increment": null,
       "control_board": "PBC",
       "control_board_id": 5,
-      "created_at": "2022-07-13T04:29:24.000000Z",
-      "deleted_at": null,
       "description": null,
       "enabled": true,
       "friendly_name": "",
@@ -4053,7 +3013,6 @@
       "image": null,
       "image_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/Nav-1150.png",
       "lights": 0,
-      "manual_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-manuals/Navigator/PB550G_PB700G_PB850G_PB1150G_OwnersManual_110V_EN_FR_ES.pdf",
       "max_temp": "500",
       "meat_probes": 2,
       "min_temp": "180",
@@ -4065,17 +3024,13 @@
       "shopify_product_id": null,
       "site_id": 1,
       "sku": null,
-      "temp_increment": "180/200/225/250/300/350/400/450/475/500",
-      "updated_at": "2024-08-12T22:33:27.000000Z"
+      "temp_increment": "180/200/225/250/300/350/400/450/475/500"
     },
     "PB1150PS2": {
-      "app_layout": "standard",
       "category": null,
       "celsius_temp_increment": null,
       "control_board": "PBL",
       "control_board_id": 1,
-      "created_at": "2022-07-13T04:29:24.000000Z",
-      "deleted_at": null,
       "description": null,
       "enabled": true,
       "friendly_name": "",
@@ -4088,7 +3043,6 @@
       "image": null,
       "image_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/PB1150PS2-2020-5-22-107.png",
       "lights": 0,
-      "manual_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-manuals/Pro-Series/10832_PB1150PS2_manual_230V_ML.pdf",
       "max_temp": "500",
       "meat_probes": 4,
       "min_temp": "180",
@@ -4100,17 +3054,13 @@
       "shopify_product_id": null,
       "site_id": 1,
       "sku": null,
-      "temp_increment": "180/190/200/210/220/230/240/250/260/270/280/290/300/325/350/375/400/450/500",
-      "updated_at": "2024-08-12T20:26:16.000000Z"
+      "temp_increment": "180/190/200/210/220/230/240/250/260/270/280/290/300/325/350/375/400/450/500"
     },
     "PB1150PS3": {
-      "app_layout": "standard",
       "category": null,
       "celsius_temp_increment": null,
       "control_board": "PBA",
       "control_board_id": 10,
-      "created_at": "2022-11-09T23:16:07.000000Z",
-      "deleted_at": null,
       "description": null,
       "enabled": true,
       "friendly_name": "",
@@ -4123,7 +3073,6 @@
       "image": null,
       "image_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/PB1150PS3.png",
       "lights": 0,
-      "manual_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-manuals/Pro-Series/10980%2010983_PB1150PS3_manual_110V_EN_FR_ES.pdf",
       "max_temp": "500",
       "meat_probes": 2,
       "min_temp": "180",
@@ -4135,17 +3084,13 @@
       "shopify_product_id": null,
       "site_id": 1,
       "sku": null,
-      "temp_increment": "180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420/425/430/435/440/445/450/455/460/465/470/475/480/485/490/495/500",
-      "updated_at": "2024-08-12T22:54:23.000000Z"
+      "temp_increment": "180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420/425/430/435/440/445/450/455/460/465/470/475/480/485/490/495/500"
     },
     "PB1230": {
-      "app_layout": "standard",
       "category": null,
       "celsius_temp_increment": null,
       "control_board": "PBC",
       "control_board_id": 5,
-      "created_at": "2022-07-13T04:29:24.000000Z",
-      "deleted_at": null,
       "description": null,
       "enabled": true,
       "friendly_name": "",
@@ -4158,7 +3103,6 @@
       "image": null,
       "image_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/pitboss-logo-transparent.png",
       "lights": 0,
-      "manual_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-manuals/Standard/10515_10694_PB1230_manual_110V_EN_FR.pdf",
       "max_temp": "500",
       "meat_probes": 2,
       "min_temp": "180",
@@ -4170,17 +3114,13 @@
       "shopify_product_id": null,
       "site_id": 1,
       "sku": null,
-      "temp_increment": "180/200/225/250/300/350/400/450/475/500",
-      "updated_at": "2024-08-12T22:34:39.000000Z"
+      "temp_increment": "180/200/225/250/300/350/400/450/475/500"
     },
     "PB1230CS1": {
-      "app_layout": "standard",
       "category": null,
       "celsius_temp_increment": null,
       "control_board": "PBM",
       "control_board_id": 6,
-      "created_at": "2022-07-13T04:29:24.000000Z",
-      "deleted_at": null,
       "description": null,
       "enabled": true,
       "friendly_name": "",
@@ -4193,7 +3133,6 @@
       "image": null,
       "image_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/PB1230CS1-2021-9-17-tank-with-cover116.png",
       "lights": 0,
-      "manual_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-manuals/Competition/10923_PB1230CS1_OwnersManual_110V_EN_FR_ES.pdf",
       "max_temp": "500",
       "meat_probes": 2,
       "min_temp": "180",
@@ -4205,17 +3144,13 @@
       "shopify_product_id": null,
       "site_id": 1,
       "sku": null,
-      "temp_increment": "180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420/425/430/435/440/445/450/455/460/465/470/475/480/485/490/495/500",
-      "updated_at": "2024-08-12T22:52:28.000000Z"
+      "temp_increment": "180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420/425/430/435/440/445/450/455/460/465/470/475/480/485/490/495/500"
     },
     "PB1230G/GW": {
-      "app_layout": "standard",
       "category": null,
       "celsius_temp_increment": null,
       "control_board": "PBC",
       "control_board_id": 5,
-      "created_at": "2022-07-13T04:29:24.000000Z",
-      "deleted_at": null,
       "description": null,
       "enabled": true,
       "friendly_name": "",
@@ -4228,7 +3163,6 @@
       "image": null,
       "image_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/PB1230G-2019-10-21-109.png",
       "lights": 0,
-      "manual_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-manuals/Navigator/10618_PB1230G_Owners%20Manual_230V_ML.pdf",
       "max_temp": "500",
       "meat_probes": 2,
       "min_temp": "180",
@@ -4240,17 +3174,13 @@
       "shopify_product_id": null,
       "site_id": 1,
       "sku": null,
-      "temp_increment": "180/200/225/250/300/350/400/450/475/500",
-      "updated_at": "2024-08-12T22:35:29.000000Z"
+      "temp_increment": "180/200/225/250/300/350/400/450/475/500"
     },
     "PB1230SP/SPW": {
-      "app_layout": "standard",
       "category": null,
       "celsius_temp_increment": null,
       "control_board": "PBC",
       "control_board_id": 5,
-      "created_at": "2022-07-13T04:29:24.000000Z",
-      "deleted_at": null,
       "description": null,
       "enabled": true,
       "friendly_name": "",
@@ -4263,7 +3193,6 @@
       "image": null,
       "image_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/PB1230sp-112.png",
       "lights": 0,
-      "manual_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-manuals/Sportsman/10568_10533_PB1230SP_Owners_Manual_110V_EN_FR.pdf",
       "max_temp": "500",
       "meat_probes": 2,
       "min_temp": "180",
@@ -4275,17 +3204,13 @@
       "shopify_product_id": null,
       "site_id": 1,
       "sku": null,
-      "temp_increment": "180/200/225/250/300/350/400/450/475/500",
-      "updated_at": "2024-08-12T22:34:28.000000Z"
+      "temp_increment": "180/200/225/250/300/350/400/450/475/500"
     },
     "PB1250 CS2": {
-      "app_layout": "standard",
       "category": null,
       "celsius_temp_increment": null,
       "control_board": "PBT",
       "control_board_id": 7,
-      "created_at": "2025-03-17T22:28:05.000000Z",
-      "deleted_at": null,
       "description": null,
       "enabled": true,
       "friendly_name": null,
@@ -4298,7 +3223,6 @@
       "image": null,
       "image_url": "https://dansons-mobile.s3.dualstack.us-east-1.amazonaws.com/grill-images/PB1250CS2.2.png",
       "lights": 0,
-      "manual_url": "https://dansons-mobile.s3.dualstack.us-east-1.amazonaws.com/grill-manuals/Competition/11131_PB1250CS2_owners_manual_bleed_20240930.pdf",
       "max_temp": "500",
       "meat_probes": 2,
       "min_temp": "180",
@@ -4310,17 +3234,13 @@
       "shopify_product_id": null,
       "site_id": 1,
       "sku": null,
-      "temp_increment": "180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420/425/430/435/440/445/450/455/460/465/470/475/480/485/490/495/500",
-      "updated_at": "2025-03-17T22:28:05.000000Z"
+      "temp_increment": "180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420/425/430/435/440/445/450/455/460/465/470/475/480/485/490/495/500"
     },
     "PB1250 NX": {
-      "app_layout": "standard",
       "category": null,
       "celsius_temp_increment": null,
       "control_board": "PBT",
       "control_board_id": 7,
-      "created_at": "2025-03-17T22:26:24.000000Z",
-      "deleted_at": null,
       "description": null,
       "enabled": true,
       "friendly_name": null,
@@ -4333,7 +3253,6 @@
       "image": null,
       "image_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/PB1250NX.png",
       "lights": 0,
-      "manual_url": null,
       "max_temp": "500",
       "meat_probes": 2,
       "min_temp": "180",
@@ -4345,17 +3264,13 @@
       "shopify_product_id": null,
       "site_id": 1,
       "sku": null,
-      "temp_increment": "180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420/425/430/435/440/445/450/455/460/465/470/475/480/485/490/495/500",
-      "updated_at": "2025-03-17T22:26:24.000000Z"
+      "temp_increment": "180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420/425/430/435/440/445/450/455/460/465/470/475/480/485/490/495/500"
     },
     "PB1250 PL": {
-      "app_layout": "standard",
       "category": null,
       "celsius_temp_increment": null,
       "control_board": "PBT",
       "control_board_id": 7,
-      "created_at": "2025-03-27T18:59:55.000000Z",
-      "deleted_at": null,
       "description": null,
       "enabled": true,
       "friendly_name": null,
@@ -4368,7 +3283,6 @@
       "image": null,
       "image_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/PB1250PL.%20no%20shadow.png",
       "lights": 0,
-      "manual_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-manuals/Platinum-Series/11040_PB1250PL_owners_manual.pdf",
       "max_temp": "500",
       "meat_probes": 2,
       "min_temp": "180",
@@ -4380,17 +3294,13 @@
       "shopify_product_id": null,
       "site_id": 1,
       "sku": null,
-      "temp_increment": "180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420/425/430/435/440/445/450/455/460/465/470/475/480/485/490/495/500",
-      "updated_at": "2025-03-27T18:59:55.000000Z"
+      "temp_increment": "180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420/425/430/435/440/445/450/455/460/465/470/475/480/485/490/495/500"
     },
     "PB1250CS": {
-      "app_layout": "standard",
       "category": null,
       "celsius_temp_increment": null,
       "control_board": "PBM",
       "control_board_id": 6,
-      "created_at": "2022-07-13T04:29:24.000000Z",
-      "deleted_at": null,
       "description": null,
       "enabled": true,
       "friendly_name": "",
@@ -4403,7 +3313,6 @@
       "image": null,
       "image_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/PB1250CS-2021-10-14-EN-124.png",
       "lights": 0,
-      "manual_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-manuals/Competition/PB1250CS_PB1600CS_OwnersManual_110V_EN_FR_ES.pdf",
       "max_temp": "500",
       "meat_probes": 2,
       "min_temp": "180",
@@ -4415,17 +3324,13 @@
       "shopify_product_id": null,
       "site_id": 1,
       "sku": null,
-      "temp_increment": "180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420/425/430/435/440/445/450/455/460/465/470/475/480/485/490/495/500",
-      "updated_at": "2024-08-12T22:48:45.000000Z"
+      "temp_increment": "180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420/425/430/435/440/445/450/455/460/465/470/475/480/485/490/495/500"
     },
     "PB1250CS2": {
-      "app_layout": "standard",
       "category": null,
       "celsius_temp_increment": null,
       "control_board": "PBA",
       "control_board_id": 10,
-      "created_at": "2025-01-22T23:07:04.000000Z",
-      "deleted_at": null,
       "description": null,
       "enabled": true,
       "friendly_name": null,
@@ -4438,7 +3343,6 @@
       "image": null,
       "image_url": "https://dansons-mobile.s3.dualstack.us-east-1.amazonaws.com/grill-images/PB1250CS2.2.png",
       "lights": 0,
-      "manual_url": "https://dansons-mobile.s3.dualstack.us-east-1.amazonaws.com/grill-manuals/Competition/11131_PB1250CS2_owners_manual_bleed_20240930.pdf",
       "max_temp": "500",
       "meat_probes": 2,
       "min_temp": "180",
@@ -4450,17 +3354,13 @@
       "shopify_product_id": null,
       "site_id": 1,
       "sku": null,
-      "temp_increment": "180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420/425/430/435/440/445/450/455/460/465/470/475/480/485/490/495/500",
-      "updated_at": "2025-01-22T23:13:22.000000Z"
+      "temp_increment": "180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420/425/430/435/440/445/450/455/460/465/470/475/480/485/490/495/500"
     },
     "PB1250NX": {
-      "app_layout": "standard",
       "category": null,
       "celsius_temp_increment": null,
       "control_board": "PBA",
       "control_board_id": 10,
-      "created_at": "2024-11-05T23:07:43.000000Z",
-      "deleted_at": null,
       "description": null,
       "enabled": true,
       "friendly_name": null,
@@ -4473,7 +3373,6 @@
       "image": null,
       "image_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/PB1250NX.png",
       "lights": 0,
-      "manual_url": null,
       "max_temp": "500",
       "meat_probes": 2,
       "min_temp": "180",
@@ -4485,17 +3384,13 @@
       "shopify_product_id": null,
       "site_id": 1,
       "sku": null,
-      "temp_increment": "180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420/425/430/435/440/445/450/455/460/465/470/475/480/485/490/495/500",
-      "updated_at": "2024-11-05T23:07:43.000000Z"
+      "temp_increment": "180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420/425/430/435/440/445/450/455/460/465/470/475/480/485/490/495/500"
     },
     "PB1250PL": {
-      "app_layout": "standard",
       "category": null,
       "celsius_temp_increment": null,
       "control_board": "PBA",
       "control_board_id": 10,
-      "created_at": "2024-01-04T20:56:02.000000Z",
-      "deleted_at": null,
       "description": null,
       "enabled": true,
       "friendly_name": "",
@@ -4508,7 +3403,6 @@
       "image": null,
       "image_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/PB1250PL.%20no%20shadow.png",
       "lights": 0,
-      "manual_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-manuals/Platinum-Series/11040_PB1250PL_owners_manual.pdf",
       "max_temp": "500",
       "meat_probes": 2,
       "min_temp": "180",
@@ -4520,17 +3414,13 @@
       "shopify_product_id": null,
       "site_id": 1,
       "sku": null,
-      "temp_increment": "180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420/425/430/435/440/445/450/455/460/465/470/475/480/485/490/495/500",
-      "updated_at": "2024-08-12T23:15:17.000000Z"
+      "temp_increment": "180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420/425/430/435/440/445/450/455/460/465/470/475/480/485/490/495/500"
     },
     "PB1285KC": {
-      "app_layout": "standard",
       "category": null,
       "celsius_temp_increment": null,
       "control_board": "PBG",
       "control_board_id": 3,
-      "created_at": "2022-07-13T04:29:24.000000Z",
-      "deleted_at": null,
       "description": null,
       "enabled": true,
       "friendly_name": "",
@@ -4543,7 +3433,6 @@
       "image": null,
       "image_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/PB1285KC-103.png",
       "lights": 2,
-      "manual_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-manuals/Platinum-Series/10499_10879_PB1285KC_manual_110V_EN_FR_ES%20%281%29.pdf",
       "max_temp": "High",
       "meat_probes": 2,
       "min_temp": "Smoke",
@@ -4555,17 +3444,13 @@
       "shopify_product_id": null,
       "site_id": 1,
       "sku": null,
-      "temp_increment": "180/200/225/250/275/300/325/350/375/400/425/450/500",
-      "updated_at": "2024-08-12T19:51:42.000000Z"
+      "temp_increment": "180/200/225/250/275/300/325/350/375/400/425/450/500"
     },
     "PB1285PC": {
-      "app_layout": "standard",
       "category": null,
       "celsius_temp_increment": null,
       "control_board": "PBG",
       "control_board_id": 3,
-      "created_at": "2024-09-13T21:25:53.000000Z",
-      "deleted_at": null,
       "description": null,
       "enabled": true,
       "friendly_name": null,
@@ -4578,7 +3463,6 @@
       "image": null,
       "image_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/PB1285PC.Rona.png",
       "lights": 0,
-      "manual_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-manuals/Platinum-Series/10499_10879_PB1285KC_manual_110V_EN_FR_ES%20%281%29.pdf",
       "max_temp": "500",
       "meat_probes": 2,
       "min_temp": "180",
@@ -4590,17 +3474,13 @@
       "shopify_product_id": null,
       "site_id": 1,
       "sku": null,
-      "temp_increment": "180/200/225/250/275/300/325/350/375/400/425/450/500",
-      "updated_at": "2024-09-13T21:25:53.000000Z"
+      "temp_increment": "180/200/225/250/275/300/325/350/375/400/425/450/500"
     },
     "PB1300 M": {
-      "app_layout": "standard",
       "category": null,
       "celsius_temp_increment": null,
       "control_board": "PBT",
       "control_board_id": 7,
-      "created_at": "2025-03-17T22:33:33.000000Z",
-      "deleted_at": null,
       "description": null,
       "enabled": true,
       "friendly_name": null,
@@ -4613,7 +3493,6 @@
       "image": null,
       "image_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/PB1300M.png",
       "lights": 0,
-      "manual_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-manuals/M-Line/11112_PB1300M_owners_manual.pdf",
       "max_temp": "500",
       "meat_probes": 2,
       "min_temp": "180",
@@ -4625,17 +3504,13 @@
       "shopify_product_id": null,
       "site_id": 1,
       "sku": null,
-      "temp_increment": "180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420/425/430/435/440/445/450/455/460/465/470/475/480/485/490/495/500",
-      "updated_at": "2025-03-17T22:33:33.000000Z"
+      "temp_increment": "180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420/425/430/435/440/445/450/455/460/465/470/475/480/485/490/495/500"
     },
     "PB1300 PS4": {
-      "app_layout": "standard",
       "category": null,
       "celsius_temp_increment": null,
       "control_board": "PBT",
       "control_board_id": 7,
-      "created_at": "2025-03-17T22:37:22.000000Z",
-      "deleted_at": null,
       "description": null,
       "enabled": true,
       "friendly_name": null,
@@ -4648,7 +3523,6 @@
       "image": null,
       "image_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/PB1300PS4.png",
       "lights": 0,
-      "manual_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-manuals/Pro-Series/11126_PB1300PS4_owners_manual.pdf",
       "max_temp": "500",
       "meat_probes": 2,
       "min_temp": "180",
@@ -4660,17 +3534,13 @@
       "shopify_product_id": null,
       "site_id": 1,
       "sku": null,
-      "temp_increment": "180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420/425/430/435/440/445/450/455/460/465/470/475/480/485/490/495/500",
-      "updated_at": "2025-03-17T22:37:22.000000Z"
+      "temp_increment": "180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420/425/430/435/440/445/450/455/460/465/470/475/480/485/490/495/500"
     },
     "PB1300M": {
-      "app_layout": "standard",
       "category": null,
       "celsius_temp_increment": null,
       "control_board": "PBA",
       "control_board_id": 10,
-      "created_at": "2024-09-17T21:37:19.000000Z",
-      "deleted_at": null,
       "description": null,
       "enabled": true,
       "friendly_name": null,
@@ -4683,7 +3553,6 @@
       "image": null,
       "image_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/PB1300M.png",
       "lights": 0,
-      "manual_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-manuals/M-Line/11112_PB1300M_owners_manual.pdf",
       "max_temp": "500",
       "meat_probes": 2,
       "min_temp": "180",
@@ -4695,17 +3564,13 @@
       "shopify_product_id": null,
       "site_id": 1,
       "sku": null,
-      "temp_increment": "180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420/425/430/435/440/445/450/455/460/465/470/475/480/485/490/495/500",
-      "updated_at": "2025-03-17T22:32:14.000000Z"
+      "temp_increment": "180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420/425/430/435/440/445/450/455/460/465/470/475/480/485/490/495/500"
     },
     "PB1300PS4": {
-      "app_layout": "standard",
       "category": null,
       "celsius_temp_increment": null,
       "control_board": "PBA",
       "control_board_id": 10,
-      "created_at": "2024-08-27T17:32:23.000000Z",
-      "deleted_at": null,
       "description": null,
       "enabled": true,
       "friendly_name": null,
@@ -4718,7 +3583,6 @@
       "image": null,
       "image_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/PB1300PS4.png",
       "lights": 0,
-      "manual_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-manuals/Pro-Series/11126_PB1300PS4_owners_manual.pdf",
       "max_temp": "500",
       "meat_probes": 2,
       "min_temp": "180",
@@ -4730,17 +3594,13 @@
       "shopify_product_id": null,
       "site_id": 1,
       "sku": null,
-      "temp_increment": "180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420/425/430/435/440/445/450/455/460/465/470/475/480/485/490/495/500",
-      "updated_at": "2024-08-27T22:07:25.000000Z"
+      "temp_increment": "180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420/425/430/435/440/445/450/455/460/465/470/475/480/485/490/495/500"
     },
     "PB1450CS": {
-      "app_layout": "standard",
       "category": null,
       "celsius_temp_increment": null,
       "control_board": "PBM",
       "control_board_id": 6,
-      "created_at": "2022-07-13T04:29:24.000000Z",
-      "deleted_at": null,
       "description": null,
       "enabled": true,
       "friendly_name": "",
@@ -4753,7 +3613,6 @@
       "image": null,
       "image_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/PB1450CS-2021-10-14-124.png",
       "lights": 0,
-      "manual_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-manuals/Competition/PB1450CS_OwnersManual_110V_EN_FR.pdf",
       "max_temp": "500",
       "meat_probes": 2,
       "min_temp": "180",
@@ -4765,17 +3624,13 @@
       "shopify_product_id": null,
       "site_id": 1,
       "sku": null,
-      "temp_increment": "180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420/425/430/435/440/445/450/455/460/465/470/475/480/485/490/495/500",
-      "updated_at": "2024-08-12T22:49:10.000000Z"
+      "temp_increment": "180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420/425/430/435/440/445/450/455/460/465/470/475/480/485/490/495/500"
     },
     "PB1500NXW": {
-      "app_layout": "standard",
       "category": null,
       "celsius_temp_increment": null,
       "control_board": "PBM2",
       "control_board_id": 20,
-      "created_at": "2025-07-28T21:12:43.000000Z",
-      "deleted_at": null,
       "description": null,
       "enabled": true,
       "friendly_name": null,
@@ -4788,7 +3643,6 @@
       "image": null,
       "image_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/PB1500NX.png",
       "lights": 0,
-      "manual_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-manuals/Onyx/10989_PB1500NX_owners_manual.pdf",
       "max_temp": "500",
       "meat_probes": 2,
       "min_temp": "180",
@@ -4800,17 +3654,13 @@
       "shopify_product_id": null,
       "site_id": 1,
       "sku": null,
-      "temp_increment": "180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420/425/430/435/440/445/450/455/460/465/470/475/480/485/490/495/500",
-      "updated_at": "2025-07-28T21:13:04.000000Z"
+      "temp_increment": "180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420/425/430/435/440/445/450/455/460/465/470/475/480/485/490/495/500"
     },
     "PB1500NXW (PBM)": {
-      "app_layout": "standard",
       "category": null,
       "celsius_temp_increment": null,
       "control_board": "PBM",
       "control_board_id": 6,
-      "created_at": "2023-06-13T15:00:25.000000Z",
-      "deleted_at": null,
       "description": null,
       "enabled": true,
       "friendly_name": null,
@@ -4823,7 +3673,6 @@
       "image": null,
       "image_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/PB1500NX.png",
       "lights": 0,
-      "manual_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-manuals/Onyx/10989_PB1500NX_owners_manual.pdf",
       "max_temp": "500",
       "meat_probes": 2,
       "min_temp": "180",
@@ -4835,17 +3684,13 @@
       "shopify_product_id": null,
       "site_id": 1,
       "sku": null,
-      "temp_increment": "180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420/425/430/435/440/445/450/455/460/465/470/475/480/485/490/495/500",
-      "updated_at": "2024-09-13T16:56:00.000000Z"
+      "temp_increment": "180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420/425/430/435/440/445/450/455/460/465/470/475/480/485/490/495/500"
     },
     "PB1600 CS": {
-      "app_layout": "standard",
       "category": null,
       "celsius_temp_increment": null,
       "control_board": "PBM2",
       "control_board_id": 20,
-      "created_at": "2025-05-27T22:51:16.000000Z",
-      "deleted_at": null,
       "description": null,
       "enabled": true,
       "friendly_name": null,
@@ -4858,7 +3703,6 @@
       "image": null,
       "image_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/PB1600CS-2021-10-14-EN-119.png",
       "lights": 0,
-      "manual_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-manuals/Competition/PB1250CS_PB1600CS_OwnersManual_110V_EN_FR_ES.pdf",
       "max_temp": "500",
       "meat_probes": 2,
       "min_temp": "180",
@@ -4870,17 +3714,13 @@
       "shopify_product_id": null,
       "site_id": 1,
       "sku": null,
-      "temp_increment": "180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420/425/430/435/440/445/450/455/460/465/470/475/480/485/490/495/500",
-      "updated_at": "2025-05-27T22:51:16.000000Z"
+      "temp_increment": "180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420/425/430/435/440/445/450/455/460/465/470/475/480/485/490/495/500"
     },
     "PB1600 CS2": {
-      "app_layout": "standard",
       "category": null,
       "celsius_temp_increment": null,
       "control_board": "PBT",
       "control_board_id": 7,
-      "created_at": "2025-03-17T22:29:41.000000Z",
-      "deleted_at": null,
       "description": null,
       "enabled": true,
       "friendly_name": null,
@@ -4893,7 +3733,6 @@
       "image": null,
       "image_url": "https://dansons-mobile.s3.dualstack.us-east-1.amazonaws.com/grill-images/PB1600CS2.2.png",
       "lights": 0,
-      "manual_url": "https://dansons-mobile.s3.dualstack.us-east-1.amazonaws.com/grill-manuals/Competition/11128_PB1600CS2_owners_manual_bleed_20240930.pdf",
       "max_temp": "500",
       "meat_probes": 2,
       "min_temp": "180",
@@ -4905,17 +3744,13 @@
       "shopify_product_id": null,
       "site_id": 1,
       "sku": null,
-      "temp_increment": "180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420/425/430/435/440/445/450/455/460/465/470/475/480/485/490/495/500",
-      "updated_at": "2025-03-17T22:29:41.000000Z"
+      "temp_increment": "180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420/425/430/435/440/445/450/455/460/465/470/475/480/485/490/495/500"
     },
     "PB1600 M": {
-      "app_layout": "standard",
       "category": null,
       "celsius_temp_increment": null,
       "control_board": "PBT",
       "control_board_id": 7,
-      "created_at": "2025-03-17T22:35:27.000000Z",
-      "deleted_at": null,
       "description": null,
       "enabled": true,
       "friendly_name": null,
@@ -4928,7 +3763,6 @@
       "image": null,
       "image_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/PB1600M.png",
       "lights": 0,
-      "manual_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-manuals/M-Line/11113_PB1600M_owners_manual.pdf",
       "max_temp": "500",
       "meat_probes": 2,
       "min_temp": "180",
@@ -4940,17 +3774,13 @@
       "shopify_product_id": null,
       "site_id": 1,
       "sku": null,
-      "temp_increment": "180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420/425/430/435/440/445/450/455/460/465/470/475/480/485/490/495/500",
-      "updated_at": "2025-03-17T22:35:27.000000Z"
+      "temp_increment": "180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420/425/430/435/440/445/450/455/460/465/470/475/480/485/490/495/500"
     },
     "PB1600 PSE": {
-      "app_layout": "standard",
       "category": null,
       "celsius_temp_increment": null,
       "control_board": "PBD",
       "control_board_id": 12,
-      "created_at": "2023-01-25T12:01:10.000000Z",
-      "deleted_at": null,
       "description": null,
       "enabled": true,
       "friendly_name": "",
@@ -4963,7 +3793,6 @@
       "image": null,
       "image_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/PB1600PS.Elite2024.png",
       "lights": 0,
-      "manual_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-manuals/Pro-Series/10982_PB1600PSE_manual_110V_EN_FR_ES.pdf",
       "max_temp": "500",
       "meat_probes": 2,
       "min_temp": "150",
@@ -4975,17 +3804,13 @@
       "shopify_product_id": null,
       "site_id": 1,
       "sku": null,
-      "temp_increment": "150/155/160/165/170/175/180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420/425/430/435/440/445/450/455/460/465/470/475/480/485/490/495/500",
-      "updated_at": "2024-08-13T16:16:49.000000Z"
+      "temp_increment": "150/155/160/165/170/175/180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420/425/430/435/440/445/450/455/460/465/470/475/480/485/490/495/500"
     },
     "PB1600AMB": {
-      "app_layout": "standard",
       "category": null,
       "celsius_temp_increment": null,
       "control_board": "PBT",
       "control_board_id": 7,
-      "created_at": "2025-04-23T21:44:10.000000Z",
-      "deleted_at": null,
       "description": null,
       "enabled": true,
       "friendly_name": null,
@@ -4998,7 +3823,6 @@
       "image": null,
       "image_url": "https://dansons-mobile.s3.dualstack.us-east-1.amazonaws.com/grill-images/PB1600AMB.png",
       "lights": 0,
-      "manual_url": "https://dansons-mobile.s3.dualstack.us-east-1.amazonaws.com/grill-manuals/Ambiance/11143_PB1600AMB_owners_manual.pdf",
       "max_temp": "500",
       "meat_probes": 2,
       "min_temp": "180",
@@ -5010,17 +3834,13 @@
       "shopify_product_id": null,
       "site_id": 1,
       "sku": null,
-      "temp_increment": "180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420/425/430/435/440/445/450/455/460/465/470/475/480/485/490/495/500",
-      "updated_at": "2025-04-24T15:22:06.000000Z"
+      "temp_increment": "180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420/425/430/435/440/445/450/455/460/465/470/475/480/485/490/495/500"
     },
     "PB1600CS": {
-      "app_layout": "standard",
       "category": null,
       "celsius_temp_increment": null,
       "control_board": "PBM",
       "control_board_id": 6,
-      "created_at": "2022-07-13T04:29:24.000000Z",
-      "deleted_at": null,
       "description": null,
       "enabled": true,
       "friendly_name": "",
@@ -5033,7 +3853,6 @@
       "image": null,
       "image_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/PB1600CS-2021-10-14-EN-119.png",
       "lights": 0,
-      "manual_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-manuals/Competition/PB1250CS_PB1600CS_OwnersManual_110V_EN_FR_ES.pdf",
       "max_temp": "500",
       "meat_probes": 2,
       "min_temp": "180",
@@ -5045,17 +3864,13 @@
       "shopify_product_id": null,
       "site_id": 1,
       "sku": null,
-      "temp_increment": "180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420/425/430/435/440/445/450/455/460/465/470/475/480/485/490/495/500",
-      "updated_at": "2024-08-12T22:49:34.000000Z"
+      "temp_increment": "180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420/425/430/435/440/445/450/455/460/465/470/475/480/485/490/495/500"
     },
     "PB1600CS2": {
-      "app_layout": "standard",
       "category": null,
       "celsius_temp_increment": null,
       "control_board": "PBA",
       "control_board_id": 10,
-      "created_at": "2025-01-22T23:09:48.000000Z",
-      "deleted_at": null,
       "description": null,
       "enabled": true,
       "friendly_name": null,
@@ -5068,7 +3883,6 @@
       "image": null,
       "image_url": "https://dansons-mobile.s3.dualstack.us-east-1.amazonaws.com/grill-images/PB1600CS2.2.png",
       "lights": 0,
-      "manual_url": "https://dansons-mobile.s3.dualstack.us-east-1.amazonaws.com/grill-manuals/Competition/11128_PB1600CS2_owners_manual_bleed_20240930.pdf",
       "max_temp": "500",
       "meat_probes": 2,
       "min_temp": "180",
@@ -5080,17 +3894,13 @@
       "shopify_product_id": null,
       "site_id": 1,
       "sku": null,
-      "temp_increment": "180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420/425/430/435/440/445/450/455/460/465/470/475/480/485/490/495/500",
-      "updated_at": "2025-01-22T23:09:48.000000Z"
+      "temp_increment": "180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420/425/430/435/440/445/450/455/460/465/470/475/480/485/490/495/500"
     },
     "PB1600CST": {
-      "app_layout": "standard",
       "category": null,
       "celsius_temp_increment": null,
       "control_board": "PBE",
       "control_board_id": 15,
-      "created_at": "2023-12-08T17:07:55.000000Z",
-      "deleted_at": null,
       "description": null,
       "enabled": true,
       "friendly_name": "",
@@ -5103,7 +3913,6 @@
       "image": null,
       "image_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/PB1600CST.png",
       "lights": 0,
-      "manual_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-manuals/Competition/11038_PB1600CST_owners_manual.pdf",
       "max_temp": "500",
       "meat_probes": 2,
       "min_temp": "150",
@@ -5115,17 +3924,13 @@
       "shopify_product_id": null,
       "site_id": 1,
       "sku": null,
-      "temp_increment": "150/155/160/165/170/175/180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420/425/430/435/440/445/450/455/460/465/470/475/480/485/490/495/500",
-      "updated_at": "2024-08-12T23:13:26.000000Z"
+      "temp_increment": "150/155/160/165/170/175/180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420/425/430/435/440/445/450/455/460/465/470/475/480/485/490/495/500"
     },
     "PB1600M": {
-      "app_layout": "standard",
       "category": null,
       "celsius_temp_increment": null,
       "control_board": "PBA",
       "control_board_id": 10,
-      "created_at": "2024-09-17T21:42:01.000000Z",
-      "deleted_at": null,
       "description": null,
       "enabled": true,
       "friendly_name": null,
@@ -5138,7 +3943,6 @@
       "image": null,
       "image_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/PB1600M.png",
       "lights": 0,
-      "manual_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-manuals/M-Line/11113_PB1600M_owners_manual.pdf",
       "max_temp": "500",
       "meat_probes": 2,
       "min_temp": "180",
@@ -5150,17 +3954,13 @@
       "shopify_product_id": null,
       "site_id": 1,
       "sku": null,
-      "temp_increment": "180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420/425/430/435/440/445/450/455/460/465/470/475/480/485/490/495/500",
-      "updated_at": "2024-09-17T21:42:01.000000Z"
+      "temp_increment": "180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420/425/430/435/440/445/450/455/460/465/470/475/480/485/490/495/500"
     },
     "PB1600PS1": {
-      "app_layout": "standard",
       "category": null,
       "celsius_temp_increment": null,
       "control_board": "PBL",
       "control_board_id": 1,
-      "created_at": "2022-07-13T04:29:24.000000Z",
-      "deleted_at": null,
       "description": null,
       "enabled": true,
       "friendly_name": "",
@@ -5173,7 +3973,6 @@
       "image": null,
       "image_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/PB1600PS1-2020-5-22-single-105.png",
       "lights": 0,
-      "manual_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-manuals/Pro-Series/10737_PB1600PS1_manual_110V_EN_FR_ES.pdf",
       "max_temp": "500",
       "meat_probes": 4,
       "min_temp": "180",
@@ -5185,17 +3984,13 @@
       "shopify_product_id": null,
       "site_id": 1,
       "sku": null,
-      "temp_increment": "180/190/200/210/220/230/240/250/260/270/280/290/300/325/350/375/400/450/500",
-      "updated_at": "2024-08-12T20:24:28.000000Z"
+      "temp_increment": "180/190/200/210/220/230/240/250/260/270/280/290/300/325/350/375/400/450/500"
     },
     "PB1600PS2": {
-      "app_layout": "standard",
       "category": null,
       "celsius_temp_increment": null,
       "control_board": "PBP",
       "control_board_id": 13,
-      "created_at": "2022-07-13T04:29:24.000000Z",
-      "deleted_at": null,
       "description": null,
       "enabled": true,
       "friendly_name": "",
@@ -5208,7 +4003,6 @@
       "image": null,
       "image_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/PB1600PS2-2021-8-17-120.png",
       "lights": 1,
-      "manual_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-manuals/Pro-Series/10908_PB1600PS2_manual_110V_EN_FR_ES.pdf",
       "max_temp": "500",
       "meat_probes": 4,
       "min_temp": "150",
@@ -5220,17 +4014,13 @@
       "shopify_product_id": null,
       "site_id": 1,
       "sku": null,
-      "temp_increment": "150/155/160/165/170/175/180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420/425/430/435/440/445/450/455/460/465/470/475/480/485/490/495/500",
-      "updated_at": "2024-08-12T23:06:06.000000Z"
+      "temp_increment": "150/155/160/165/170/175/180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420/425/430/435/440/445/450/455/460/465/470/475/480/485/490/495/500"
     },
     "PB1600PS2 (PBL)": {
-      "app_layout": "standard",
       "category": null,
       "celsius_temp_increment": null,
       "control_board": "PBL",
       "control_board_id": 1,
-      "created_at": "2022-07-13T04:29:24.000000Z",
-      "deleted_at": null,
       "description": null,
       "enabled": true,
       "friendly_name": "",
@@ -5243,7 +4033,6 @@
       "image": null,
       "image_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/PB1600PS2-2021-8-17-120.png",
       "lights": 0,
-      "manual_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-manuals/Pro-Series/10908_PB1600PS2_manual_110V_EN_FR_ES.pdf",
       "max_temp": "500",
       "meat_probes": 4,
       "min_temp": "150",
@@ -5255,17 +4044,13 @@
       "shopify_product_id": null,
       "site_id": 1,
       "sku": null,
-      "temp_increment": "150/155/160/165/170/175/180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420/425/430/435/440/445/450/455/460/465/470/475/480/485/490/495/500",
-      "updated_at": "2024-08-12T22:53:05.000000Z"
+      "temp_increment": "150/155/160/165/170/175/180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420/425/430/435/440/445/450/455/460/465/470/475/480/485/490/495/500"
     },
     "PB1600PS3": {
-      "app_layout": "standard",
       "category": null,
       "celsius_temp_increment": null,
       "control_board": "PBA",
       "control_board_id": 10,
-      "created_at": "2022-11-09T23:18:25.000000Z",
-      "deleted_at": null,
       "description": null,
       "enabled": true,
       "friendly_name": "",
@@ -5278,7 +4063,6 @@
       "image": null,
       "image_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/PB1600PS3.png",
       "lights": 1,
-      "manual_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-manuals/Pro-Series/10981%2010984_PB1600PS3_manual_110V_EN_FR_ES.pdf",
       "max_temp": "500",
       "meat_probes": 2,
       "min_temp": "180",
@@ -5290,17 +4074,13 @@
       "shopify_product_id": null,
       "site_id": 1,
       "sku": null,
-      "temp_increment": "180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420/425/430/435/440/445/450/455/460/465/470/475/480/485/490/495/500",
-      "updated_at": "2024-08-12T22:54:42.000000Z"
+      "temp_increment": "180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420/425/430/435/440/445/450/455/460/465/470/475/480/485/490/495/500"
     },
     "PB1600PS3_": {
-      "app_layout": "standard",
       "category": "N/A",
       "celsius_temp_increment": null,
       "control_board": "PBT",
       "control_board_id": 7,
-      "created_at": "2023-01-10T11:58:26.000000Z",
-      "deleted_at": null,
       "description": "<p>N/A</p>",
       "enabled": true,
       "friendly_name": "",
@@ -5313,7 +4093,6 @@
       "image": null,
       "image_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/PB1600PS3.png",
       "lights": 0,
-      "manual_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-manuals/Pro-Series/10981%2010984_PB1600PS3_manual_110V_EN_FR_ES.pdf",
       "max_temp": "500",
       "meat_probes": 2,
       "min_temp": "180",
@@ -5325,17 +4104,13 @@
       "shopify_product_id": "N/A",
       "site_id": 1,
       "sku": "N/A",
-      "temp_increment": "180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420/425/430/435/440/445/450/455/460/465/470/475/480/485/490/495/500",
-      "updated_at": "2024-08-13T16:23:57.000000Z"
+      "temp_increment": "180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420/425/430/435/440/445/450/455/460/465/470/475/480/485/490/495/500"
     },
     "PB1600PS4": {
-      "app_layout": "standard",
       "category": null,
       "celsius_temp_increment": null,
       "control_board": "PBT",
       "control_board_id": 7,
-      "created_at": "2025-09-17T16:34:30.000000Z",
-      "deleted_at": null,
       "description": null,
       "enabled": true,
       "friendly_name": null,
@@ -5348,7 +4123,6 @@
       "image": null,
       "image_url": "https://dansons-mobile.s3.dualstack.us-east-1.amazonaws.com/grill-images/PB1600PS4.png",
       "lights": 0,
-      "manual_url": "https://dansons-mobile.s3.dualstack.us-east-1.amazonaws.com/grill-manuals/Pro-Series/11191_PB1600PS4_owners_manual.pdf",
       "max_temp": "500",
       "meat_probes": 2,
       "min_temp": "180",
@@ -5360,17 +4134,13 @@
       "shopify_product_id": null,
       "site_id": 1,
       "sku": null,
-      "temp_increment": "180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420/425/430/435/440/445/450/455/460/465/470/475/480/485/490/495/500",
-      "updated_at": "2025-09-17T22:54:38.000000Z"
+      "temp_increment": "180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420/425/430/435/440/445/450/455/460/465/470/475/480/485/490/495/500"
     },
     "PB1600PSE": {
-      "app_layout": "standard",
       "category": null,
       "celsius_temp_increment": null,
       "control_board": "PBB",
       "control_board_id": 11,
-      "created_at": "2022-11-09T23:20:07.000000Z",
-      "deleted_at": null,
       "description": null,
       "enabled": true,
       "friendly_name": "",
@@ -5383,7 +4153,6 @@
       "image": null,
       "image_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/PB1600PS.Elite2024.png",
       "lights": 1,
-      "manual_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-manuals/Pro-Series/10982_PB1600PSE_manual_110V_EN_FR_ES.pdf",
       "max_temp": "500",
       "meat_probes": 2,
       "min_temp": "150",
@@ -5395,17 +4164,13 @@
       "shopify_product_id": null,
       "site_id": 1,
       "sku": null,
-      "temp_increment": "150/155/160/165/170/175/180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420/425/430/435/440/445/450/455/460/465/470/475/480/485/490/495/500",
-      "updated_at": "2024-08-12T22:55:48.000000Z"
+      "temp_increment": "150/155/160/165/170/175/180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420/425/430/435/440/445/450/455/460/465/470/475/480/485/490/495/500"
     },
     "PB1600SPW": {
-      "app_layout": "standard",
       "category": null,
       "celsius_temp_increment": null,
       "control_board": "PBM",
       "control_board_id": 6,
-      "created_at": "2023-09-27T18:20:06.000000Z",
-      "deleted_at": null,
       "description": null,
       "enabled": true,
       "friendly_name": null,
@@ -5418,7 +4183,6 @@
       "image": null,
       "image_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/PB1600SPW.png",
       "lights": 0,
-      "manual_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-manuals/Sportsman/11014_PB1600SPW_owners_manual.pdf",
       "max_temp": "500",
       "meat_probes": 2,
       "min_temp": "180",
@@ -5430,17 +4194,13 @@
       "shopify_product_id": null,
       "site_id": 1,
       "sku": null,
-      "temp_increment": "180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420/425/430/435/440/445/450/455/460/465/470/475/480/485/490/495/500",
-      "updated_at": "2024-08-14T21:46:36.000000Z"
+      "temp_increment": "180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420/425/430/435/440/445/450/455/460/465/470/475/480/485/490/495/500"
     },
     "PB1600SPW2": {
-      "app_layout": "standard",
       "category": null,
       "celsius_temp_increment": null,
       "control_board": "PBM",
       "control_board_id": 6,
-      "created_at": "2024-11-05T23:05:54.000000Z",
-      "deleted_at": null,
       "description": null,
       "enabled": true,
       "friendly_name": null,
@@ -5453,7 +4213,6 @@
       "image": null,
       "image_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/PB1600SPW2.png",
       "lights": 0,
-      "manual_url": null,
       "max_temp": "500",
       "meat_probes": 2,
       "min_temp": "180",
@@ -5465,17 +4224,13 @@
       "shopify_product_id": null,
       "site_id": 1,
       "sku": null,
-      "temp_increment": "180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420/425/430/435/440/445/450/455/460/465/470/475/480/485/490/495/500",
-      "updated_at": "2024-11-05T23:05:54.000000Z"
+      "temp_increment": "180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420/425/430/435/440/445/450/455/460/465/470/475/480/485/490/495/500"
     },
     "PB2180LK": {
-      "app_layout": "standard",
       "category": null,
       "celsius_temp_increment": null,
       "control_board": "PBG",
       "control_board_id": 3,
-      "created_at": "2022-07-13T04:29:24.000000Z",
-      "deleted_at": null,
       "description": null,
       "enabled": true,
       "friendly_name": "",
@@ -5488,7 +4243,6 @@
       "image": null,
       "image_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/PB2180LK-2020-3-16-105.png",
       "lights": 2,
-      "manual_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-manuals/Platinum-Series/10500_PB2180LK_manualUSA_EN_FR_ES.pdf",
       "max_temp": "High",
       "meat_probes": 4,
       "min_temp": "Smoke",
@@ -5500,17 +4254,13 @@
       "shopify_product_id": null,
       "site_id": 1,
       "sku": null,
-      "temp_increment": "160/180/200/225/250/275/300/325/350/375/400/425/450/500",
-      "updated_at": "2024-08-12T20:18:29.000000Z"
+      "temp_increment": "160/180/200/225/250/275/300/325/350/375/400/425/450/500"
     },
     "PB340": {
-      "app_layout": "standard",
       "category": null,
       "celsius_temp_increment": null,
       "control_board": "PBV",
       "control_board_id": 4,
-      "created_at": "2022-07-13T04:29:24.000000Z",
-      "deleted_at": null,
       "description": null,
       "enabled": true,
       "friendly_name": "",
@@ -5523,7 +4273,6 @@
       "image": null,
       "image_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/PB340.png",
       "lights": 0,
-      "manual_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-manuals/Standard/71343_PB340_manualUSA_EN_FR.pdf",
       "max_temp": "500",
       "meat_probes": 3,
       "min_temp": "180",
@@ -5535,17 +4284,13 @@
       "shopify_product_id": null,
       "site_id": 1,
       "sku": null,
-      "temp_increment": "180/200/225/250/300/350/400/450/475/500",
-      "updated_at": "2024-08-12T20:35:55.000000Z"
+      "temp_increment": "180/200/225/250/300/350/400/450/475/500"
     },
     "PB340TGW1 (Tailgator)": {
-      "app_layout": "standard",
       "category": null,
       "celsius_temp_increment": null,
       "control_board": "PBC",
       "control_board_id": 5,
-      "created_at": "2022-07-13T04:29:24.000000Z",
-      "deleted_at": null,
       "description": null,
       "enabled": true,
       "friendly_name": "",
@@ -5558,7 +4303,6 @@
       "image": null,
       "image_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/PB340TGW1-2018-9-20-abby-22.png",
       "lights": 0,
-      "manual_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-manuals/Copper/71344_PB340TGW1_manual_110V_EN_FR_ES.pdf",
       "max_temp": "500",
       "meat_probes": 2,
       "min_temp": "180",
@@ -5570,17 +4314,13 @@
       "shopify_product_id": null,
       "site_id": 1,
       "sku": null,
-      "temp_increment": "180/200/225/250/300/350/400/450/475/500",
-      "updated_at": "2024-08-12T22:40:30.000000Z"
+      "temp_increment": "180/200/225/250/300/350/400/450/475/500"
     },
     "PB440D": {
-      "app_layout": "standard",
       "category": null,
       "celsius_temp_increment": null,
       "control_board": "PBV",
       "control_board_id": 4,
-      "created_at": "2022-07-13T04:29:24.000000Z",
-      "deleted_at": null,
       "description": null,
       "enabled": true,
       "friendly_name": "",
@@ -5593,7 +4333,6 @@
       "image": null,
       "image_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/PB440D3-2019-4-18-abby.png",
       "lights": 0,
-      "manual_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-manuals/Standard/72440_PB440D_manualCAN_EN_FR.pdf",
       "max_temp": "500",
       "meat_probes": 3,
       "min_temp": "180",
@@ -5605,17 +4344,13 @@
       "shopify_product_id": null,
       "site_id": 1,
       "sku": null,
-      "temp_increment": "180/200/225/250/300/350/400/450/475/500",
-      "updated_at": "2024-08-12T20:36:39.000000Z"
+      "temp_increment": "180/200/225/250/300/350/400/450/475/500"
     },
     "PB440D2": {
-      "app_layout": "standard",
       "category": null,
       "celsius_temp_increment": null,
       "control_board": "PBC",
       "control_board_id": 5,
-      "created_at": "2022-07-13T04:29:24.000000Z",
-      "deleted_at": null,
       "description": null,
       "enabled": true,
       "friendly_name": "",
@@ -5628,7 +4363,6 @@
       "image": null,
       "image_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/PB440D2-2019-1-7-abby-23.png",
       "lights": 0,
-      "manual_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-manuals/Standard/10735_72455_PB440D2_manual_110V_EN_FR_ES.pdf",
       "max_temp": "500",
       "meat_probes": 2,
       "min_temp": "180",
@@ -5640,17 +4374,13 @@
       "shopify_product_id": null,
       "site_id": 1,
       "sku": null,
-      "temp_increment": "180/200/225/250/300/350/400/450/475/500",
-      "updated_at": "2024-08-12T22:26:09.000000Z"
+      "temp_increment": "180/200/225/250/300/350/400/450/475/500"
     },
     "PB440D3/PB456D": {
-      "app_layout": "standard",
       "category": null,
       "celsius_temp_increment": null,
       "control_board": "PBC",
       "control_board_id": 5,
-      "created_at": "2022-07-13T04:29:24.000000Z",
-      "deleted_at": null,
       "description": null,
       "enabled": true,
       "friendly_name": "",
@@ -5663,7 +4393,6 @@
       "image": null,
       "image_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/pb456d.png",
       "lights": 0,
-      "manual_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-manuals/Standard/10250_10251_PB456D_manual_110V_EN_FR_ES.pdf",
       "max_temp": "500",
       "meat_probes": 2,
       "min_temp": "180",
@@ -5675,17 +4404,13 @@
       "shopify_product_id": null,
       "site_id": 1,
       "sku": null,
-      "temp_increment": "180/200/225/250/300/350/400/450/475/500",
-      "updated_at": "2024-08-12T22:25:51.000000Z"
+      "temp_increment": "180/200/225/250/300/350/400/450/475/500"
     },
     "PB440TG1": {
-      "app_layout": "standard",
       "category": null,
       "celsius_temp_increment": null,
       "control_board": "PBV",
       "control_board_id": 4,
-      "created_at": "2022-07-13T04:29:24.000000Z",
-      "deleted_at": null,
       "description": null,
       "enabled": true,
       "friendly_name": "",
@@ -5698,7 +4423,6 @@
       "image": null,
       "image_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/PB440TG1.png",
       "lights": 0,
-      "manual_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-manuals/Standard/72445_72448_PB440TG1_manualCAN_EN_FR.pdf",
       "max_temp": "500",
       "meat_probes": 3,
       "min_temp": "180",
@@ -5710,17 +4434,13 @@
       "shopify_product_id": null,
       "site_id": 1,
       "sku": null,
-      "temp_increment": "180/200/225/250/300/350/400/450/475/500",
-      "updated_at": "2024-08-12T20:36:53.000000Z"
+      "temp_increment": "180/200/225/250/300/350/400/450/475/500"
     },
     "PB440TGNC1": {
-      "app_layout": "standard",
       "category": null,
       "celsius_temp_increment": null,
       "control_board": "PBC",
       "control_board_id": 5,
-      "created_at": "2022-07-13T04:29:24.000000Z",
-      "deleted_at": null,
       "description": null,
       "enabled": true,
       "friendly_name": "",
@@ -5733,7 +4453,6 @@
       "image": null,
       "image_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/PB440TGNC1.png",
       "lights": 0,
-      "manual_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-manuals/Nascar/10400_PBPEL44010400_manualUSA_EN_FR.pdf",
       "max_temp": "500",
       "meat_probes": 2,
       "min_temp": "180",
@@ -5745,17 +4464,13 @@
       "shopify_product_id": null,
       "site_id": 1,
       "sku": null,
-      "temp_increment": "180/200/225/250/300/350/400/450/475/500",
-      "updated_at": "2024-08-12T22:29:20.000000Z"
+      "temp_increment": "180/200/225/250/300/350/400/450/475/500"
     },
     "PB440TGR1": {
-      "app_layout": "standard",
       "category": null,
       "celsius_temp_increment": null,
       "control_board": "PBV",
       "control_board_id": 4,
-      "created_at": "2022-07-13T04:29:24.000000Z",
-      "deleted_at": null,
       "description": null,
       "enabled": true,
       "friendly_name": "",
@@ -5768,7 +4483,6 @@
       "image": null,
       "image_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/PB440TGR1.png",
       "lights": 0,
-      "manual_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-manuals/Standard/72445_72448_PB440TG1_manualCAN_EN_FR.pdf",
       "max_temp": "500",
       "meat_probes": 3,
       "min_temp": "180",
@@ -5780,17 +4494,13 @@
       "shopify_product_id": null,
       "site_id": 1,
       "sku": null,
-      "temp_increment": "180/200/225/250/300/350/400/450/475/500",
-      "updated_at": "2024-08-12T20:37:40.000000Z"
+      "temp_increment": "180/200/225/250/300/350/400/450/475/500"
     },
     "PB550G": {
-      "app_layout": "standard",
       "category": null,
       "celsius_temp_increment": null,
       "control_board": "PBC",
       "control_board_id": 5,
-      "created_at": "2022-07-13T04:29:24.000000Z",
-      "deleted_at": null,
       "description": null,
       "enabled": true,
       "friendly_name": "",
@@ -5803,7 +4513,6 @@
       "image": null,
       "image_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/550-nav-109.png",
       "lights": 0,
-      "manual_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-manuals/Navigator/PB550G_PB700G_PB850G_PB1150G_OwnersManual_110V_EN_FR_ES.pdf",
       "max_temp": "500",
       "meat_probes": 2,
       "min_temp": "180",
@@ -5815,17 +4524,13 @@
       "shopify_product_id": null,
       "site_id": 1,
       "sku": null,
-      "temp_increment": "180/200/225/250/300/350/400/450/475/500",
-      "updated_at": "2024-08-12T22:35:17.000000Z"
+      "temp_increment": "180/200/225/250/300/350/400/450/475/500"
     },
     "PB700D": {
-      "app_layout": "standard",
       "category": null,
       "celsius_temp_increment": null,
       "control_board": "PBV",
       "control_board_id": 4,
-      "created_at": "2022-07-13T04:29:24.000000Z",
-      "deleted_at": null,
       "description": null,
       "enabled": true,
       "friendly_name": "",
@@ -5838,7 +4543,6 @@
       "image": null,
       "image_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/PB700D.Canada.png",
       "lights": 0,
-      "manual_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-manuals/Standard/72700_PB700D_manual_USA_EN_FR.pdf",
       "max_temp": "500",
       "meat_probes": 3,
       "min_temp": "180",
@@ -5850,17 +4554,13 @@
       "shopify_product_id": null,
       "site_id": 1,
       "sku": null,
-      "temp_increment": "180/200/225/250/300/350/400/450/475/500",
-      "updated_at": "2024-08-12T20:37:53.000000Z"
+      "temp_increment": "180/200/225/250/300/350/400/450/475/500"
     },
     "PB700FB": {
-      "app_layout": "standard",
       "category": "Wood Pellet",
       "celsius_temp_increment": null,
       "control_board": "PBV",
       "control_board_id": 4,
-      "created_at": "2022-07-13T04:29:24.000000Z",
-      "deleted_at": null,
       "description": null,
       "enabled": true,
       "friendly_name": "",
@@ -5873,7 +4573,6 @@
       "image": null,
       "image_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/pitboss700FB.png",
       "lights": 0,
-      "manual_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-manuals/Standard/71700FB_71703_10660_PB700FB_manual_110V_EN_FR_ES%20%281%29.pdf",
       "max_temp": "500",
       "meat_probes": 3,
       "min_temp": "180",
@@ -5885,17 +4584,13 @@
       "shopify_product_id": null,
       "site_id": 1,
       "sku": null,
-      "temp_increment": "180/200/225/250/300/350/400/450/475/500",
-      "updated_at": "2024-08-12T21:12:38.000000Z"
+      "temp_increment": "180/200/225/250/300/350/400/450/475/500"
     },
     "PB700FBM2": {
-      "app_layout": "standard",
       "category": null,
       "celsius_temp_increment": null,
       "control_board": "PBV",
       "control_board_id": 4,
-      "created_at": "2022-07-13T04:29:24.000000Z",
-      "deleted_at": null,
       "description": null,
       "enabled": true,
       "friendly_name": "",
@@ -5908,7 +4603,6 @@
       "image": null,
       "image_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/PB700FBM2.png",
       "lights": 0,
-      "manual_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-manuals/Standard/71725_PB700FBM2_manual_110V_EN_FR.pdf",
       "max_temp": "500",
       "meat_probes": 3,
       "min_temp": "180",
@@ -5920,17 +4614,13 @@
       "shopify_product_id": null,
       "site_id": 1,
       "sku": null,
-      "temp_increment": "180/200/225/250/300/350/400/450/475/500",
-      "updated_at": "2024-08-12T21:13:05.000000Z"
+      "temp_increment": "180/200/225/250/300/350/400/450/475/500"
     },
     "PB700FBW2 (Classic)": {
-      "app_layout": "standard",
       "category": null,
       "celsius_temp_increment": null,
       "control_board": "PBC",
       "control_board_id": 5,
-      "created_at": "2022-07-13T04:29:24.000000Z",
-      "deleted_at": null,
       "description": null,
       "enabled": true,
       "friendly_name": "",
@@ -5943,7 +4633,6 @@
       "image": null,
       "image_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/Copper-classic-pb700-8.png",
       "lights": 0,
-      "manual_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-manuals/Copper/71705_PB700FBW2_manualCAN_EN_FR.pdf",
       "max_temp": "500",
       "meat_probes": 2,
       "min_temp": "180",
@@ -5955,17 +4644,13 @@
       "shopify_product_id": null,
       "site_id": 1,
       "sku": null,
-      "temp_increment": "180/200/225/250/300/350/400/450/475/500",
-      "updated_at": "2024-08-12T22:40:44.000000Z"
+      "temp_increment": "180/200/225/250/300/350/400/450/475/500"
     },
     "PB700NC1": {
-      "app_layout": "standard",
       "category": null,
       "celsius_temp_increment": null,
       "control_board": "PBC",
       "control_board_id": 5,
-      "created_at": "2022-07-13T04:29:24.000000Z",
-      "deleted_at": null,
       "description": null,
       "enabled": true,
       "friendly_name": "",
@@ -5978,7 +4663,6 @@
       "image": null,
       "image_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/pb700nc1-110.png",
       "lights": 0,
-      "manual_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-manuals/Nascar/10401_PBPEL70010401_manual_EN_FR.pdf",
       "max_temp": "500",
       "meat_probes": 2,
       "min_temp": "180",
@@ -5990,17 +4674,13 @@
       "shopify_product_id": null,
       "site_id": 1,
       "sku": null,
-      "temp_increment": "180/200/225/250/300/350/400/450/475/500",
-      "updated_at": "2024-08-12T22:29:40.000000Z"
+      "temp_increment": "180/200/225/250/300/350/400/450/475/500"
     },
     "PB700R1": {
-      "app_layout": "standard",
       "category": null,
       "celsius_temp_increment": null,
       "control_board": "PBV",
       "control_board_id": 4,
-      "created_at": "2022-07-13T04:29:24.000000Z",
-      "deleted_at": null,
       "description": null,
       "enabled": true,
       "friendly_name": "",
@@ -6013,7 +4693,6 @@
       "image": null,
       "image_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/PB700R1-2019-1-22-abby-21.png",
       "lights": 0,
-      "manual_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-manuals/R-Series/72700_PB700R1_manualUSA_EN.pdf",
       "max_temp": "500",
       "meat_probes": 3,
       "min_temp": "180",
@@ -6025,17 +4704,13 @@
       "shopify_product_id": null,
       "site_id": 1,
       "sku": null,
-      "temp_increment": "180/200/225/250/300/350/400/450/475/500",
-      "updated_at": "2024-08-12T20:38:11.000000Z"
+      "temp_increment": "180/200/225/250/300/350/400/450/475/500"
     },
     "PB700R2": {
-      "app_layout": "standard",
       "category": null,
       "celsius_temp_increment": null,
       "control_board": "PBV",
       "control_board_id": 4,
-      "created_at": "2022-07-13T04:29:24.000000Z",
-      "deleted_at": null,
       "description": null,
       "enabled": true,
       "friendly_name": "",
@@ -6048,7 +4723,6 @@
       "image": null,
       "image_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/PB700R2-2019-7-1-Abby-111.png",
       "lights": 0,
-      "manual_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-manuals/R-Series/10539_10681_PB700R2_manual_110V_EN_FR.pdf",
       "max_temp": "500",
       "meat_probes": 3,
       "min_temp": "180",
@@ -6060,17 +4734,13 @@
       "shopify_product_id": null,
       "site_id": 1,
       "sku": null,
-      "temp_increment": "180/200/225/250/300/350/400/450/475/500",
-      "updated_at": "2024-08-12T21:13:56.000000Z"
+      "temp_increment": "180/200/225/250/300/350/400/450/475/500"
     },
     "PB700S": {
-      "app_layout": "standard",
       "category": null,
       "celsius_temp_increment": null,
       "control_board": "PBV",
       "control_board_id": 4,
-      "created_at": "2022-07-13T04:29:24.000000Z",
-      "deleted_at": null,
       "description": null,
       "enabled": true,
       "friendly_name": "",
@@ -6083,7 +4753,6 @@
       "image": null,
       "image_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/pb700s.png",
       "lights": 0,
-      "manual_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-manuals/Standard/72711_PB700S_manual_110V_EN.pdf",
       "max_temp": "500",
       "meat_probes": 3,
       "min_temp": "180",
@@ -6095,17 +4764,13 @@
       "shopify_product_id": null,
       "site_id": 1,
       "sku": null,
-      "temp_increment": "180/200/225/250/300/350/400/450/475/500",
-      "updated_at": "2024-08-12T20:39:05.000000Z"
+      "temp_increment": "180/200/225/250/300/350/400/450/475/500"
     },
     "PB700S1": {
-      "app_layout": "standard",
       "category": null,
       "celsius_temp_increment": null,
       "control_board": "PBV",
       "control_board_id": 4,
-      "created_at": "2022-07-13T04:29:24.000000Z",
-      "deleted_at": null,
       "description": null,
       "enabled": true,
       "friendly_name": "",
@@ -6118,7 +4783,6 @@
       "image": null,
       "image_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/PB700S1-26.png",
       "lights": 0,
-      "manual_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-manuals/Standard/72724_PB700S1_manual_110V_EN_FR.pdf",
       "max_temp": "500",
       "meat_probes": 3,
       "min_temp": "180",
@@ -6130,17 +4794,13 @@
       "shopify_product_id": null,
       "site_id": 1,
       "sku": null,
-      "temp_increment": "180/200/225/250/300/350/400/450/475/500",
-      "updated_at": "2024-08-12T20:39:18.000000Z"
+      "temp_increment": "180/200/225/250/300/350/400/450/475/500"
     },
     "PB700S2": {
-      "app_layout": "standard",
       "category": null,
       "celsius_temp_increment": null,
       "control_board": "PBV",
       "control_board_id": 4,
-      "created_at": "2022-07-13T04:29:24.000000Z",
-      "deleted_at": null,
       "description": null,
       "enabled": true,
       "friendly_name": "",
@@ -6153,7 +4813,6 @@
       "image": null,
       "image_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/PB700S2-2019-1-22-abby-27.png",
       "lights": 0,
-      "manual_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-manuals/Standard/72725_PB700S2_manual_110V_EN_FR.pdf",
       "max_temp": "500",
       "meat_probes": 3,
       "min_temp": "180",
@@ -6165,17 +4824,13 @@
       "shopify_product_id": null,
       "site_id": 1,
       "sku": null,
-      "temp_increment": "180/200/225/250/300/350/400/450/475/500",
-      "updated_at": "2024-08-12T21:14:15.000000Z"
+      "temp_increment": "180/200/225/250/300/350/400/450/475/500"
     },
     "PB700SC": {
-      "app_layout": "standard",
       "category": null,
       "celsius_temp_increment": null,
       "control_board": "PBV",
       "control_board_id": 4,
-      "created_at": "2022-07-13T04:29:24.000000Z",
-      "deleted_at": null,
       "description": null,
       "enabled": true,
       "friendly_name": "",
@@ -6188,7 +4843,6 @@
       "image": null,
       "image_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/PB700SC-2019-1-22-abby-125.png",
       "lights": 0,
-      "manual_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-manuals/Standard/72700SC_72707_PB700SC_manualUSA_EN_FR.pdf",
       "max_temp": "500",
       "meat_probes": 3,
       "min_temp": "180",
@@ -6200,17 +4854,13 @@
       "shopify_product_id": null,
       "site_id": 1,
       "sku": null,
-      "temp_increment": "180/200/225/250/300/350/400/450/475/500",
-      "updated_at": "2024-08-12T21:13:42.000000Z"
+      "temp_increment": "180/200/225/250/300/350/400/450/475/500"
     },
     "PB700T1": {
-      "app_layout": "standard",
       "category": null,
       "celsius_temp_increment": null,
       "control_board": "PBV",
       "control_board_id": 4,
-      "created_at": "2022-07-13T04:29:24.000000Z",
-      "deleted_at": null,
       "description": null,
       "enabled": true,
       "friendly_name": "",
@@ -6223,7 +4873,6 @@
       "image": null,
       "image_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/PB700T1-114.png",
       "lights": 0,
-      "manual_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-manuals/Traditional/10771_PB700T1_manual_110V_EN_FR_ES.pdf",
       "max_temp": "500",
       "meat_probes": 3,
       "min_temp": "180",
@@ -6235,17 +4884,13 @@
       "shopify_product_id": null,
       "site_id": 1,
       "sku": null,
-      "temp_increment": "180/200/225/250/300/350/400/450/475/500",
-      "updated_at": "2024-08-12T21:12:21.000000Z"
+      "temp_increment": "180/200/225/250/300/350/400/450/475/500"
     },
     "PB820CS1": {
-      "app_layout": "standard",
       "category": null,
       "celsius_temp_increment": null,
       "control_board": "PBM",
       "control_board_id": 6,
-      "created_at": "2022-07-13T04:29:24.000000Z",
-      "deleted_at": null,
       "description": null,
       "enabled": true,
       "friendly_name": "",
@@ -6258,7 +4903,6 @@
       "image": null,
       "image_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/PB820CS1-2021-7-20-28.png",
       "lights": 0,
-      "manual_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-manuals/Competition/10922_10931_PB820CS1_owners_manual%20%285%29.pdf",
       "max_temp": "500",
       "meat_probes": 2,
       "min_temp": "180",
@@ -6270,17 +4914,13 @@
       "shopify_product_id": null,
       "site_id": 1,
       "sku": null,
-      "temp_increment": "180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420/425/430/435/440/445/450/455/460/465/470/475/480/485/490/495/500",
-      "updated_at": "2024-08-12T22:51:02.000000Z"
+      "temp_increment": "180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420/425/430/435/440/445/450/455/460/465/470/475/480/485/490/495/500"
     },
     "PB820D": {
-      "app_layout": "standard",
       "category": null,
       "celsius_temp_increment": null,
       "control_board": "PBV",
       "control_board_id": 4,
-      "created_at": "2022-07-13T04:29:24.000000Z",
-      "deleted_at": null,
       "description": null,
       "enabled": true,
       "friendly_name": "",
@@ -6293,7 +4933,6 @@
       "image": null,
       "image_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/PB820D.png",
       "lights": 0,
-      "manual_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-manuals/Standard/72820_PB820D_manualUSA_EN_FR_ES.pdf",
       "max_temp": "500",
       "meat_probes": 3,
       "min_temp": "180",
@@ -6305,17 +4944,13 @@
       "shopify_product_id": null,
       "site_id": 1,
       "sku": null,
-      "temp_increment": "180/200/225/250/300/350/400/450/475/500",
-      "updated_at": "2024-08-12T21:14:44.000000Z"
+      "temp_increment": "180/200/225/250/300/350/400/450/475/500"
     },
     "PB820D2": {
-      "app_layout": "standard",
       "category": null,
       "celsius_temp_increment": null,
       "control_board": "PBC",
       "control_board_id": 5,
-      "created_at": "2022-07-13T04:29:24.000000Z",
-      "deleted_at": null,
       "description": null,
       "enabled": true,
       "friendly_name": "",
@@ -6328,7 +4963,6 @@
       "image": null,
       "image_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/PB820D2-2019-1-7-abby-29.png",
       "lights": 0,
-      "manual_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-manuals/Standard/72460_PB820D2_manualCAN_EN_FR.pdf",
       "max_temp": "500",
       "meat_probes": 2,
       "min_temp": "180",
@@ -6340,17 +4974,13 @@
       "shopify_product_id": null,
       "site_id": 1,
       "sku": null,
-      "temp_increment": "180/200/225/250/300/350/400/450/475/500",
-      "updated_at": "2022-10-31T14:42:07.000000Z"
+      "temp_increment": "180/200/225/250/300/350/400/450/475/500"
     },
     "PB820D3": {
-      "app_layout": "standard",
       "category": null,
       "celsius_temp_increment": null,
       "control_board": "PBC",
       "control_board_id": 5,
-      "created_at": "2022-07-13T04:29:24.000000Z",
-      "deleted_at": null,
       "description": null,
       "enabled": true,
       "friendly_name": "",
@@ -6363,7 +4993,6 @@
       "image": null,
       "image_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/PB0820D3-2019-11-7-EN-AN-FR-116.png",
       "lights": 0,
-      "manual_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-manuals/Standard/10970_PB0820D3_manual_110V_EN_FR_ES.pdf",
       "max_temp": "500",
       "meat_probes": 2,
       "min_temp": "180",
@@ -6375,17 +5004,13 @@
       "shopify_product_id": null,
       "site_id": 1,
       "sku": null,
-      "temp_increment": "180/200/225/250/300/350/400/450/475/500",
-      "updated_at": "2024-08-12T22:28:59.000000Z"
+      "temp_increment": "180/200/225/250/300/350/400/450/475/500"
     },
     "PB820D4": {
-      "app_layout": "standard",
       "category": null,
       "celsius_temp_increment": null,
       "control_board": "PBC",
       "control_board_id": 5,
-      "created_at": "2022-07-13T04:29:24.000000Z",
-      "deleted_at": null,
       "description": null,
       "enabled": true,
       "friendly_name": "",
@@ -6398,7 +5023,6 @@
       "image": null,
       "image_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/PB820D4.png",
       "lights": 0,
-      "manual_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-manuals/Standard/10899_PB820D4_manual_110V_EN_FR_ES.pdf",
       "max_temp": "500",
       "meat_probes": 2,
       "min_temp": "180",
@@ -6410,17 +5034,13 @@
       "shopify_product_id": null,
       "site_id": 1,
       "sku": null,
-      "temp_increment": "180/200/225/250/300/350/400/450/475/500",
-      "updated_at": "2024-08-12T22:33:56.000000Z"
+      "temp_increment": "180/200/225/250/300/350/400/450/475/500"
     },
     "PB820FB": {
-      "app_layout": "standard",
       "category": null,
       "celsius_temp_increment": null,
       "control_board": "PBV",
       "control_board_id": 4,
-      "created_at": "2022-07-13T04:29:24.000000Z",
-      "deleted_at": null,
       "description": null,
       "enabled": true,
       "friendly_name": "",
@@ -6433,7 +5053,6 @@
       "image": null,
       "image_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/pb820fb.png",
       "lights": 0,
-      "manual_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-manuals/Standard/71820FB_PB820FB_manualUSA_EN_FR_ES.pdf",
       "max_temp": "500",
       "meat_probes": 3,
       "min_temp": "180",
@@ -6445,17 +5064,13 @@
       "shopify_product_id": null,
       "site_id": 1,
       "sku": null,
-      "temp_increment": "180/200/225/250/300/350/400/450/475/500",
-      "updated_at": "2024-08-12T22:16:15.000000Z"
+      "temp_increment": "180/200/225/250/300/350/400/450/475/500"
     },
     "PB820FBC": {
-      "app_layout": "standard",
       "category": null,
       "celsius_temp_increment": null,
       "control_board": "PBV",
       "control_board_id": 4,
-      "created_at": "2022-07-13T04:29:24.000000Z",
-      "deleted_at": null,
       "description": null,
       "enabled": true,
       "friendly_name": "",
@@ -6468,7 +5083,6 @@
       "image": null,
       "image_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/PB820FBC.png",
       "lights": 0,
-      "manual_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-manuals/Standard/71821_PB820FBC_manual_110V_EN_FR_ES.pdf",
       "max_temp": "500",
       "meat_probes": 3,
       "min_temp": "180",
@@ -6480,17 +5094,13 @@
       "shopify_product_id": null,
       "site_id": 1,
       "sku": null,
-      "temp_increment": "180/200/225/250/300/350/400/450/475/500",
-      "updated_at": "2024-08-12T22:16:32.000000Z"
+      "temp_increment": "180/200/225/250/300/350/400/450/475/500"
     },
     "PB820PS1": {
-      "app_layout": "standard",
       "category": null,
       "celsius_temp_increment": null,
       "control_board": "PBC",
       "control_board_id": 5,
-      "created_at": "2022-07-13T04:29:24.000000Z",
-      "deleted_at": null,
       "description": null,
       "enabled": true,
       "friendly_name": "",
@@ -6503,7 +5113,6 @@
       "image": null,
       "image_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/pb820ps1.png",
       "lights": 0,
-      "manual_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-manuals/Pro-Series/72770_PB820PS1_manualUSA_EN_FR_ES.pdf",
       "max_temp": "500",
       "meat_probes": 2,
       "min_temp": "180",
@@ -6515,17 +5124,13 @@
       "shopify_product_id": null,
       "site_id": 1,
       "sku": null,
-      "temp_increment": "180/200/225/250/300/350/400/450/475/500",
-      "updated_at": "2024-08-12T22:22:07.000000Z"
+      "temp_increment": "180/200/225/250/300/350/400/450/475/500"
     },
     "PB820S": {
-      "app_layout": "standard",
       "category": null,
       "celsius_temp_increment": null,
       "control_board": "PBV",
       "control_board_id": 4,
-      "created_at": "2022-07-13T04:29:24.000000Z",
-      "deleted_at": null,
       "description": null,
       "enabled": true,
       "friendly_name": "",
@@ -6538,7 +5143,6 @@
       "image": null,
       "image_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/pb_820S.png",
       "lights": 0,
-      "manual_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-manuals/Standard/PB820S_manual_USA.pdf",
       "max_temp": "500",
       "meat_probes": 3,
       "min_temp": "180",
@@ -6550,17 +5154,13 @@
       "shopify_product_id": null,
       "site_id": 1,
       "sku": null,
-      "temp_increment": "180/200/225/250/300/350/400/450/475/500",
-      "updated_at": "2024-08-12T22:15:45.000000Z"
+      "temp_increment": "180/200/225/250/300/350/400/450/475/500"
     },
     "PB820SC": {
-      "app_layout": "standard",
       "category": null,
       "celsius_temp_increment": null,
       "control_board": "PBV",
       "control_board_id": 4,
-      "created_at": "2022-07-13T04:29:24.000000Z",
-      "deleted_at": null,
       "description": null,
       "enabled": true,
       "friendly_name": "",
@@ -6573,7 +5173,6 @@
       "image": null,
       "image_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/PB820SC.png",
       "lights": 0,
-      "manual_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-manuals/Standard/72820SC_PB820SC_manual_110V_EN_FR_ES.pdf",
       "max_temp": "500",
       "meat_probes": 3,
       "min_temp": "180",
@@ -6585,17 +5184,13 @@
       "shopify_product_id": null,
       "site_id": 1,
       "sku": null,
-      "temp_increment": "180/200/225/250/300/350/400/450/475/500",
-      "updated_at": "2024-08-12T22:17:09.000000Z"
+      "temp_increment": "180/200/225/250/300/350/400/450/475/500"
     },
     "PB820T1": {
-      "app_layout": "standard",
       "category": null,
       "celsius_temp_increment": null,
       "control_board": "PBV",
       "control_board_id": 4,
-      "created_at": "2022-07-13T04:29:24.000000Z",
-      "deleted_at": null,
       "description": null,
       "enabled": true,
       "friendly_name": "",
@@ -6608,7 +5203,6 @@
       "image": null,
       "image_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/PB820T1.png",
       "lights": 0,
-      "manual_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-manuals/Traditional/PB820T1_manual_USA_EN_FR.pdf",
       "max_temp": "500",
       "meat_probes": 3,
       "min_temp": "180",
@@ -6620,17 +5214,13 @@
       "shopify_product_id": null,
       "site_id": 1,
       "sku": null,
-      "temp_increment": "180/200/225/250/300/350/400/450/475/500",
-      "updated_at": "2024-08-12T21:17:25.000000Z"
+      "temp_increment": "180/200/225/250/300/350/400/450/475/500"
     },
     "PB820XL/PB820ME": {
-      "app_layout": "standard",
       "category": null,
       "celsius_temp_increment": null,
       "control_board": "PBC",
       "control_board_id": 5,
-      "created_at": "2022-07-13T04:29:24.000000Z",
-      "deleted_at": null,
       "description": null,
       "enabled": true,
       "friendly_name": "",
@@ -6643,7 +5233,6 @@
       "image": null,
       "image_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/820xl.png",
       "lights": 0,
-      "manual_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-manuals/Standard/10589_PB820XL_manual_110V_EN_FR.pdf",
       "max_temp": "500",
       "meat_probes": 2,
       "min_temp": "180",
@@ -6655,17 +5244,13 @@
       "shopify_product_id": null,
       "site_id": 1,
       "sku": null,
-      "temp_increment": "180/200/225/250/300/350/400/450/475/500",
-      "updated_at": "2024-08-12T22:24:08.000000Z"
+      "temp_increment": "180/200/225/250/300/350/400/450/475/500"
     },
     "PB850AMB": {
-      "app_layout": "standard",
       "category": null,
       "celsius_temp_increment": null,
       "control_board": "PBM",
       "control_board_id": 6,
-      "created_at": "2025-04-23T21:48:42.000000Z",
-      "deleted_at": null,
       "description": null,
       "enabled": true,
       "friendly_name": null,
@@ -6678,7 +5263,6 @@
       "image": null,
       "image_url": "https://dansons-mobile.s3.dualstack.us-east-1.amazonaws.com/grill-images/PB850AMB.png",
       "lights": 0,
-      "manual_url": "https://dansons-mobile.s3.dualstack.us-east-1.amazonaws.com/grill-manuals/Ambiance/11141_PB850AMB_owners_manual.pdf",
       "max_temp": "500",
       "meat_probes": 2,
       "min_temp": "180",
@@ -6690,17 +5274,13 @@
       "shopify_product_id": null,
       "site_id": 1,
       "sku": null,
-      "temp_increment": "180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420/425/430/435/440/445/450/455/460/465/470/475/480/485/490/495/500",
-      "updated_at": "2025-04-24T15:57:40.000000Z"
+      "temp_increment": "180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420/425/430/435/440/445/450/455/460/465/470/475/480/485/490/495/500"
     },
     "PB850CS1": {
-      "app_layout": "standard",
       "category": null,
       "celsius_temp_increment": null,
       "control_board": "PBM",
       "control_board_id": 6,
-      "created_at": "2023-07-06T08:48:37.000000Z",
-      "deleted_at": null,
       "description": null,
       "enabled": true,
       "friendly_name": "",
@@ -6713,7 +5293,6 @@
       "image": null,
       "image_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/PB820CS1-2021-7-20-28.png",
       "lights": 0,
-      "manual_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-manuals/Competition/10922_10931_PB850CS1_Manual_110V_EN_FR_ES.pdf",
       "max_temp": "500",
       "meat_probes": 2,
       "min_temp": "180",
@@ -6725,17 +5304,13 @@
       "shopify_product_id": null,
       "site_id": 1,
       "sku": null,
-      "temp_increment": "180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420/425/430/435/440/445/450/455/460/465/470/475/480/485/490/495/500",
-      "updated_at": "2024-08-12T23:11:37.000000Z"
+      "temp_increment": "180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420/425/430/435/440/445/450/455/460/465/470/475/480/485/490/495/500"
     },
     "PB850CS2": {
-      "app_layout": "standard",
       "category": null,
       "celsius_temp_increment": null,
       "control_board": "PBM2",
       "control_board_id": 20,
-      "created_at": "2025-07-28T21:12:02.000000Z",
-      "deleted_at": null,
       "description": null,
       "enabled": true,
       "friendly_name": null,
@@ -6748,7 +5323,6 @@
       "image": null,
       "image_url": "https://dansons-mobile.s3.dualstack.us-east-1.amazonaws.com/grill-images/PB850CS2.2.png",
       "lights": 0,
-      "manual_url": "https://dansons-mobile.s3.dualstack.us-east-1.amazonaws.com/grill-manuals/Competition/11129_PB850CS2_owners_manual_bleed_20240925.pdf",
       "max_temp": "500",
       "meat_probes": 2,
       "min_temp": "180",
@@ -6760,17 +5334,13 @@
       "shopify_product_id": null,
       "site_id": 1,
       "sku": null,
-      "temp_increment": "180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420/425/430/435/440/445/450/455/460/465/470/475/480/485/490/495/500",
-      "updated_at": "2025-07-28T21:12:28.000000Z"
+      "temp_increment": "180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420/425/430/435/440/445/450/455/460/465/470/475/480/485/490/495/500"
     },
     "PB850CS2 (PBM)": {
-      "app_layout": "standard",
       "category": null,
       "celsius_temp_increment": null,
       "control_board": "PBM",
       "control_board_id": 6,
-      "created_at": "2025-01-22T23:01:26.000000Z",
-      "deleted_at": null,
       "description": null,
       "enabled": true,
       "friendly_name": null,
@@ -6783,7 +5353,6 @@
       "image": null,
       "image_url": "https://dansons-mobile.s3.dualstack.us-east-1.amazonaws.com/grill-images/PB850CS2.2.png",
       "lights": 0,
-      "manual_url": "https://dansons-mobile.s3.dualstack.us-east-1.amazonaws.com/grill-manuals/Competition/11129_PB850CS2_owners_manual_bleed_20240925.pdf",
       "max_temp": "500",
       "meat_probes": 2,
       "min_temp": "180",
@@ -6795,17 +5364,13 @@
       "shopify_product_id": null,
       "site_id": 1,
       "sku": null,
-      "temp_increment": "180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420/425/430/435/440/445/450/455/460/465/470/475/480/485/490/495/500",
-      "updated_at": "2025-01-22T23:01:26.000000Z"
+      "temp_increment": "180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420/425/430/435/440/445/450/455/460/465/470/475/480/485/490/495/500"
     },
     "PB850DX": {
-      "app_layout": "standard",
       "category": null,
       "celsius_temp_increment": null,
       "control_board": "PBL3",
       "control_board_id": 21,
-      "created_at": "2025-07-17T19:17:03.000000Z",
-      "deleted_at": null,
       "description": null,
       "enabled": true,
       "friendly_name": null,
@@ -6818,7 +5383,6 @@
       "image": null,
       "image_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/PB850DX.png",
       "lights": 0,
-      "manual_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-manuals/DX-Series/11077_11080_PB850DX_owners_manual.pdf",
       "max_temp": "500",
       "meat_probes": 2,
       "min_temp": "180",
@@ -6830,17 +5394,13 @@
       "shopify_product_id": null,
       "site_id": 1,
       "sku": null,
-      "temp_increment": "180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420/425/430/435/440/445/450/455/460/465/470/475/480/485/490/495/500",
-      "updated_at": "2025-07-22T21:33:15.000000Z"
+      "temp_increment": "180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420/425/430/435/440/445/450/455/460/465/470/475/480/485/490/495/500"
     },
     "PB850DX (PBL2)": {
-      "app_layout": "standard",
       "category": "grill",
       "celsius_temp_increment": null,
       "control_board": "PBL2",
       "control_board_id": 16,
-      "created_at": "2024-05-20T21:08:46.000000Z",
-      "deleted_at": null,
       "description": null,
       "enabled": true,
       "friendly_name": null,
@@ -6853,7 +5413,6 @@
       "image": null,
       "image_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/PB850DX.png",
       "lights": 0,
-      "manual_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-manuals/DX-Series/11077_11080_PB850DX_owners_manual.pdf",
       "max_temp": "500",
       "meat_probes": 2,
       "min_temp": "180",
@@ -6865,17 +5424,13 @@
       "shopify_product_id": null,
       "site_id": 1,
       "sku": null,
-      "temp_increment": "180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420/425/430/435/440/445/450/455/460/465/470/475/480/485/490/495/500",
-      "updated_at": "2026-06-08T21:05:07.000000Z"
+      "temp_increment": "180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420/425/430/435/440/445/450/455/460/465/470/475/480/485/490/495/500"
     },
     "PB850G/GW": {
-      "app_layout": "standard",
       "category": null,
       "celsius_temp_increment": null,
       "control_board": "PBC",
       "control_board_id": 5,
-      "created_at": "2022-07-13T04:29:24.000000Z",
-      "deleted_at": null,
       "description": null,
       "enabled": true,
       "friendly_name": "",
@@ -6888,7 +5443,6 @@
       "image": null,
       "image_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/850-nav-109.png",
       "lights": 0,
-      "manual_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-manuals/Navigator/PB550G_PB700G_PB850G_PB1150G_OwnersManual_110V_EN_FR_ES.pdf",
       "max_temp": "500",
       "meat_probes": 2,
       "min_temp": "180",
@@ -6900,17 +5454,13 @@
       "shopify_product_id": null,
       "site_id": 1,
       "sku": null,
-      "temp_increment": "180/200/225/250/300/350/400/450/475/500",
-      "updated_at": "2024-08-12T22:33:14.000000Z"
+      "temp_increment": "180/200/225/250/300/350/400/450/475/500"
     },
     "PB850M": {
-      "app_layout": "standard",
       "category": null,
       "celsius_temp_increment": null,
       "control_board": "PBM2",
       "control_board_id": 20,
-      "created_at": "2025-09-17T16:44:05.000000Z",
-      "deleted_at": null,
       "description": null,
       "enabled": true,
       "friendly_name": null,
@@ -6923,7 +5473,6 @@
       "image": null,
       "image_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/PB850M.png",
       "lights": 0,
-      "manual_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-manuals/M-Line/11111_PB850M_owners_manual.pdf",
       "max_temp": "500",
       "meat_probes": 2,
       "min_temp": "180",
@@ -6935,17 +5484,13 @@
       "shopify_product_id": null,
       "site_id": 1,
       "sku": null,
-      "temp_increment": "180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420/425/430/435/440/445/450/455/460/465/470/475/480/485/490/495/500",
-      "updated_at": "2025-09-17T16:53:18.000000Z"
+      "temp_increment": "180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420/425/430/435/440/445/450/455/460/465/470/475/480/485/490/495/500"
     },
     "PB850M (PBM)": {
-      "app_layout": "standard",
       "category": null,
       "celsius_temp_increment": null,
       "control_board": "PBM",
       "control_board_id": 6,
-      "created_at": "2024-09-17T21:34:20.000000Z",
-      "deleted_at": null,
       "description": null,
       "enabled": true,
       "friendly_name": null,
@@ -6958,7 +5503,6 @@
       "image": null,
       "image_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/PB850M.png",
       "lights": 0,
-      "manual_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-manuals/M-Line/11111_PB850M_owners_manual.pdf",
       "max_temp": "500",
       "meat_probes": 2,
       "min_temp": "180",
@@ -6970,17 +5514,13 @@
       "shopify_product_id": null,
       "site_id": 1,
       "sku": null,
-      "temp_increment": "180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420/425/430/435/440/445/450/455/460/465/470/475/480/485/490/495/500",
-      "updated_at": "2024-09-17T21:34:20.000000Z"
+      "temp_increment": "180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420/425/430/435/440/445/450/455/460/465/470/475/480/485/490/495/500"
     },
     "PB850PS2": {
-      "app_layout": "standard",
       "category": null,
       "celsius_temp_increment": null,
       "control_board": "PBL",
       "control_board_id": 1,
-      "created_at": "2022-07-13T04:29:24.000000Z",
-      "deleted_at": null,
       "description": null,
       "enabled": true,
       "friendly_name": "",
@@ -6993,7 +5533,6 @@
       "image": null,
       "image_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/PB850PS2-2020-5-26-107.png",
       "lights": 0,
-      "manual_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-manuals/Pro-Series/10831_PB850PS2_manual_230V_ML.pdf",
       "max_temp": "500",
       "meat_probes": 2,
       "min_temp": "180",
@@ -7005,17 +5544,13 @@
       "shopify_product_id": null,
       "site_id": 1,
       "sku": null,
-      "temp_increment": "180/190/200/210/220/230/240/250/260/270/280/290/300/325/350/375/400/450/500",
-      "updated_at": "2024-08-12T20:25:42.000000Z"
+      "temp_increment": "180/190/200/210/220/230/240/250/260/270/280/290/300/325/350/375/400/450/500"
     },
     "PB850SPW2": {
-      "app_layout": "standard",
       "category": null,
       "celsius_temp_increment": null,
       "control_board": "PBC2",
       "control_board_id": 17,
-      "created_at": "2024-09-10T15:28:26.000000Z",
-      "deleted_at": null,
       "description": null,
       "enabled": true,
       "friendly_name": null,
@@ -7028,7 +5563,6 @@
       "image": null,
       "image_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/PB850SPW2.png",
       "lights": 0,
-      "manual_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-manuals/Sportsman/11106_PB850SPW2_owners_manual.pdf",
       "max_temp": "500",
       "meat_probes": 2,
       "min_temp": "180",
@@ -7040,17 +5574,13 @@
       "shopify_product_id": null,
       "site_id": 1,
       "sku": null,
-      "temp_increment": "180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420/425/430/435/440/445/450/455/460/465/470/475/480/485/490/495/500",
-      "updated_at": "2024-09-10T18:24:56.000000Z"
+      "temp_increment": "180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420/425/430/435/440/445/450/455/460/465/470/475/480/485/490/495/500"
     },
     "PBV3 M": {
-      "app_layout": "standard",
       "category": null,
       "celsius_temp_increment": null,
       "control_board": "PBV2",
       "control_board_id": 18,
-      "created_at": "2025-06-09T16:32:25.000000Z",
-      "deleted_at": null,
       "description": null,
       "enabled": true,
       "friendly_name": null,
@@ -7063,7 +5593,6 @@
       "image": null,
       "image_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/PBV3M.png",
       "lights": 0,
-      "manual_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-manuals/M-Line/11114_PBV3M_owners_manual.pdf",
       "max_temp": "420",
       "meat_probes": 3,
       "min_temp": "130",
@@ -7075,17 +5604,13 @@
       "shopify_product_id": null,
       "site_id": 1,
       "sku": null,
-      "temp_increment": "130/135/140/145/150/155/160/165/170/175/180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420",
-      "updated_at": "2025-06-09T16:32:25.000000Z"
+      "temp_increment": "130/135/140/145/150/155/160/165/170/175/180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420"
     },
     "PBV30DS": {
-      "app_layout": "standard",
       "category": null,
       "celsius_temp_increment": "40/45/50/55/60/65/70/75/80/85/90/95/100/105/110/115/120/125/130/135/140/145/150",
       "control_board": "PBVA",
       "control_board_id": 19,
-      "created_at": "2025-04-24T17:26:07.000000Z",
-      "deleted_at": null,
       "description": null,
       "enabled": true,
       "friendly_name": null,
@@ -7098,7 +5623,6 @@
       "image": null,
       "image_url": "https://dansons-mobile.s3.dualstack.us-east-1.amazonaws.com/grill-images/PBV30DS_DTC.png",
       "lights": 0,
-      "manual_url": null,
       "max_temp": "320",
       "meat_probes": 2,
       "min_temp": "100",
@@ -7110,17 +5634,13 @@
       "shopify_product_id": null,
       "site_id": 1,
       "sku": null,
-      "temp_increment": "100/105/110/115/120/125/130/135/140/145/150/155/160/165/170/175/180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300",
-      "updated_at": "2025-11-11T16:47:42.000000Z"
+      "temp_increment": "100/105/110/115/120/125/130/135/140/145/150/155/160/165/170/175/180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300"
     },
     "PBV30DX": {
-      "app_layout": "standard",
       "category": null,
       "celsius_temp_increment": "40/45/50/55/60/65/70/75/80/85/90/95/100/105/110/115/120/125/130/135/140/145/150",
       "control_board": "PBVA",
       "control_board_id": 19,
-      "created_at": "2025-05-15T18:57:54.000000Z",
-      "deleted_at": null,
       "description": null,
       "enabled": true,
       "friendly_name": null,
@@ -7133,7 +5653,6 @@
       "image": null,
       "image_url": "https://dansons-mobile.s3.dualstack.us-east-1.amazonaws.com/grill-images/PBV30DS_DX.png",
       "lights": 0,
-      "manual_url": null,
       "max_temp": "320",
       "meat_probes": 2,
       "min_temp": "100",
@@ -7145,17 +5664,13 @@
       "shopify_product_id": null,
       "site_id": 1,
       "sku": null,
-      "temp_increment": "100/105/110/115/120/125/130/135/140/145/150/155/160/165/170/175/180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300",
-      "updated_at": "2025-11-11T16:48:26.000000Z"
+      "temp_increment": "100/105/110/115/120/125/130/135/140/145/150/155/160/165/170/175/180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300"
     },
     "PBV3M": {
-      "app_layout": "standard",
       "category": null,
       "celsius_temp_increment": null,
       "control_board": "PBV",
       "control_board_id": 4,
-      "created_at": "2024-08-29T23:09:07.000000Z",
-      "deleted_at": null,
       "description": null,
       "enabled": true,
       "friendly_name": null,
@@ -7168,7 +5683,6 @@
       "image": null,
       "image_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/PBV3M.png",
       "lights": 0,
-      "manual_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-manuals/M-Line/11114_PBV3M_owners_manual.pdf",
       "max_temp": "420",
       "meat_probes": 3,
       "min_temp": "130",
@@ -7180,17 +5694,13 @@
       "shopify_product_id": null,
       "site_id": 1,
       "sku": null,
-      "temp_increment": "130/135/140/145/150/155/160/165/170/175/180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420",
-      "updated_at": "2024-09-18T15:30:09.000000Z"
+      "temp_increment": "130/135/140/145/150/155/160/165/170/175/180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420"
     },
     "PBV3NX": {
-      "app_layout": "standard",
       "category": null,
       "celsius_temp_increment": null,
       "control_board": "PBV2",
       "control_board_id": 18,
-      "created_at": "2025-09-23T16:19:31.000000Z",
-      "deleted_at": null,
       "description": null,
       "enabled": true,
       "friendly_name": null,
@@ -7203,7 +5713,6 @@
       "image": null,
       "image_url": "https://dansons-mobile.s3.dualstack.us-east-1.amazonaws.com/grill-images/PBV3NX.1.png",
       "lights": 0,
-      "manual_url": "https://dansons-mobile.s3.dualstack.us-east-1.amazonaws.com/grill-manuals/Onyx/11140_PBV3NX_owners_manual.pdf",
       "max_temp": "420",
       "meat_probes": 3,
       "min_temp": "130",
@@ -7215,17 +5724,13 @@
       "shopify_product_id": null,
       "site_id": 1,
       "sku": null,
-      "temp_increment": "130/135/140/145/150/155/160/165/170/175/180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420",
-      "updated_at": "2025-09-23T16:20:07.000000Z"
+      "temp_increment": "130/135/140/145/150/155/160/165/170/175/180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420"
     },
     "PBV3NX (PBV)": {
-      "app_layout": "standard",
       "category": null,
       "celsius_temp_increment": null,
       "control_board": "PBV",
       "control_board_id": 4,
-      "created_at": "2025-04-29T22:43:05.000000Z",
-      "deleted_at": null,
       "description": null,
       "enabled": true,
       "friendly_name": null,
@@ -7238,7 +5743,6 @@
       "image": null,
       "image_url": "https://dansons-mobile.s3.dualstack.us-east-1.amazonaws.com/grill-images/PBV3NX.1.png",
       "lights": 0,
-      "manual_url": "https://dansons-mobile.s3.dualstack.us-east-1.amazonaws.com/grill-manuals/Onyx/11140_PBV3NX_owners_manual.pdf",
       "max_temp": "420",
       "meat_probes": 3,
       "min_temp": "130",
@@ -7250,17 +5754,13 @@
       "shopify_product_id": null,
       "site_id": 1,
       "sku": null,
-      "temp_increment": "130/135/140/145/150/155/160/165/170/175/180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420",
-      "updated_at": "2025-04-29T22:43:05.000000Z"
+      "temp_increment": "130/135/140/145/150/155/160/165/170/175/180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420"
     },
     "PBV4DX": {
-      "app_layout": "standard",
       "category": null,
       "celsius_temp_increment": null,
       "control_board": "PBL3",
       "control_board_id": 21,
-      "created_at": "2025-06-26T21:32:02.000000Z",
-      "deleted_at": null,
       "description": null,
       "enabled": true,
       "friendly_name": "",
@@ -7273,7 +5773,6 @@
       "image": null,
       "image_url": "https://dansons-mobile.s3.dualstack.us-east-1.amazonaws.com/grill-images/PBV4DX.png",
       "lights": 0,
-      "manual_url": null,
       "max_temp": "420",
       "meat_probes": 2,
       "min_temp": "130",
@@ -7285,17 +5784,13 @@
       "shopify_product_id": null,
       "site_id": 1,
       "sku": null,
-      "temp_increment": "130/135/140/145/150/155/160/165/170/175/180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420",
-      "updated_at": "2026-07-21T21:20:53.000000Z"
+      "temp_increment": "130/135/140/145/150/155/160/165/170/175/180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420"
     },
     "PBV4NXW": {
-      "app_layout": "standard",
       "category": null,
       "celsius_temp_increment": null,
       "control_board": "PBV",
       "control_board_id": 4,
-      "created_at": "2024-09-10T22:40:49.000000Z",
-      "deleted_at": null,
       "description": null,
       "enabled": true,
       "friendly_name": null,
@@ -7308,7 +5803,6 @@
       "image": null,
       "image_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/PBV4NX.png",
       "lights": 0,
-      "manual_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-manuals/Onyx/11084_PBV4NXW_owners_manual.pdf",
       "max_temp": "420",
       "meat_probes": 3,
       "min_temp": "130",
@@ -7320,17 +5814,13 @@
       "shopify_product_id": null,
       "site_id": 1,
       "sku": null,
-      "temp_increment": "130/135/140/145/150/160/170/180/190/200/210/220/230/240/250/260/270/280/290/300/310/320/330/340/350/360/370/380/390/400/410/420",
-      "updated_at": "2024-09-13T16:48:43.000000Z"
+      "temp_increment": "130/135/140/145/150/160/170/180/190/200/210/220/230/240/250/260/270/280/290/300/310/320/330/340/350/360/370/380/390/400/410/420"
     },
     "PBV4PS2": {
-      "app_layout": "standard",
       "category": null,
       "celsius_temp_increment": null,
       "control_board": "PBL",
       "control_board_id": 1,
-      "created_at": "2022-07-13T04:29:24.000000Z",
-      "deleted_at": null,
       "description": null,
       "enabled": true,
       "friendly_name": "",
@@ -7343,7 +5833,6 @@
       "image": null,
       "image_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/PBV4PS2.png",
       "lights": 0,
-      "manual_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-manuals/Pro-Series/10803_PBV4PS2_manual_230V_ML.pdf",
       "max_temp": "420",
       "meat_probes": 2,
       "min_temp": "130",
@@ -7355,17 +5844,13 @@
       "shopify_product_id": null,
       "site_id": 1,
       "sku": null,
-      "temp_increment": "130/140/150/160/170/180/190/200/210/220/230/240/250/260/270/280/290/300/310/320/330/340/350/360/370/380/390/400/410/420",
-      "updated_at": "2024-08-12T20:25:22.000000Z"
+      "temp_increment": "130/140/150/160/170/180/190/200/210/220/230/240/250/260/270/280/290/300/310/320/330/340/350/360/370/380/390/400/410/420"
     },
     "PBV5 P2": {
-      "app_layout": "standard",
       "category": null,
       "celsius_temp_increment": null,
       "control_board": "PBV2",
       "control_board_id": 18,
-      "created_at": "2025-06-03T20:43:35.000000Z",
-      "deleted_at": null,
       "description": null,
       "enabled": true,
       "friendly_name": null,
@@ -7378,7 +5863,6 @@
       "image": null,
       "image_url": "https://dansons-mobile.s3.dualstack.us-east-1.amazonaws.com/grill-images/ghost%20vertical.png",
       "lights": 0,
-      "manual_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-manuals/Competition/10903_10904_PBV5P2_owners_manual.pdf",
       "max_temp": "420",
       "meat_probes": 3,
       "min_temp": "130",
@@ -7390,17 +5874,13 @@
       "shopify_product_id": null,
       "site_id": 1,
       "sku": null,
-      "temp_increment": "130/135/140/145/150/155/160/165/170/175/180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420",
-      "updated_at": "2025-09-24T17:36:29.000000Z"
+      "temp_increment": "130/135/140/145/150/155/160/165/170/175/180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420"
     },
     "PBV5CS": {
-      "app_layout": "standard",
       "category": null,
       "celsius_temp_increment": null,
       "control_board": "PBC",
       "control_board_id": 5,
-      "created_at": "2022-07-13T04:29:24.000000Z",
-      "deleted_at": null,
       "description": null,
       "enabled": true,
       "friendly_name": "",
@@ -7413,7 +5893,6 @@
       "image": null,
       "image_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/PBV5CS1-2021-6-17-121.png",
       "lights": 0,
-      "manual_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-manuals/Competition/10924_PBV5CS_OwnersManual_110V_EN_FR_ES.pdf",
       "max_temp": "420",
       "meat_probes": 2,
       "min_temp": "150",
@@ -7425,17 +5904,13 @@
       "shopify_product_id": null,
       "site_id": 1,
       "sku": null,
-      "temp_increment": "150/155/160/165/170/175/180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420",
-      "updated_at": "2024-08-12T22:43:23.000000Z"
+      "temp_increment": "150/155/160/165/170/175/180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420"
     },
     "PBV5P2": {
-      "app_layout": "standard",
       "category": null,
       "celsius_temp_increment": null,
       "control_board": "PBV",
       "control_board_id": 4,
-      "created_at": "2022-11-30T12:05:56.000000Z",
-      "deleted_at": null,
       "description": null,
       "enabled": true,
       "friendly_name": null,
@@ -7448,7 +5923,6 @@
       "image": null,
       "image_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/V5%20Competition.png",
       "lights": 0,
-      "manual_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-manuals/Competition/10903_10904_PBV5P2_owners_manual.pdf",
       "max_temp": "420",
       "meat_probes": 3,
       "min_temp": "130",
@@ -7460,17 +5934,13 @@
       "shopify_product_id": null,
       "site_id": 1,
       "sku": null,
-      "temp_increment": "130/135/140/145/150/155/160/165/170/175/180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420",
-      "updated_at": "2024-09-17T22:06:02.000000Z"
+      "temp_increment": "130/135/140/145/150/155/160/165/170/175/180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420"
     },
     "PBV5PL": {
-      "app_layout": "standard",
       "category": null,
       "celsius_temp_increment": null,
       "control_board": "PBG",
       "control_board_id": 3,
-      "created_at": "2022-07-13T04:29:24.000000Z",
-      "deleted_at": null,
       "description": null,
       "enabled": true,
       "friendly_name": "",
@@ -7483,7 +5953,6 @@
       "image": null,
       "image_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/PBV5PL-2020-5-6-Brunswick-104.png",
       "lights": 1,
-      "manual_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-manuals/Platinum-Series/10577_10932_PBV5PL_manual_110V_EN_FR_ES.pdf",
       "max_temp": "420",
       "meat_probes": 2,
       "min_temp": "150",
@@ -7495,17 +5964,13 @@
       "shopify_product_id": null,
       "site_id": 1,
       "sku": null,
-      "temp_increment": "150/160/170/180/190/200/210/220/230/240/250/260/270/280/290/300/310/320/330/340/350/360/370/380/390/400/410/420",
-      "updated_at": "2024-08-12T20:19:39.000000Z"
+      "temp_increment": "150/160/170/180/190/200/210/220/230/240/250/260/270/280/290/300/310/320/330/340/350/360/370/380/390/400/410/420"
     },
     "PBV6 M": {
-      "app_layout": "standard",
       "category": null,
       "celsius_temp_increment": null,
       "control_board": "PBV2",
       "control_board_id": 18,
-      "created_at": "2025-06-09T16:34:42.000000Z",
-      "deleted_at": null,
       "description": null,
       "enabled": true,
       "friendly_name": null,
@@ -7518,7 +5983,6 @@
       "image": null,
       "image_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/PBV6M.png",
       "lights": 0,
-      "manual_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-manuals/M-Line/11115_PBV6M_owners_manual.pdf",
       "max_temp": "420",
       "meat_probes": 3,
       "min_temp": "130",
@@ -7530,17 +5994,13 @@
       "shopify_product_id": null,
       "site_id": 1,
       "sku": null,
-      "temp_increment": "130/135/140/145/150/155/160/165/170/175/180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420",
-      "updated_at": "2025-06-09T16:34:42.000000Z"
+      "temp_increment": "130/135/140/145/150/155/160/165/170/175/180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420"
     },
     "PBV6 PSE": {
-      "app_layout": "standard",
       "category": null,
       "celsius_temp_increment": null,
       "control_board": "PBD",
       "control_board_id": 12,
-      "created_at": "2023-02-01T16:41:44.000000Z",
-      "deleted_at": null,
       "description": null,
       "enabled": true,
       "friendly_name": "",
@@ -7553,7 +6013,6 @@
       "image": null,
       "image_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/V6%20Elite.png",
       "lights": 0,
-      "manual_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-manuals/Pro-Series/11007_PBV6PSE_manual_EN_FR_ES.pdf",
       "max_temp": "420",
       "meat_probes": 2,
       "min_temp": "130",
@@ -7565,17 +6024,13 @@
       "shopify_product_id": null,
       "site_id": 1,
       "sku": null,
-      "temp_increment": "130/135/140/145/150/155/160/165/170/175/180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420",
-      "updated_at": "2024-08-13T16:25:31.000000Z"
+      "temp_increment": "130/135/140/145/150/155/160/165/170/175/180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420"
     },
     "PBV6M": {
-      "app_layout": "standard",
       "category": null,
       "celsius_temp_increment": null,
       "control_board": "PBV",
       "control_board_id": 4,
-      "created_at": "2024-09-17T22:03:15.000000Z",
-      "deleted_at": null,
       "description": null,
       "enabled": true,
       "friendly_name": null,
@@ -7588,7 +6043,6 @@
       "image": null,
       "image_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/PBV6M.png",
       "lights": 0,
-      "manual_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-manuals/M-Line/11115_PBV6M_owners_manual.pdf",
       "max_temp": "420",
       "meat_probes": 3,
       "min_temp": "130",
@@ -7600,17 +6054,13 @@
       "shopify_product_id": null,
       "site_id": 1,
       "sku": null,
-      "temp_increment": "130/135/140/145/150/155/160/165/170/175/180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420",
-      "updated_at": "2024-09-17T22:03:15.000000Z"
+      "temp_increment": "130/135/140/145/150/155/160/165/170/175/180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420"
     },
     "PBV6PSE": {
-      "app_layout": "standard",
       "category": null,
       "celsius_temp_increment": null,
       "control_board": "PBB",
       "control_board_id": 11,
-      "created_at": "2022-11-09T23:21:31.000000Z",
-      "deleted_at": null,
       "description": null,
       "enabled": true,
       "friendly_name": "",
@@ -7623,7 +6073,6 @@
       "image": null,
       "image_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/V6%20Elite.png",
       "lights": 1,
-      "manual_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-manuals/Pro-Series/11007_PBV6PSE_manual_EN_FR_ES.pdf",
       "max_temp": "420",
       "meat_probes": 2,
       "min_temp": "130",
@@ -7635,17 +6084,13 @@
       "shopify_product_id": null,
       "site_id": 1,
       "sku": null,
-      "temp_increment": "130/135/140/145/150/155/160/165/170/175/180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420",
-      "updated_at": "2024-08-12T22:56:03.000000Z"
+      "temp_increment": "130/135/140/145/150/155/160/165/170/175/180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420"
     },
     "PBV7P2": {
-      "app_layout": "standard",
       "category": null,
       "celsius_temp_increment": null,
       "control_board": "PBV2",
       "control_board_id": 18,
-      "created_at": "2025-09-23T16:46:51.000000Z",
-      "deleted_at": null,
       "description": null,
       "enabled": true,
       "friendly_name": null,
@@ -7658,7 +6103,6 @@
       "image": null,
       "image_url": "Https://dansons-mobile.s3.dualstack.us-east-1.amazonaws.com/grill-images/PBV7P2.png",
       "lights": 0,
-      "manual_url": "Https://dansons-mobile.s3.dualstack.us-east-1.amazonaws.com/grill-manuals/Sportsman/11110_PBV7P2_owners_manual.pdf",
       "max_temp": "420",
       "meat_probes": 3,
       "min_temp": "130",
@@ -7670,17 +6114,13 @@
       "shopify_product_id": null,
       "site_id": 1,
       "sku": null,
-      "temp_increment": "130/135/140/145/150/155/160/165/170/175/180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420",
-      "updated_at": "2025-09-24T15:58:50.000000Z"
+      "temp_increment": "130/135/140/145/150/155/160/165/170/175/180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420"
     },
     "PBV7PW1": {
-      "app_layout": "standard",
       "category": null,
       "celsius_temp_increment": null,
       "control_board": "PBC",
       "control_board_id": 5,
-      "created_at": "2022-07-13T04:29:24.000000Z",
-      "deleted_at": null,
       "description": null,
       "enabled": true,
       "friendly_name": "",
@@ -7693,7 +6133,6 @@
       "image": null,
       "image_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/PBV7PW1_Sportsman-2021-6-30-controller123.png",
       "lights": 0,
-      "manual_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-manuals/Sportsman/10912_PBV7PW1_manual_110V_EN_FR_ES.pdf",
       "max_temp": "420",
       "meat_probes": 2,
       "min_temp": "150",
@@ -7705,17 +6144,13 @@
       "shopify_product_id": null,
       "site_id": 1,
       "sku": null,
-      "temp_increment": "150/155/160/165/170/175/180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420",
-      "updated_at": "2024-08-12T23:12:00.000000Z"
+      "temp_increment": "150/155/160/165/170/175/180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420"
     },
     "PBX - test 1": {
-      "app_layout": "standard",
       "category": "N/A",
       "celsius_temp_increment": null,
       "control_board": "PBX1",
       "control_board_id": 14,
-      "created_at": "2023-09-21T18:56:38.000000Z",
-      "deleted_at": null,
       "description": "<p>develpment</p>",
       "enabled": true,
       "friendly_name": "",
@@ -7728,7 +6163,6 @@
       "image": null,
       "image_url": "https://dansons-mobile.s3.us-east-1.amazonaws.com/grill-images/PB1600PS3.png",
       "lights": 0,
-      "manual_url": null,
       "max_temp": "500",
       "meat_probes": 2,
       "min_temp": "180",
@@ -7740,8 +6174,7 @@
       "shopify_product_id": "xxxx",
       "site_id": 1,
       "sku": "xxxx",
-      "temp_increment": "180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420/425/430/435/440/445/450/455/460/465/470/475/480/485/490/495/500",
-      "updated_at": "2024-06-20T18:36:28.000000Z"
+      "temp_increment": "180/185/190/195/200/205/210/215/220/225/230/235/240/245/250/255/260/265/270/275/280/285/290/295/300/305/310/315/320/325/330/335/340/345/350/355/360/365/370/375/380/385/390/395/400/405/410/415/420/425/430/435/440/445/450/455/460/465/470/475/480/485/490/495/500"
     }
   }
 }

--- a/scripts/dump_grills.py
+++ b/scripts/dump_grills.py
@@ -30,6 +30,23 @@ _LOGGER = logging.getLogger(__name__)
 
 API_URL = "https://api-prod.dansonscorp.com/api/v1"
 
+# Vendor bookkeeping the library never reads, dropped to keep the checked-in
+# definitions to a manageable size. The timestamps are the bulk of it: they sit
+# on every grill, board and command, and the vendor touches rows without
+# changing anything that affects parsing.
+_DROPPED_FIELDS = frozenset({"created_at", "updated_at", "deleted_at"})
+_DROPPED_GRILL_FIELDS = _DROPPED_FIELDS | {"app_layout", "manual_url"}
+# Commands are stored inside the board they belong to, so naming it again on
+# every one of them says nothing the position does not.
+_DROPPED_COMMAND_FIELDS = _DROPPED_FIELDS | {"control_board_id"}
+
+
+def _drop(
+    obj: dict[str, Any], fields: frozenset[str], **replace: Any
+) -> dict[str, Any]:
+    """Copies `obj` without `fields`, applying any `replace` overrides."""
+    return {k: v for k, v in obj.items() if k not in fields} | replace
+
 
 async def get_grill_details(
     session: ClientSession, grill_id: int, attempts: int = 3
@@ -147,9 +164,23 @@ async def main():
     print(
         json.dumps(
             {
-                "control_boards": control_boards,
+                "control_boards": {
+                    name: _drop(
+                        board,
+                        _DROPPED_FIELDS,
+                        control_board_commands=[
+                            _drop(command, _DROPPED_COMMAND_FIELDS)
+                            for command in board["control_board_commands"]
+                        ],
+                    )
+                    for name, board in control_boards.items()
+                },
                 "grills": {
-                    name: {**grill, "control_board": grill["control_board"]["name"]}
+                    name: _drop(
+                        grill,
+                        _DROPPED_GRILL_FIELDS,
+                        control_board=grill["control_board"]["name"],
+                    )
                     for name, grill in grills.items()
                 },
             },


### PR DESCRIPTION
## Summary

`created_at`, `updated_at` and `deleted_at` sit on every grill, every control board and every one of their commands. `app_layout` is `"standard"` on all 147 rows. `manual_url` is a product support link. Nothing in pytboss, its scripts or ha-pitboss reads any of them.

Dropping them at dump time:

```
before:  336,948 bytes
after:   268,213 bytes   (20% smaller)
```

on top of the 72% #500 saved by storing boards once. Together the definitions have gone from 1,185,170 bytes to 268,213 — a **77% reduction**.

The timestamps are the bulk of it, mostly because they repeat on all ~200 command objects; grill and board timestamps alone would only be 14%.

## Verified

- **Nothing consumes the dropped fields** — grepped `pytboss/`, `scripts/`, `tests/` and ha-pitboss's `custom_components/pitboss/`.
- **Everything retained is untouched**: grill and board counts unchanged, and no surviving value differs from before. None of the dropped keys remains anywhere, at any of the three levels.
- **A fresh `python -m scripts.dump_grills` against the live API reproduces the committed file exactly**, so the script genuinely emits this shape rather than the transformation having been applied by hand.
- 534 tests pass; `ruff`, `ruff format --check`, `mypy` clean; `scripts/update_readme.py` regenerates `README.md` with no diff.

## What this does not do

It does not meaningfully quieten the automated refreshes. I checked against the #499 data: the vendor also materialised `mpc_type` and `device_status_function` as null columns in that refresh, so one still touches most rows.

```
entries differing in the #499 refresh
  untrimmed:                     140 of 147
  with this change:              140 of 147
  + mpc_type, device_status_fn:    6 of 147
```

Both of those are `null` on every row and referenced nowhere — not in pytboss, not in ha-pitboss, and not in any vendor firmware build I checked (0.2.3, 0.5.7, 0.6.0). Adding them would cost another 4 KB and collapse a refresh to 6 entries, but that is a separate call and this PR deliberately sticks to the fields agreed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
