### PR TITLE
Snap the grill setpoint to an accepted value in the grill's own unit

### DIFF
--- a/pytboss/api.py
+++ b/pytboss/api.py
@@ -5,6 +5,7 @@ import inspect
 import json
 import logging
 from collections.abc import Awaitable, Callable
+from math import floor
 from time import monotonic
 
 from .codec import encode, timed_key
@@ -198,16 +199,33 @@ class PitBoss:
         )
         self._password = new_password_bytes
 
+    def accepted_setpoints(self, fahrenheit: bool = True) -> list[int]:
+        """Grill setpoints the control board honours.
+
+        The board ignores anything that is not on this list.
+
+        :param fahrenheit: Whether to return the list in Fahrenheit.
+        """
+        increments = self.spec.temp_increments or []
+        if fahrenheit:
+            return list(increments)
+        if celsius := self.spec.celsius_temp_increments:
+            return list(celsius)
+        # Match the boards that convert inside their own parsing routine:
+        # they floor, so 190F is 87C to the grill rather than 88.
+        return [floor((v - 32) / 1.8) for v in increments]
+
     async def set_grill_temperature(self, temp: int) -> dict:
         """Sets the target grill temperature.
 
-        :param temp: Target grill temperature.
+        Snapped to the nearest value the control board accepts, expressed in
+        the unit the grill is currently working in.
+
+        :param temp: Target grill temperature, in the grill's own unit.
         """
-        # TODO: Clamp to a value from self.spec.temp_increments.
-        if self.spec.max_temp:
-            temp = min(temp, self.spec.max_temp)
-        if self.spec.min_temp:
-            temp = max(temp, self.spec.min_temp)
+        fahrenheit = self._state.get("isFahrenheit", True)
+        if accepted := self.accepted_setpoints(fahrenheit):
+            temp = min(accepted, key=lambda value: abs(value - temp))
         return await self._send_command("set-temperature", temp)
 
     async def set_probe_temperature(self, temp: int) -> dict:

--- a/pytboss/grills.py
+++ b/pytboss/grills.py
@@ -389,7 +389,11 @@ class Grill:
     """The number of meat probes available on the grill."""
 
     temp_increments: list[int] | None = field(default_factory=list)
-    """Supported temperature increments."""
+    """Supported temperature increments, in Fahrenheit."""
+
+    celsius_temp_increments: list[int] | None = field(default_factory=list)
+    """Supported temperature increments in Celsius, where the grill declares
+    its own list. Most do not; theirs is derived from `temp_increments`."""
 
     json: dict[str, Any] = field(default_factory=dict)
     """The raw JSON returned by the PitBoss API."""
@@ -400,7 +404,8 @@ class Grill:
 
         :param grill_dict: A top-level entry from `grills.json`, with `name`,
             `control_board`, `lights`, `has_mpc`, `meat_probes`,
