### PR TITLE
Add set_temperature_unit()

### DIFF
--- a/pytboss/api.py
+++ b/pytboss/api.py
@@ -219,6 +219,18 @@ class PitBoss:
             raise UnsupportedOperation
         return await self._send_command(cmd, temp)
 
+    async def set_temperature_unit(self, fahrenheit: bool) -> dict:
+        """Switches the unit the grill itself works in.
+
+        This is the grill's own setting -- the one shown on its panel and
+        used by the values it reports -- not a display preference.
+
+        :param fahrenheit: Whether the grill should work in Fahrenheit.
+        """
+        return await self._send_command(
+            "set-fahrenheit" if fahrenheit else "set-celsius"
+        )
+
     async def turn_light_on(self) -> dict:
         """Turns the light on if the grill has a light."""
         if not self.spec.has_lights:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -154,6 +154,8 @@ def mock_control_board() -> Mock:
         for cmd in (
             "set-temperature",
             "set-probe-1-temperature",
+            "set-celsius",
+            "set-fahrenheit",
             "turn-light-on",
             "turn-light-off",
             "turn-off",
@@ -504,3 +506,10 @@ async def test_get_state_updates_the_cached_state(conn: FakeTransport, password:
     want: dict[str, Any] = STATE_DICT.copy()
     want.update(TEMPS_DICT)
     assert pitboss._state == want
+
+async def test_set_temperature_unit(pitboss: api.PitBoss, conn: FakeTransport):
+    assert (await pitboss.set_temperature_unit(fahrenheit=False)) == {}
+    assert conn.last_mcu_command == "set-celsius()"
+
+    assert (await pitboss.set_temperature_unit(fahrenheit=True)) == {}
+    assert conn.last_mcu_command == "set-fahrenheit()"


### PR DESCRIPTION
Fixes #514.

Every board declares `set-celsius` and `set-fahrenheit`, but neither is reachable without `_send_command`. `isFahrenheit` can be observed and not changed, which makes the unit the one grill setting a consumer can see but not touch.

`set_temperature_unit(fahrenheit: bool)`, in the same shape as the other command wrappers. Smallest of the set.

I went with one method taking a bool rather than two methods mirroring the two MCU commands, since callers generally have a unit in hand rather than a branch. Trivial to flip if you prefer the pair.

`pytest` (688), `ruff` and `mypy` clean. Label: `enhancement`.
