### PR TITLE
Update the cached state from get_state()

### DIFF
--- a/pytboss/api.py
+++ b/pytboss/api.py
@@ -246,15 +246,19 @@ class PitBoss:
     async def get_state(self) -> StateDict:
         """Issues a live RPC to fetch and return the current grill state.
 
-        Unlike `subscribe_state()`, this does not use the cached state
-        maintained from prior pushed updates; it always queries the grill
-        directly.
+        Unlike `subscribe_state()`, this always queries the grill rather than
+        returning the cached state. The reply does update that cache, so
+        anything relying on it stays correct on a connection that only ever
+        polls.
         """
         resp = await self._conn.send_command(
             "PB.GetState", await self._authenticate({})
         )
         status = self.spec.control_board.parse_status(resp["sc_11"]) or {}
         status.update(self.spec.control_board.parse_temperatures(resp["sc_12"]) or {})
+        if status:
+            async with self._lock:
+                self._state.update(status)
         return status
 
     async def get_firmware_version(self) -> dict:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -492,3 +492,15 @@ async def test_ping():
     ) as send_command:
         assert await pitboss.ping(timeout=5.0) == {}
         send_command.assert_awaited_once_with("RPC.Ping", {}, timeout=5.0)
+
+
+async def test_get_state_updates_the_cached_state(conn: FakeTransport, password: str):
+    """A polling-only connection must still keep the cache current."""
+    pitboss = api.PitBoss(conn, "PBV4PS2", password)
+    await pitboss.start()
+    assert pitboss._state == {}
+
+    await pitboss.get_state()
+    want: dict[str, Any] = STATE_DICT.copy()
+    want.update(TEMPS_DICT)
+    assert pitboss._state == want


### PR DESCRIPTION
Fixes #508.

`self._state` is only ever written by `_on_state_received`, so on a connection that polls rather than subscribes it stays empty for the whole session. `get_state()` parses exactly the same fields and throws them away afterwards.

The immediate consequence is that `isFahrenheit` is unknowable on such a connection, which is what #509 needs to send a setpoint in the grill's own unit — but the cache being silently empty seems worth fixing on its own regardless.

`get_state()` still returns a live read rather than the cache; only the side effect is new, and the docstring says so. Guarded on a non-empty parse so a malformed reply cannot wipe what is already there.

One test, which fails on `main`: after `get_state()`, `_state` matches the parsed reply.