-            `temp_increment`, `min_temp`, and `max_temp` keys.
+            `temp_increment`, `celsius_temp_increment`, `min_temp`, and
+            `max_temp` keys.
         """
         min_temp = None
         try:
@@ -424,6 +429,11 @@ class Grill:
             max_temp=max_temp,
             meat_probes=grill_dict["meat_probes"],
             temp_increments=[int(t) for t in grill_dict["temp_increment"].split("/")],
+            celsius_temp_increments=[
+                int(t)
+                for t in (grill_dict.get("celsius_temp_increment") or "").split("/")
+                if t.strip().isdigit()
+            ],
             json=grill_dict,
             control_board=ControlBoard.from_dict(grill_dict["control_board"]),
         )

--- a/pytboss/grills.py
+++ b/pytboss/grills.py
@@ -391,12 +391,16 @@ class Grill:
     temp_increments: list[int] | None = field(default_factory=list)
     """Supported temperature increments, in Fahrenheit."""
 
-    celsius_temp_increments: list[int] | None = field(default_factory=list)
-    """Supported temperature increments in Celsius, where the grill declares
-    its own list. Most do not; theirs is derived from `temp_increments`."""
-
     json: dict[str, Any] = field(default_factory=dict)
     """The raw JSON returned by the PitBoss API."""
+
+    celsius_temp_increments: list[int] | None = field(default_factory=list)
+    """Supported temperature increments in Celsius, where the grill declares
+    its own list. Most do not; theirs is derived from `temp_increments`.
+
+    Declared after `json` rather than beside `temp_increments`: `Grill` is not
+    `kw_only`, so inserting a field earlier would shift every positional
+    argument after it and silently change what an existing caller passes."""
 
     @classmethod
     def from_dict(cls, grill_dict) -> "Grill":

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -187,6 +187,8 @@ def my_grill(
         min_temp=kwargs.get("min_temp", None),
         max_temp=kwargs.get("max_temp", None),
         has_lights=kwargs.get("has_lights", False),
+        temp_increments=kwargs.get("temp_increments", []),
+        celsius_temp_increments=kwargs.get("celsius_temp_increments", []),
     )
 
 
@@ -283,16 +285,49 @@ async def test_set_grill_temperature(pitboss: api.PitBoss, conn: FakeTransport):
     assert conn.last_mcu_command == "set-temperature(225,)"
 
 
-@pytest.mark.grill_params({"max_temp": 200})
+@pytest.mark.grill_params({"temp_increments": [180, 200, 220]})
 async def test_set_grill_temperature_high(pitboss: api.PitBoss, conn: FakeTransport):
-    assert (await pitboss.set_grill_temperature(225)) == {}
+    """Above the range, the highest accepted setpoint."""
+    assert (await pitboss.set_grill_temperature(400)) == {}
+    assert conn.last_mcu_command == "set-temperature(220,)"
+
+
+@pytest.mark.grill_params({"temp_increments": [180, 200, 220]})
+async def test_set_grill_temperature_low(pitboss: api.PitBoss, conn: FakeTransport):
+    """Below the range, the lowest accepted setpoint."""
+    assert (await pitboss.set_grill_temperature(100)) == {}
+    assert conn.last_mcu_command == "set-temperature(180,)"
+
+
+@pytest.mark.grill_params({"temp_increments": [180, 200, 220]})
+async def test_set_grill_temperature_snaps_to_the_nearest(
+    pitboss: api.PitBoss, conn: FakeTransport
+):
+    """The board ignores anything that is not on its list."""
+    assert (await pitboss.set_grill_temperature(206)) == {}
     assert conn.last_mcu_command == "set-temperature(200,)"
 
 
-@pytest.mark.grill_params({"min_temp": 300})
-async def test_set_grill_temperature_low(pitboss: api.PitBoss, conn: FakeTransport):
-    assert (await pitboss.set_grill_temperature(225)) == {}
-    assert conn.last_mcu_command == "set-temperature(300,)"
+@pytest.mark.grill_params({"temp_increments": [180, 190, 200]})
+async def test_set_grill_temperature_in_celsius(
+    pitboss: api.PitBoss, conn: FakeTransport
+):
+    """A grill reporting Celsius is sent Celsius, not a Fahrenheit bound."""
+    pitboss._state["isFahrenheit"] = False
+    # 180/190/200F floor to 82/87/93C.
+    assert (await pitboss.set_grill_temperature(88)) == {}
+    assert conn.last_mcu_command == "set-temperature(87,)"
+
+
+@pytest.mark.grill_params(
+    {"temp_increments": [180, 190], "celsius_temp_increments": [40, 45, 50]}
+)
+async def test_set_grill_temperature_prefers_a_declared_celsius_list(
+    pitboss: api.PitBoss, conn: FakeTransport
+):
+    pitboss._state["isFahrenheit"] = False
+    assert (await pitboss.set_grill_temperature(44)) == {}
+    assert conn.last_mcu_command == "set-temperature(45,)"
 
 
 async def test_set_probe_temperature(pitboss: api.PitBoss, conn: FakeTransport):


### PR DESCRIPTION
Fixes #509.

`set_grill_temperature` clamped against `min_temp`/`max_temp`, which are Fahrenheit, so a Celsius grill had a floor of 180 and a ceiling of 500 in a range that tops out around 260. The `TODO` above it already said the right answer was `temp_increments`.

This replaces the clamp with a snap to the nearest accepted setpoint, in whichever unit the grill is currently working in, and exposes `accepted_setpoints(fahrenheit=...)` so a caller can present the same list.

Two details worth flagging, both verified against real hardware (PBV4PS2, Pit Boss 1600 Pro Elite):

**The Celsius list is truncated, not rounded.** The boards that convert internally do `Math.floor((temp - 32) / 1.8)`, so 190F is 87C to the grill, not 88. Rounding gets 9 of my grill's 19 Celsius setpoints wrong — I found this by sending 88 and reading back 87. Where `grills.json` declares its own `celsius_temp_increment`, that wins over the derivation; `Grill` didn't parse that field before, so this adds it.

**Unit inference.** I picked `_state["isFahrenheit"]` over adding an explicit argument, because every existing caller passes a temperature in the unit the grill is displaying and an argument would change that contract. This is the choice I asked about in the issue and haven't heard back on — if you'd rather have `set_grill_temperature(temp, fahrenheit=True)`, say so and I'll reshape it; the snapping logic is unaffected either way.

The one soft spot: before the first poll `_state` is empty and it assumes Fahrenheit. That is no worse than today, where the Fahrenheit bounds were applied unconditionally, but it is an assumption rather than a fact. #516 landing means a polling-only transport now populates `_state` on the first `get_state()`, which is why this one was waiting on it.

`pytest` (692), `ruff` and `mypy` clean.

`AGENTS.md` asks for a label; I still can't set one here, so `bug` is on you.
