### PR TITLE
Expose whether a control board converts to celsius itself

### DIFF
--- a/pytboss/grills.py
+++ b/pytboss/grills.py
@@ -258,6 +258,13 @@ class Command:
         return evaljs(_COMMAND_JS_TMPL % self._js_func, args=args)
 
 
+def _live_code(js: str | None) -> str:
+    """The routine with commented-out code removed."""
+    if not js:
+        return ""
+    return re.sub(r"//.*", "", re.sub(r"/\*.*?\*/", "", js, flags=re.DOTALL))
+
+
 @dataclass(frozen=True)
 class ControlBoard:
     """Specifications for a control board connected via UART."""
@@ -295,6 +302,31 @@ class ControlBoard:
     def _evaljs(self, js_func: str, message: str) -> StateDict | None:
         js = _CONTROLLER_JS_TMPL % js_func
         return evaljs(js, message=message)
+
+    @property
+    def converts_temperatures_to_celsius(self) -> bool:
+        """Whether the temperatures routine converts fahrenheit itself.
+
+        Most boards convert internally and report whichever unit the grill is
+        set to; some report fahrenheit always and convert with an `ftoc()`
+        helper in their JS. Consumers deciding what unit a value is in, or
+        what unit to send, need to know which.
+
+        Read off the routine rather than a list of board names: a definitions
+        refresh can introduce a converting board, and only live code counts --
+        PBL2 ships PBL3's conversion block entirely commented out, which is
+        the whole difference between those two boards.
+        """
+        return "ftoc" in _live_code(self._temperatures_js_func)
+
+    @property
+    def converts_status_to_celsius(self) -> bool:
+        """Whether the status routine converts fahrenheit itself.
+
+        The two routines for one board do not always agree: PBL3 converts in
+        its temperatures reply but not in its status reply.
+        """
+        return "ftoc" in _live_code(self._status_js_func)
 
     def parse_status(self, message: str) -> StateDict | None:
         """Parses a status message.

--- a/tests/test_grills.py
+++ b/tests/test_grills.py
@@ -391,3 +391,28 @@ class TestGetGrill:
     def test_invalid(self):
         with pytest.raises(InvalidGrill):
             grills_lib.get_grill("unknown-grill")
+
+
+def test_converts_to_celsius_reads_the_routine():
+    """Live code only: a commented-out conversion does not count."""
+    converting = grills_lib.ControlBoard(
+        "PBx", {}, "", "var ftoc = function (t) { return t; };"
+    )
+    assert converting.converts_temperatures_to_celsius is True
+
+    commented = grills_lib.ControlBoard(
+        "PBx", {}, "", "/* var ftoc = function (t) { return t; }; */"
+    )
+    assert commented.converts_temperatures_to_celsius is False
+
+    line_commented = grills_lib.ControlBoard(
+        "PBx", {}, "", "// var ftoc = function (t) { return t; };"
+    )
+    assert line_commented.converts_temperatures_to_celsius is False
+
+
+def test_converts_to_celsius_is_per_routine():
+    """One board's two routines need not agree; PBL3 is the real example."""
+    board = grills_lib.ControlBoard("PBx", {}, "return {};", "ftoc(1);")
+    assert board.converts_temperatures_to_celsius is True
+    assert board.converts_status_to_celsius is False


### PR DESCRIPTION
Fixes #513.

Most boards convert internally and report whichever unit the grill is set to; some report Fahrenheit always and convert with an `ftoc()` helper in their JS. A consumer deciding what unit a reading is in has no way to ask, so it ends up reimplementing the check against `_temperatures_js_func` — which is private, and easy to get wrong.

This adds `converts_temperatures_to_celsius` and `converts_status_to_celsius` on `ControlBoard`.

Two reasons they're separate properties rather than one:

**The two routines for a board don't always agree.** PBL3 converts in its temperatures reply but not in its status reply. One flag would have to pick a side and be wrong half the time.

**Only live code counts.** PBL2 ships PBL3's conversion block entirely commented out — that is the whole difference between those two boards. A plain `"ftoc" in js` counts PBL2 and shouldn't:

```
naive  'ftoc' in js : 12  [LFS PBA PBE PBL2 PBL3 PBM PBM2 PBT PBV PBV2 PBVA PBX1]
live code only      : 11  [LFS PBA PBE      PBL3 PBM PBM2 PBT PBV PBV2 PBVA PBX1]
```

I made that exact mistake in the original issue and had to correct myself, which is the best argument I have for the property existing at all.

It's read off the routine rather than a list of board names deliberately: `grills.json` is refreshed from the upstream API, so a definitions update can introduce a converting board without any code change here.

`pytest` (688), `ruff` and `mypy` clean. Label: `enhancement`, if you would.
