### PR TITLE
Restore celsius_temp_increment to the definitions

### DIFF
--- a/pytboss/grills.json
+++ b/pytboss/grills.json
@@ -956,6 +956,7 @@
   "grills": {
     "LG0800BL": {
       "category": null,
+      "celsius_temp_increment": null,
       "control_board": "LBL",
       "enabled": true,
       "has_fc_functionality": 1,
@@ -971,6 +972,7 @@
     },
     "LG1000BL": {
       "category": null,
+      "celsius_temp_increment": null,
       "control_board": "LBL",
       "enabled": true,
       "has_fc_functionality": 1,
@@ -986,6 +988,7 @@
     },
     "LG1200BL": {
       "category": null,
+      "celsius_temp_increment": null,
       "control_board": "LBL",
       "enabled": true,
       "has_fc_functionality": 1,
@@ -1001,6 +1004,7 @@
     },
     "LG1200FL": {
       "category": null,
+      "celsius_temp_increment": null,
       "control_board": "LFS",
       "enabled": true,
       "has_fc_functionality": 1,
@@ -1016,6 +1020,7 @@
     },
     "LG1200FP": {
       "category": null,
+      "celsius_temp_increment": null,
       "control_board": "LFS",
       "enabled": true,
       "has_fc_functionality": 1,
@@ -1031,6 +1036,7 @@
     },
     "LG300BL": {
       "category": null,
+      "celsius_temp_increment": null,
       "control_board": "LBL",
       "enabled": true,
       "has_fc_functionality": 1,
@@ -1046,6 +1052,7 @@
     },
     "LG800FL": {
       "category": null,
+      "celsius_temp_increment": null,
       "control_board": "LFS",
       "enabled": true,
       "has_fc_functionality": 1,
@@ -1061,6 +1068,7 @@
     },
     "LG800FP": {
       "category": null,
+      "celsius_temp_increment": null,
       "control_board": "LFS",
       "enabled": true,
       "has_fc_functionality": 1,
@@ -1076,6 +1084,7 @@
     },
     "LGV4BL": {
       "category": null,
+      "celsius_temp_increment": null,
       "control_board": "LBL",
       "enabled": true,
       "has_fc_functionality": 1,
@@ -1091,6 +1100,7 @@
     },
     "Lexington Wi-Fi Upgrade": {
       "category": null,
+      "celsius_temp_increment": null,
       "control_board": "PBM",
       "enabled": true,
       "has_fc_functionality": 1,
@@ -1106,6 +1116,7 @@
     },
     "PB0500SP": {
       "category": null,
+      "celsius_temp_increment": null,
       "control_board": "PBC",
       "enabled": true,
       "has_fc_functionality": 1,
@@ -1121,6 +1132,7 @@
     },
     "PB0820SP/SPW": {
       "category": null,
+      "celsius_temp_increment": null,
       "control_board": "PBC",
       "enabled": true,
       "has_fc_functionality": 1,
@@ -1136,6 +1148,7 @@
     },
     "PB1000D3": {
       "category": null,
+      "celsius_temp_increment": null,
       "control_board": "PBC",
       "enabled": true,
       "has_fc_functionality": 1,
@@ -1151,6 +1164,7 @@
     },
     "PB1000NC1": {
       "category": null,
+      "celsius_temp_increment": null,
       "control_board": "PBC",
       "enabled": true,
       "has_fc_functionality": 1,
@@ -1166,6 +1180,7 @@
     },
     "PB1000NXW": {
       "category": null,
+      "celsius_temp_increment": null,
       "control_board": "PBM",
       "enabled": true,
       "has_fc_functionality": 1,
@@ -1181,6 +1196,7 @@
     },
     "PB1000PL": {
       "category": "Wood Pellet",
+      "celsius_temp_increment": null,
       "control_board": "PBG",
       "enabled": true,
       "has_fc_functionality": 1,
@@ -1196,6 +1212,7 @@
     },
     "PB1000R1": {
       "category": null,
+      "celsius_temp_increment": null,
       "control_board": "PBV",
       "enabled": true,
       "has_fc_functionality": 1,
@@ -1211,6 +1228,7 @@
     },
     "PB1000R2": {
       "category": null,
+      "celsius_temp_increment": null,
       "control_board": "PBV",
       "enabled": true,
       "has_fc_functionality": 1,
@@ -1226,6 +1244,7 @@
     },
     "PB1000S1": {
       "category": null,
+      "celsius_temp_increment": null,
       "control_board": "PBV",
       "enabled": true,
       "has_fc_functionality": 1,
@@ -1241,6 +1260,7 @@
     },
     "PB1000SC1": {
       "category": null,
+      "celsius_temp_increment": null,
       "control_board": "PBV",
       "enabled": true,
       "has_fc_functionality": 1,
@@ -1256,6 +1276,7 @@
     },
     "PB1000SC2": {
       "category": null,
+      "celsius_temp_increment": null,
       "control_board": "PBC",
       "enabled": true,
       "has_fc_functionality": 1,
@@ -1271,6 +1292,7 @@
     },
     "PB1000SP": {
       "category": null,
+      "celsius_temp_increment": null,
       "control_board": "PBC",
       "enabled": true,
       "has_fc_functionality": 1,
@@ -1286,6 +1308,7 @@
     },
     "PB1000T1": {
       "category": null,
+      "celsius_temp_increment": null,
       "control_board": "PBV",
       "enabled": true,
       "has_fc_functionality": 1,
@@ -1301,6 +1324,7 @@
     },
     "PB1000T2": {
       "category": null,
+      "celsius_temp_increment": null,
       "control_board": "PBV",
       "enabled": true,
       "has_fc_functionality": 1,
@@ -1316,6 +1340,7 @@
     },
     "PB1000T3": {
       "category": null,
+      "celsius_temp_increment": null,
       "control_board": "PBC",
       "enabled": true,
       "has_fc_functionality": 1,
@@ -1331,6 +1356,7 @@
     },
     "PB1000T4": {
       "category": null,
+      "celsius_temp_increment": null,
       "control_board": "PBC",
       "enabled": true,
       "has_fc_functionality": 1,
@@ -1346,6 +1372,7 @@
     },
     "PB1000XL/PB1000SC3": {
       "category": null,
+      "celsius_temp_increment": null,
       "control_board": "PBC",
       "enabled": true,
       "has_fc_functionality": 1,
@@ -1361,6 +1388,7 @@
     },
     "PB1000XLW1 (Austin XL)": {
       "category": null,
+      "celsius_temp_increment": null,
       "control_board": "PBC",
       "enabled": true,
       "has_fc_functionality": 1,
@@ -1376,6 +1404,7 @@
     },
     "PB1020CS2": {
       "category": null,
+      "celsius_temp_increment": null,
       "control_board": "PBM",
       "enabled": true,
       "has_fc_functionality": 1,
@@ -1391,6 +1420,7 @@
     },
     "PB1020DX": {
       "category": null,
+      "celsius_temp_increment": null,
       "control_board": "PBL3",
       "enabled": true,
       "has_fc_functionality": 1,
@@ -1406,6 +1436,7 @@
     },
     "PB1020NXW": {
       "category": null,
+      "celsius_temp_increment": null,
       "control_board": "PBM",
       "enabled": true,
       "has_fc_functionality": 1,
@@ -1421,6 +1452,7 @@
     },
     "PB1100HTC": {
       "category": null,
+      "celsius_temp_increment": null,
       "control_board": "PBE",
       "enabled": true,
       "has_fc_functionality": 1,
@@ -1436,6 +1468,7 @@
     },
     "PB1100PS1": {
       "category": "WiFi Upgrade /Legacy H1",
+      "celsius_temp_increment": null,
       "control_board": "PBC",
       "enabled": true,
       "has_fc_functionality": 1,
@@ -1451,6 +1484,7 @@
     },
     "PB1100PSC1": {
       "category": null,
+      "celsius_temp_increment": null,
       "control_board": "PBC",
       "enabled": true,
       "has_fc_functionality": 1,
@@ -1466,6 +1500,7 @@
     },
     "PB1100PSC2": {
       "category": null,
+      "celsius_temp_increment": null,
       "control_board": "PBL",
       "enabled": true,
       "has_fc_functionality": 1,
@@ -1481,6 +1516,7 @@
     },
     "PB1100PSC3": {
       "category": null,
+      "celsius_temp_increment": null,
       "control_board": "PBL",
       "enabled": true,
       "has_fc_functionality": 1,
@@ -1496,6 +1532,7 @@
     },
     "PB1100SP/SPW": {
       "category": null,
+      "celsius_temp_increment": null,
       "control_board": "PBC",
       "enabled": true,
       "has_fc_functionality": 1,
@@ -1511,6 +1548,7 @@
     },
     "PB1100SPW2": {
       "category": null,
+      "celsius_temp_increment": null,
       "control_board": "PBC2",
       "enabled": true,
       "has_fc_functionality": 1,
@@ -1526,6 +1564,7 @@
     },
     "PB1150 PS3": {
       "category": null,
+      "celsius_temp_increment": null,
       "control_board": "PBT",
       "enabled": true,
       "has_fc_functionality": 1,
@@ -1541,6 +1580,7 @@
     },
     "PB1150DX": {
       "category": null,
+      "celsius_temp_increment": null,
       "control_board": "PBL3",
       "enabled": true,
       "has_fc_functionality": 1,
@@ -1556,6 +1596,7 @@
     },
     "PB1150DX (PBL2)": {
       "category": null,
+      "celsius_temp_increment": null,
       "control_board": "PBL2",
       "enabled": true,
       "has_fc_functionality": 1,
@@ -1571,6 +1612,7 @@
     },
     "PB1150G/GW": {
       "category": null,
+      "celsius_temp_increment": null,
       "control_board": "PBC",
       "enabled": true,
       "has_fc_functionality": 1,
@@ -1586,6 +1628,7 @@
     },
     "PB1150PS2": {
       "category": null,
+      "celsius_temp_increment": null,
       "control_board": "PBL",
       "enabled": true,
       "has_fc_functionality": 1,
@@ -1601,6 +1644,7 @@
     },
     "PB1150PS3": {
       "category": null,
+      "celsius_temp_increment": null,
       "control_board": "PBA",
       "enabled": true,
       "has_fc_functionality": 1,
@@ -1616,6 +1660,7 @@
     },
     "PB1230": {
       "category": null,
+      "celsius_temp_increment": null,
       "control_board": "PBC",
       "enabled": true,
       "has_fc_functionality": 1,
@@ -1631,6 +1676,7 @@
     },
     "PB1230CS1": {
       "category": null,
+      "celsius_temp_increment": null,
       "control_board": "PBM",
       "enabled": true,
       "has_fc_functionality": 1,
@@ -1646,6 +1692,7 @@
     },
     "PB1230G/GW": {
       "category": null,
+      "celsius_temp_increment": null,
       "control_board": "PBC",
       "enabled": true,
       "has_fc_functionality": 1,
@@ -1661,6 +1708,7 @@
     },
     "PB1230SP/SPW": {
       "category": null,
+      "celsius_temp_increment": null,
       "control_board": "PBC",
       "enabled": true,
       "has_fc_functionality": 1,
@@ -1676,6 +1724,7 @@
     },
     "PB1250 CS2": {
       "category": null,
+      "celsius_temp_increment": null,
       "control_board": "PBT",
       "enabled": true,
       "has_fc_functionality": 1,
@@ -1691,6 +1740,7 @@
     },
     "PB1250 NX": {
       "category": null,
+      "celsius_temp_increment": null,
       "control_board": "PBT",
       "enabled": true,
       "has_fc_functionality": 1,
@@ -1706,6 +1756,7 @@
     },
     "PB1250 PL": {
       "category": null,
+      "celsius_temp_increment": null,
       "control_board": "PBT",
       "enabled": true,
       "has_fc_functionality": 1,
@@ -1721,6 +1772,7 @@
     },
     "PB1250CS": {
       "category": null,
+      "celsius_temp_increment": null,
       "control_board": "PBM",
       "enabled": true,
       "has_fc_functionality": 1,
@@ -1736,6 +1788,7 @@
     },
     "PB1250CS2": {
       "category": null,
+      "celsius_temp_increment": null,
       "control_board": "PBA",
       "enabled": true,
       "has_fc_functionality": 1,
@@ -1751,6 +1804,7 @@
     },
     "PB1250NX": {
       "category": null,
+      "celsius_temp_increment": null,
       "control_board": "PBA",
       "enabled": true,
       "has_fc_functionality": 1,
@@ -1766,6 +1820,7 @@
     },
     "PB1250PL": {
       "category": null,
+      "celsius_temp_increment": null,
       "control_board": "PBA",
       "enabled": true,
       "has_fc_functionality": 1,
@@ -1781,6 +1836,7 @@
     },
     "PB1285KC": {
       "category": null,
+      "celsius_temp_increment": null,
       "control_board": "PBG",
       "enabled": true,
       "has_fc_functionality": 1,
@@ -1796,6 +1852,7 @@
     },
     "PB1285PC": {
       "category": null,
+      "celsius_temp_increment": null,
       "control_board": "PBG",
       "enabled": true,
       "has_fc_functionality": 1,
@@ -1811,6 +1868,7 @@
     },
     "PB1300 M": {
       "category": null,
+      "celsius_temp_increment": null,
       "control_board": "PBT",
       "enabled": true,
       "has_fc_functionality": 1,
@@ -1826,6 +1884,7 @@
     },
     "PB1300 PS4": {
       "category": null,
+      "celsius_temp_increment": null,
       "control_board": "PBT",
       "enabled": true,
       "has_fc_functionality": 1,
@@ -1841,6 +1900,7 @@
     },
     "PB1300M": {
       "category": null,
+      "celsius_temp_increment": null,
       "control_board": "PBA",
       "enabled": true,
       "has_fc_functionality": 1,
@@ -1856,6 +1916,7 @@
     },
     "PB1300PS4": {
       "category": null,
+      "celsius_temp_increment": null,
       "control_board": "PBA",
       "enabled": true,
       "has_fc_functionality": 1,
@@ -1871,6 +1932,7 @@
     },
     "PB1450CS": {
       "category": null,
+      "celsius_temp_increment": null,
       "control_board": "PBM",
       "enabled": true,
       "has_fc_functionality": 1,
@@ -1886,6 +1948,7 @@
     },
     "PB1500NXW": {
       "category": null,
+      "celsius_temp_increment": null,
       "control_board": "PBM2",
       "enabled": true,
       "has_fc_functionality": 1,
@@ -1901,6 +1964,7 @@
     },
     "PB1500NXW (PBM)": {
       "category": null,
+      "celsius_temp_increment": null,
       "control_board": "PBM",
       "enabled": true,
       "has_fc_functionality": 1,
@@ -1916,6 +1980,7 @@
     },
     "PB1600 CS": {
       "category": null,
+      "celsius_temp_increment": null,
       "control_board": "PBM2",
       "enabled": true,
       "has_fc_functionality": 1,
@@ -1931,6 +1996,7 @@
     },
     "PB1600 CS2": {
       "category": null,
+      "celsius_temp_increment": null,
       "control_board": "PBT",
       "enabled": true,
       "has_fc_functionality": 1,
@@ -1946,6 +2012,7 @@
     },
     "PB1600 M": {
       "category": null,
+      "celsius_temp_increment": null,
       "control_board": "PBT",
       "enabled": true,
       "has_fc_functionality": 1,
@@ -1961,6 +2028,7 @@
     },
     "PB1600 PSE": {
       "category": null,
+      "celsius_temp_increment": null,
       "control_board": "PBD",
       "enabled": true,
       "has_fc_functionality": 1,
@@ -1976,6 +2044,7 @@
     },
     "PB1600AMB": {
       "category": null,
+      "celsius_temp_increment": null,
       "control_board": "PBT",
       "enabled": true,
       "has_fc_functionality": 1,
@@ -1991,6 +2060,7 @@
     },
     "PB1600CS": {
       "category": null,
+      "celsius_temp_increment": null,
       "control_board": "PBM",
       "enabled": true,
       "has_fc_functionality": 1,
@@ -2006,6 +2076,7 @@
     },
     "PB1600CS2": {
       "category": null,
+      "celsius_temp_increment": null,
       "control_board": "PBA",
       "enabled": true,
       "has_fc_functionality": 1,
@@ -2021,6 +2092,7 @@
     },
     "PB1600CST": {
       "category": null,
+      "celsius_temp_increment": null,
       "control_board": "PBE",
       "enabled": true,
       "has_fc_functionality": 1,
@@ -2036,6 +2108,7 @@
     },
     "PB1600M": {
       "category": null,
+      "celsius_temp_increment": null,
       "control_board": "PBA",
       "enabled": true,
       "has_fc_functionality": 1,
@@ -2051,6 +2124,7 @@
     },
     "PB1600PS1": {
       "category": null,
+      "celsius_temp_increment": null,
       "control_board": "PBL",
       "enabled": true,
       "has_fc_functionality": 1,
@@ -2066,6 +2140,7 @@
     },
     "PB1600PS2": {
       "category": null,
+      "celsius_temp_increment": null,
       "control_board": "PBP",
       "enabled": true,
       "has_fc_functionality": 1,
@@ -2081,6 +2156,7 @@
     },
     "PB1600PS2 (PBL)": {
       "category": null,
+      "celsius_temp_increment": null,
       "control_board": "PBL",
       "enabled": true,
       "has_fc_functionality": 1,
@@ -2096,6 +2172,7 @@
     },
     "PB1600PS3": {
       "category": null,
+      "celsius_temp_increment": null,
       "control_board": "PBA",
       "enabled": true,
       "has_fc_functionality": 1,
@@ -2111,6 +2188,7 @@
     },
     "PB1600PS3_": {
       "category": "N/A",
+      "celsius_temp_increment": null,
       "control_board": "PBT",
       "enabled": true,
       "has_fc_functionality": 1,
@@ -2126,6 +2204,7 @@
     },
     "PB1600PS4": {
       "category": null,
+      "celsius_temp_increment": null,
       "control_board": "PBT",
       "enabled": true,
       "has_fc_functionality": 1,
@@ -2141,6 +2220,7 @@
     },
     "PB1600PSE": {
       "category": null,
+      "celsius_temp_increment": null,
       "control_board": "PBB",
       "enabled": true,
       "has_fc_functionality": 1,
@@ -2156,6 +2236,7 @@
     },
     "PB1600SPW": {
       "category": null,
+      "celsius_temp_increment": null,
       "control_board": "PBM",
       "enabled": true,
       "has_fc_functionality": 1,
@@ -2171,6 +2252,7 @@
     },
     "PB1600SPW2": {
       "category": null,
+      "celsius_temp_increment": null,
       "control_board": "PBM",
       "enabled": true,
       "has_fc_functionality": 1,
@@ -2186,6 +2268,7 @@
     },
     "PB2180LK": {
       "category": null,
+      "celsius_temp_increment": null,
       "control_board": "PBG",
       "enabled": true,
       "has_fc_functionality": 1,
@@ -2201,6 +2284,7 @@
     },
     "PB340": {
       "category": null,
+      "celsius_temp_increment": null,
       "control_board": "PBV",
       "enabled": true,
       "has_fc_functionality": 1,
@@ -2216,6 +2300,7 @@
     },
     "PB340TGW1 (Tailgator)": {
       "category": null,
+      "celsius_temp_increment": null,
       "control_board": "PBC",
       "enabled": true,
       "has_fc_functionality": 1,
@@ -2231,6 +2316,7 @@
     },
     "PB440D": {
       "category": null,
+      "celsius_temp_increment": null,
       "control_board": "PBV",
       "enabled": true,
       "has_fc_functionality": 1,
@@ -2246,6 +2332,7 @@
     },
     "PB440D2": {
       "category": null,
+      "celsius_temp_increment": null,
       "control_board": "PBC",
       "enabled": true,
       "has_fc_functionality": 1,
@@ -2261,6 +2348,7 @@
     },
     "PB440D3/PB456D": {
       "category": null,
+      "celsius_temp_increment": null,
       "control_board": "PBC",
       "enabled": true,
       "has_fc_functionality": 1,
@@ -2276,6 +2364,7 @@
     },
     "PB440TG1": {
       "category": null,
+      "celsius_temp_increment": null,
       "control_board": "PBV",
       "enabled": true,
       "has_fc_functionality": 1,
@@ -2291,6 +2380,7 @@
     },
     "PB440TGNC1": {
       "category": null,
+      "celsius_temp_increment": null,
       "control_board": "PBC",
       "enabled": true,
       "has_fc_functionality": 1,
@@ -2306,6 +2396,7 @@
     },
     "PB440TGR1": {
       "category": null,
+      "celsius_temp_increment": null,
       "control_board": "PBV",
       "enabled": true,
       "has_fc_functionality": 1,
@@ -2321,6 +2412,7 @@
     },
     "PB550G": {
       "category": null,
+      "celsius_temp_increment": null,
       "control_board": "PBC",
       "enabled": true,
       "has_fc_functionality": 1,
@@ -2336,6 +2428,7 @@
     },
     "PB700D": {
       "category": null,
+      "celsius_temp_increment": null,
       "control_board": "PBV",
       "enabled": true,
       "has_fc_functionality": 1,
@@ -2351,6 +2444,7 @@
     },
     "PB700FB": {
       "category": "Wood Pellet",
+      "celsius_temp_increment": null,
       "control_board": "PBV",
       "enabled": true,
       "has_fc_functionality": 1,
@@ -2366,6 +2460,7 @@
     },
     "PB700FBM2": {
       "category": null,
+      "celsius_temp_increment": null,
       "control_board": "PBV",
       "enabled": true,
       "has_fc_functionality": 1,
@@ -2381,6 +2476,7 @@
     },
     "PB700FBW2 (Classic)": {
       "category": null,
+      "celsius_temp_increment": null,
       "control_board": "PBC",
       "enabled": true,
       "has_fc_functionality": 1,
@@ -2396,6 +2492,7 @@
     },
     "PB700NC1": {
       "category": null,
+      "celsius_temp_increment": null,
       "control_board": "PBC",
       "enabled": true,
       "has_fc_functionality": 1,
@@ -2411,6 +2508,7 @@
     },
     "PB700R1": {
       "category": null,
+      "celsius_temp_increment": null,
       "control_board": "PBV",
       "enabled": true,
       "has_fc_functionality": 1,
@@ -2426,6 +2524,7 @@
     },
     "PB700R2": {
       "category": null,
+      "celsius_temp_increment": null,
       "control_board": "PBV",
       "enabled": true,
       "has_fc_functionality": 1,
@@ -2441,6 +2540,7 @@
     },
     "PB700S": {
       "category": null,
+      "celsius_temp_increment": null,
       "control_board": "PBV",
       "enabled": true,
       "has_fc_functionality": 1,
@@ -2456,6 +2556,7 @@
     },
     "PB700S1": {
       "category": null,
+      "celsius_temp_increment": null,
       "control_board": "PBV",
       "enabled": true,
       "has_fc_functionality": 1,
@@ -2471,6 +2572,7 @@
     },
     "PB700S2": {
       "category": null,
+      "celsius_temp_increment": null,
       "control_board": "PBV",
       "enabled": true,
       "has_fc_functionality": 1,
@@ -2486,6 +2588,7 @@
     },
     "PB700SC": {
       "category": null,
+      "celsius_temp_increment": null,
       "control_board": "PBV",
       "enabled": true,
       "has_fc_functionality": 1,
@@ -2501,6 +2604,7 @@
     },
     "PB700T1": {
       "category": null,
+      "celsius_temp_increment": null,
       "control_board": "PBV",
       "enabled": true,
       "has_fc_functionality": 1,
@@ -2516,6 +2620,7 @@
     },
     "PB820CS1": {
       "category": null,
+      "celsius_temp_increment": null,
       "control_board": "PBM",
       "enabled": true,
       "has_fc_functionality": 1,
@@ -2531,6 +2636,7 @@
     },
     "PB820D": {
       "category": null,
+      "celsius_temp_increment": null,
       "control_board": "PBV",
       "enabled": true,
       "has_fc_functionality": 1,
@@ -2546,6 +2652,7 @@
     },
     "PB820D2": {
       "category": null,
+      "celsius_temp_increment": null,
       "control_board": "PBC",
       "enabled": true,
       "has_fc_functionality": 1,
@@ -2561,6 +2668,7 @@
     },
     "PB820D3": {
       "category": null,
+      "celsius_temp_increment": null,
       "control_board": "PBC",
       "enabled": true,
       "has_fc_functionality": 1,
@@ -2576,6 +2684,7 @@
     },
     "PB820D4": {
       "category": null,
+      "celsius_temp_increment": null,
       "control_board": "PBC",
       "enabled": true,
       "has_fc_functionality": 1,
@@ -2591,6 +2700,7 @@
     },
     "PB820FB": {
       "category": null,
+      "celsius_temp_increment": null,
       "control_board": "PBV",
       "enabled": true,
       "has_fc_functionality": 1,
@@ -2606,6 +2716,7 @@
     },
     "PB820FBC": {
       "category": null,
+      "celsius_temp_increment": null,
       "control_board": "PBV",
       "enabled": true,
       "has_fc_functionality": 1,
@@ -2621,6 +2732,7 @@
     },
     "PB820PS1": {
       "category": null,
+      "celsius_temp_increment": null,
       "control_board": "PBC",
       "enabled": true,
       "has_fc_functionality": 1,
@@ -2636,6 +2748,7 @@
     },
     "PB820S": {
       "category": null,
+      "celsius_temp_increment": null,
       "control_board": "PBV",
       "enabled": true,
       "has_fc_functionality": 1,
@@ -2651,6 +2764,7 @@
     },
     "PB820SC": {
       "category": null,
+      "celsius_temp_increment": null,
       "control_board": "PBV",
       "enabled": true,
       "has_fc_functionality": 1,
@@ -2666,6 +2780,7 @@
     },
     "PB820T1": {
       "category": null,
+      "celsius_temp_increment": null,
       "control_board": "PBV",
       "enabled": true,
       "has_fc_functionality": 1,
@@ -2681,6 +2796,7 @@
     },
     "PB820XL/PB820ME": {
       "category": null,
+      "celsius_temp_increment": null,
       "control_board": "PBC",
       "enabled": true,
       "has_fc_functionality": 1,
@@ -2696,6 +2812,7 @@
     },
     "PB850AMB": {
       "category": null,
+      "celsius_temp_increment": null,
       "control_board": "PBM",
       "enabled": true,
       "has_fc_functionality": 1,
@@ -2711,6 +2828,7 @@
     },
     "PB850CS1": {
       "category": null,
+      "celsius_temp_increment": null,
       "control_board": "PBM",
       "enabled": true,
       "has_fc_functionality": 1,
@@ -2726,6 +2844,7 @@
     },
     "PB850CS2": {
       "category": null,
+      "celsius_temp_increment": null,
       "control_board": "PBM2",
       "enabled": true,
       "has_fc_functionality": 1,
@@ -2741,6 +2860,7 @@
     },
     "PB850CS2 (PBM)": {
       "category": null,
+      "celsius_temp_increment": null,
       "control_board": "PBM",
       "enabled": true,
       "has_fc_functionality": 1,
@@ -2756,6 +2876,7 @@
     },
     "PB850DX": {
       "category": null,
+      "celsius_temp_increment": null,
       "control_board": "PBL3",
       "enabled": true,
       "has_fc_functionality": 1,
@@ -2771,6 +2892,7 @@
     },
     "PB850DX (PBL2)": {
       "category": "grill",
+      "celsius_temp_increment": null,
       "control_board": "PBL2",
       "enabled": true,
       "has_fc_functionality": 1,
@@ -2786,6 +2908,7 @@
     },
     "PB850G/GW": {
       "category": null,
+      "celsius_temp_increment": null,
       "control_board": "PBC",
       "enabled": true,
       "has_fc_functionality": 1,
@@ -2801,6 +2924,7 @@
     },
     "PB850M": {
       "category": null,
+      "celsius_temp_increment": null,
       "control_board": "PBM2",
       "enabled": true,
       "has_fc_functionality": 1,
@@ -2816,6 +2940,7 @@
     },
     "PB850M (PBM)": {
       "category": null,
+      "celsius_temp_increment": null,
       "control_board": "PBM",
       "enabled": true,
       "has_fc_functionality": 1,
@@ -2831,6 +2956,7 @@
     },
     "PB850PS2": {
       "category": null,
+      "celsius_temp_increment": null,
       "control_board": "PBL",
       "enabled": true,
       "has_fc_functionality": 1,
@@ -2846,6 +2972,7 @@
     },
     "PB850SPW2": {
       "category": null,
+      "celsius_temp_increment": null,
       "control_board": "PBC2",
       "enabled": true,
       "has_fc_functionality": 1,
@@ -2861,6 +2988,7 @@
     },
     "PBV3 M": {
       "category": null,
+      "celsius_temp_increment": null,
       "control_board": "PBV2",
       "enabled": true,
       "has_fc_functionality": 1,
@@ -2876,6 +3004,7 @@
     },
     "PBV30DS": {
       "category": null,
+      "celsius_temp_increment": "40/45/50/55/60/65/70/75/80/85/90/95/100/105/110/115/120/125/130/135/140/145/150",
       "control_board": "PBVA",
       "enabled": true,
       "has_fc_functionality": 1,
@@ -2891,6 +3020,7 @@
     },
     "PBV30DX": {
       "category": null,
+      "celsius_temp_increment": "40/45/50/55/60/65/70/75/80/85/90/95/100/105/110/115/120/125/130/135/140/145/150",
       "control_board": "PBVA",
       "enabled": true,
       "has_fc_functionality": 1,
@@ -2906,6 +3036,7 @@
     },
     "PBV3M": {
       "category": null,
+      "celsius_temp_increment": null,
       "control_board": "PBV",
       "enabled": true,
       "has_fc_functionality": 1,
@@ -2921,6 +3052,7 @@
     },
     "PBV3NX": {
       "category": null,
+      "celsius_temp_increment": null,
       "control_board": "PBV2",
       "enabled": true,
       "has_fc_functionality": 1,
@@ -2936,6 +3068,7 @@
     },
     "PBV3NX (PBV)": {
       "category": null,
+      "celsius_temp_increment": null,
       "control_board": "PBV",
       "enabled": true,
       "has_fc_functionality": 1,
@@ -2951,6 +3084,7 @@
     },
     "PBV4DX": {
       "category": null,
+      "celsius_temp_increment": null,
       "control_board": "PBL3",
       "enabled": true,
       "has_fc_functionality": 1,
@@ -2966,6 +3100,7 @@
     },
     "PBV4NXW": {
       "category": null,
+      "celsius_temp_increment": null,
       "control_board": "PBV",
       "enabled": true,
       "has_fc_functionality": 1,
@@ -2981,6 +3116,7 @@
     },
     "PBV4PS2": {
       "category": null,
+      "celsius_temp_increment": null,
       "control_board": "PBL",
       "enabled": true,
       "has_fc_functionality": 1,
@@ -2996,6 +3132,7 @@
     },
     "PBV5 P2": {
       "category": null,
+      "celsius_temp_increment": null,
       "control_board": "PBV2",
       "enabled": true,
       "has_fc_functionality": 1,
@@ -3011,6 +3148,7 @@
     },
     "PBV5CS": {
       "category": null,
+      "celsius_temp_increment": null,
       "control_board": "PBC",
       "enabled": true,
       "has_fc_functionality": 1,
@@ -3026,6 +3164,7 @@
     },
     "PBV5P2": {
       "category": null,
+      "celsius_temp_increment": null,
       "control_board": "PBV",
       "enabled": true,
       "has_fc_functionality": 1,
@@ -3041,6 +3180,7 @@
     },
     "PBV5PL": {
       "category": null,
+      "celsius_temp_increment": null,
       "control_board": "PBG",
       "enabled": true,
       "has_fc_functionality": 1,
@@ -3056,6 +3196,7 @@
     },
     "PBV6 M": {
       "category": null,
+      "celsius_temp_increment": null,
       "control_board": "PBV2",
       "enabled": true,
       "has_fc_functionality": 1,
@@ -3071,6 +3212,7 @@
     },
     "PBV6 PSE": {
       "category": null,
+      "celsius_temp_increment": null,
       "control_board": "PBD",
       "enabled": true,
       "has_fc_functionality": 1,
@@ -3086,6 +3228,7 @@
     },
     "PBV6M": {
       "category": null,
+      "celsius_temp_increment": null,
       "control_board": "PBV",
       "enabled": true,
       "has_fc_functionality": 1,
@@ -3101,6 +3244,7 @@
     },
     "PBV6PSE": {
       "category": null,
+      "celsius_temp_increment": null,
       "control_board": "PBB",
       "enabled": true,
       "has_fc_functionality": 1,
@@ -3116,6 +3260,7 @@
     },
     "PBV7P2": {
       "category": null,
+      "celsius_temp_increment": null,
       "control_board": "PBV2",
       "enabled": true,
       "has_fc_functionality": 1,
@@ -3131,6 +3276,7 @@
     },
     "PBV7PW1": {
       "category": null,
+      "celsius_temp_increment": null,
       "control_board": "PBC",
       "enabled": true,
       "has_fc_functionality": 1,
@@ -3146,6 +3292,7 @@
     },
     "PBX - test 1": {
       "category": "N/A",
+      "celsius_temp_increment": null,
       "control_board": "PBX1",
       "enabled": true,
       "has_fc_functionality": 1,

--- a/scripts/dump_grills.py
+++ b/scripts/dump_grills.py
@@ -46,13 +46,16 @@ _DROPPED_FIELDS = frozenset(
 # protocol, so none of it is reachable through `Grill`, whose `json` attribute
 # is the only thing that ever exposed these.
 #
-# `celsius_temp_increment` is the exception worth naming, since its fahrenheit
-# counterpart is kept: it is null on all but two grills, and where it is set it
-# only restates `temp_increment` in celsius, which TemperatureConverter already
-# derives.
+# `celsius_temp_increment` was dropped here once and should not be again. It is
+# null on all but two grills -- PBV30DS and PBV30DX -- and the reasoning was
+# that where set it merely restates `temp_increment` in celsius. It does not:
+# those two declare 40..150 in steps of 5, where deriving it from the
+# fahrenheit list gives 37..148 at irregular intervals, so the two disagree at
+# nearly every entry. That is presumably why the vendor publishes one at all.
+# ha-pitboss reads it to decide which setpoints the board will honour, so
+# dropping it silently offered those grills values their board ignores.
 _DROPPED_GRILL_FIELDS = _DROPPED_FIELDS | {
     "app_layout",
-    "celsius_temp_increment",
     "control_board_id",
     "friendly_name",
     "has_indicators",


### PR DESCRIPTION
#504 dropped `celsius_temp_increment`, with a comment saying that where it is set it "only restates `temp_increment` in celsius, which TemperatureConverter already derives."

That is wrong. The two grills that declare one, `PBV30DS` and `PBV30DX`, publish:

```
40, 45, 50, ... 150          (steps of 5)
```

where deriving it from the fahrenheit list gives:

```
37, 40, 43, 46, 48, 51, ... 148   (irregular)
```

Different step, different endpoints, disagreeing at nearly every entry — presumably why the vendor publishes one at all.

**This is live downstream.** `ha-pitboss`'s `coordinator.accepted_setpoints` reads `spec.json["celsius_temp_increment"]` for exactly this case, so since 2026.8.2 those two models have been offered celsius setpoints their control board ignores, in the released integration. It also blocks #517, whose `celsius_temp_increments` branch cannot fire without the field.

Regenerated with `scripts/dump_grills.py` rather than hand-edited. The diff is a pure addition, verified structurally:

- same 147 grills, same 20 control boards, control board definitions byte-identical
- `celsius_temp_increment` is the only key added, none removed
- zero value changes on any other key

The comment above `_DROPPED_GRILL_FIELDS` now records why this one should not be dropped again.

693 tests, ruff and mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)