### PR TITLE
Give send_command a default timeout and stop it leaking futures

### DIFF
--- a/pytboss/transport.py
+++ b/pytboss/transport.py
@@ -16,6 +16,9 @@ from mypy_extensions import DefaultNamedArg
 
 from .exceptions import RPCError
 
+DEFAULT_TIMEOUT = 30.0
+"""Seconds to wait for a reply before giving up."""
+
 
 class RawStateCallback(Protocol):
     """Callback invoked by a `Transport` with raw, unparsed state payloads."""
@@ -81,13 +84,13 @@ class Transport(ABC):
     async def _send_prepared_command(self, cmd: dict) -> None: ...
 
     async def send_command(
-        self, method: str, params: dict, *, timeout: float | None = None
+        self, method: str, params: dict, *, timeout: float | None = DEFAULT_TIMEOUT
     ) -> dict:
         """Sends a comand to the device.
 
         :param method: The method to call.
         :param params: Parameters to send with the command.
-        :param timeout: Timeout for the call.
+        :param timeout: Timeout for the call. Pass `None` to wait forever.
         :raise pytboss.exceptions.RPCError: If the device returns an error response.
         :raise TimeoutError: If `timeout` elapses before a response is received.
         """
@@ -95,9 +98,15 @@ class Transport(ABC):
         future = self._loop.create_future()
         async with self._lock:
             self._rpc_futures[cmd["id"]] = future
-        async with asyncio.timeout(timeout):
-            await self._send_prepared_command(cmd)
-            return await future
+        try:
+            async with asyncio.timeout(timeout):
+                await self._send_prepared_command(cmd)
+                return await future
+        finally:
+            # A reply that never arrives would otherwise leave its future
+            # behind forever.
+            async with self._lock:
+                self._rpc_futures.pop(cmd["id"], None)
 
     async def send_command_without_answer(
         self, method: str, params: dict, *, timeout: float | None = None

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -1,3 +1,5 @@
+import pytest
+
 from pytboss.transport import Transport
 
 
@@ -32,3 +34,12 @@ async def test_on_command_response_unknown_id():
     conn = FakeTransport()
     handled = await conn._on_command_response({"id": 999, "result": {}})
     assert handled is False
+
+
+async def test_send_command_gives_up_instead_of_waiting_forever():
+    """A reply that never arrives must not block the caller indefinitely."""
+    conn = FakeTransport()
+    with pytest.raises(TimeoutError):
+        await conn.send_command("PB.GetState", {}, timeout=0.01)
+    # And the abandoned future must not be left behind.
+    assert conn._rpc_futures == {}


### PR DESCRIPTION
Fixes #510.

`send_command` defaulted to `timeout=None`, so every caller that didn't pass one waited forever. If the grill goes away mid-command — the WiFi module wedging is the common case — the awaiting task never returns, and its future stays in `_rpc_futures` for the life of the process. Nothing removes it: entries are only popped when a reply with a matching id arrives.

Two changes: a 30s default (`None` still means wait forever, so the escape hatch is intact), and popping the future in a `finally` so timeouts and cancellations clean up after themselves.

The second half has a knock-on benefit for third-party transports. My local RPC transport currently reaches into `self._rpc_futures` and `self._lock` to fail in-flight commands when the socket drops, because nothing in the base class does it. With this, that goes away and a transport only needs `connect` / `disconnect` / `is_connected` / `_send_prepared_command`.

30s is a guess informed by nothing but my own grill; if you'd rather it were 10 or 60, it's a one-line change.

`pytest` (687), `ruff` and `mypy` clean. Label is on you again, sorry — `bug` fits.
