### PR TITLE
Extrapolate the cached uptime instead of re-reading it

### DIFF
--- a/pytboss/api.py
+++ b/pytboss/api.py
@@ -8,14 +8,14 @@ from collections.abc import Awaitable, Callable
 from time import monotonic
 
 from .codec import encode, timed_key
-
-_UPTIME_TTL = 600.0
-"""Seconds before the cached uptime is re-read rather than extrapolated."""
 from .config import Config
 from .exceptions import UnsupportedOperation
 from .fs import FileSystem
 from .grills import Grill, StateDict, get_grill
 from .transport import Transport
+
+_UPTIME_TTL = 600.0
+"""Seconds before the cached uptime is re-read rather than extrapolated."""
 
 _LOGGER = logging.getLogger("pytboss")
 

--- a/pytboss/api.py
+++ b/pytboss/api.py
@@ -5,9 +5,12 @@ import inspect
 import json
 import logging
 from collections.abc import Awaitable, Callable
-from time import time
+from time import monotonic
 
 from .codec import encode, timed_key
+
+_UPTIME_TTL = 600.0
+"""Seconds before the cached uptime is re-read rather than extrapolated."""
 from .config import Config
 from .exceptions import UnsupportedOperation
 from .fs import FileSystem
@@ -65,7 +68,7 @@ class PitBoss:
         self._vdata_callbacks: list[VDataCallback] = []
         self._state = StateDict()
         self._last_uptime: float | None = None
-        self._last_uptime_check: int | None = None
+        self._last_uptime_check: float = 0.0
 
     def is_connected(self) -> bool:
         """Returns whether we are actively connected to the grill."""
@@ -305,17 +308,18 @@ class PitBoss:
     async def get_uptime(self) -> float:
         """Returns the device's uptime, in seconds.
 
-        Cached for up to 5 seconds between RPCs.
+        Read once and then extrapolated, since uptime advances with the
+        wall clock.
 
         :meta private:
         """
-        now = int(time())
-        if not self._last_uptime_check or now - self._last_uptime_check > 5:
+        now = monotonic()
+        if self._last_uptime is None or now - self._last_uptime_check > _UPTIME_TTL:
             result = await self._conn.send_command("PB.GetTime", {})
             self._last_uptime = result.get("time", 0.0)
             self._last_uptime_check = now
-        assert self._last_uptime is not None
-        return self._last_uptime
+            return self._last_uptime
+        return self._last_uptime + (now - self._last_uptime_check)
 
     async def ping(self, timeout: float | None = None) -> dict:
         """Pings the device.

--- a/pytboss/api.py
+++ b/pytboss/api.py
@@ -14,8 +14,15 @@ from .fs import FileSystem
 from .grills import Grill, StateDict, get_grill
 from .transport import Transport
 
-_UPTIME_TTL = 600.0
-"""Seconds before the cached uptime is re-read rather than extrapolated."""
+_UPTIME_TTL = 60.0
+"""Seconds before the cached uptime is re-read rather than extrapolated.
+
+Kept short because a grill that restarts resets its uptime, and no transport
+routes its reconnect through `PitBoss` -- `ble` and `wss` both reconnect
+internally -- so nothing invalidates the cache when that happens. Until the
+re-read, `timed_key` would be built from an uptime minutes too high, and every
+authenticated command on a password-protected grill would be rejected. This
+bounds that window to a minute while still saving most of the round trips."""
 
 _LOGGER = logging.getLogger("pytboss")
 
@@ -309,7 +316,8 @@ class PitBoss:
         """Returns the device's uptime, in seconds.
 
         Read once and then extrapolated, since uptime advances with the
-        wall clock.
+        wall clock, and re-read every `_UPTIME_TTL` seconds so a grill that
+        restarted cannot be extrapolated from for long.
 
         :meta private:
         """

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -341,16 +341,21 @@ async def test_get_state(conn: FakeTransport, password: str):
     assert (await pitboss.get_state()) == want
 
 
-async def test_get_uptime_is_cached(pitboss: api.PitBoss):
+async def test_get_uptime_is_extrapolated_between_reads(pitboss: api.PitBoss):
+    """Uptime advances with the clock, so it need not be asked for again."""
     with freeze_time("2025-06-01 00:00:00") as ft:
-        t1 = await pitboss.get_uptime()
-        # We should use a cached uptime for 5 seconds.
-        for _ in range(5):
-            ft.tick(1.0)
-            assert await pitboss.get_uptime() == t1
-        # Now it should change.
-        ft.tick(1.0)
-        assert await pitboss.get_uptime() > t1
+        first = await pitboss.get_uptime()
+        for elapsed in (1.0, 30.0, 300.0):
+            ft.tick(elapsed)
+        assert await pitboss.get_uptime() == first + 331.0
+
+
+async def test_get_uptime_is_re_read_once_the_cache_is_stale(pitboss: api.PitBoss):
+    """The fake grill counts up per read, so a fresh read is far lower."""
+    with freeze_time("2025-06-01 00:00:00") as ft:
+        first = await pitboss.get_uptime()
+        ft.tick(api._UPTIME_TTL + 1)
+        assert await pitboss.get_uptime() < first + api._UPTIME_TTL
 
 
 async def test_is_connected():

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -343,11 +343,14 @@ async def test_get_state(conn: FakeTransport, password: str):
 
 async def test_get_uptime_is_extrapolated_between_reads(pitboss: api.PitBoss):
     """Uptime advances with the clock, so it need not be asked for again."""
+    # Expressed as a fraction of the TTL so that changing the TTL cannot
+    # silently turn this into a test of the re-read path instead.
+    steps = [api._UPTIME_TTL / 8, api._UPTIME_TTL / 4, api._UPTIME_TTL / 2]
     with freeze_time("2025-06-01 00:00:00") as ft:
         first = await pitboss.get_uptime()
-        for elapsed in (1.0, 30.0, 300.0):
+        for elapsed in steps:
             ft.tick(elapsed)
-        assert await pitboss.get_uptime() == first + 331.0
+        assert await pitboss.get_uptime() == first + sum(steps)
 
 
 async def test_get_uptime_is_re_read_once_the_cache_is_stale(pitboss: api.PitBoss):


### PR DESCRIPTION
Fixes #512.

`get_uptime` re-reads `PB.GetTime` every 5s. It's called on every command, to build the codec key — so a 10s poll costs an extra round trip on each pass, for a value that is knowable without asking: uptime advances with the clock.

This reads it once and extrapolates from a monotonic clock, re-reading every 10 minutes to absorb drift and to notice a reboot. Also switches `time()` to `monotonic()`, which is what the arithmetic wanted all along — the old version would jump if the system clock stepped.

Two things I convinced myself of before proposing it, since this feeds the auth key:

- `timed_key` buckets the value, so small drift is absorbed rather than producing a wrong key.
- A grill reboot resets uptime, and extrapolation would then be wrong until the next re-read. That's the case the 10-minute ceiling is for. A reboot also drops the connection, so in practice the window is smaller than that.

If you'd rather it never extrapolated across a reconnect, clearing `_last_uptime` in `disconnect` would close that gap entirely — happy to add it, I left it out as it seemed like belt and braces.

**Conflict note:** this touches the same region of `api.py` as #517. They're a textual overlap rather than a semantic one; whichever lands second I'll rebase.

`pytest` (688), `ruff` and `mypy` clean. Label: `enhancement`.
