### PR TITLE
Note the downstream two-pin release requirement

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,14 @@ to run tests/ruff/mypy locally.
   must stay at the repo root (not moved into `fake_firmware/`) for the
   Mongoose OS VSCode plugin to find it.
 
+- **Releases reach ha-pitboss through two pins, not one**: a new public
+  attribute here is unreachable downstream until both `requirements.txt` and
+  `custom_components/pitboss/manifest.json` move there. Dependabot opens only
+  the first, and neither repo's CI catches the gap — downstream CI installs
+  from `requirements.txt` while users install from the manifest, so a consumer
+  reading the new attribute passes every check and fails at runtime. See
+  [REVIEW.md](REVIEW.md#releasing).
+
 ## Before committing
 
 Run the same checks CI runs, and make sure all three pass cleanly:

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -123,9 +123,21 @@ Cutting a release is what propagates a change downstream:
    by label. `breaking` deserves care: the dataclasses in `grills.py` are
    public, so removing an attribute or reordering a constructor is a breaking
    change even when nothing in either repo used it.
-2. ha-pitboss picks the new version up via Dependabot, or a manual bump.
+2. ha-pitboss picks the new version up via Dependabot, or a manual bump. That
+   bump must touch **two** files there — `requirements.txt`, which is what its
+   CI installs, and `custom_components/pitboss/manifest.json`, which is what
+   Home Assistant installs for users. Dependabot only opens the first.
 3. That bump triggers `update-grill-docs.yml` there, which regenerates
    `docs/SUPPORTED_GRILLS.md` automatically.
 
 So a change to which models are supported reaches users' documentation only
 after a release. Don't hand-edit the downstream doc to compensate.
+
+Step 2 is where this has actually gone wrong: 2026.8.2 landed in
+`requirements.txt` alone, so downstream CI tested against the new release
+while users kept the old one. A new public attribute here — `Grill.has_mpc`
+was the case — is unreachable downstream until *both* pins move, and nothing
+in either repo's CI notices, because each installs from the file it knows
+about. Adding an attribute is cheap; assume a consumer will read it before the
+manifest catches up, and treat that lag as part of the release rather than
+someone else's problem.


### PR DESCRIPTION
A pytboss release reaches ha-pitboss users only when **both** of its pins move — `requirements.txt` (what its CI installs) and `custom_components/pitboss/manifest.json` (what Home Assistant installs). Dependabot opens only the first.

2026.8.2 hit this: the bump landed in `requirements.txt` alone, so downstream CI tested the new release while users kept 2026.8.1, and [ha-pitboss#333](https://github.com/dknowles2/ha-pitboss/pull/333) was written against a `Grill.has_mpc` that shipped users did not have. Every check passed; it would have raised `AttributeError` at setup.

Documented in `REVIEW.md` under Releasing, with a pointer from `AGENTS.md`. The matching change downstream is [ha-pitboss#339](https://github.com/dknowles2/ha-pitboss/pull/339).

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)