### PR TITLE
Carry the error code on RPCError and raise Unauthorized for 401

### DIFF
--- a/pytboss/exceptions.py
+++ b/pytboss/exceptions.py
@@ -6,7 +6,16 @@ class Error(Exception):
 
 
 class RPCError(Error):
-    """Raised when an RPC returns an error."""
+    """Raised when an RPC returns an error.
+
+    :param message: The error message returned by the device.
+    :param code: The error code returned by the device, when it sent one.
+    """
+
+    def __init__(self, message: str = "", code: int | None = None) -> None:
+        super().__init__(message)
+        self.message = message
+        self.code = code
 
 
 class InvalidGrill(Error):
@@ -21,8 +30,14 @@ class NotConnectedError(Error):
     """Raised when there is no active connection to use."""
 
 
-class Unauthorized(Error):
-    """Raised when an RPC is not authorized."""
+class Unauthorized(RPCError):
+    """Raised when a request is not authorized.
+
+    Subclasses `RPCError` so that callers already catching that keep catching
+    this. It is also raised by `pytboss.auth` for rejected account
+    credentials, which is not an RPC -- hence the plain `Error` message
+    signature still working.
+    """
 
 
 class UnsupportedOperation(Error):

--- a/pytboss/transport.py
+++ b/pytboss/transport.py
@@ -14,7 +14,7 @@ from typing import Any, Protocol, Self
 
 from mypy_extensions import DefaultNamedArg
 
-from .exceptions import RPCError
+from .exceptions import RPCError, Unauthorized
 
 DEFAULT_TIMEOUT = 30.0
 """Seconds to wait for a reply before giving up."""
@@ -36,6 +36,19 @@ SendCommandFn = Callable[
     Awaitable[dict[Any, Any] | None],
 ]
 """Signature shared by `Transport.send_command` and `send_command_without_answer`."""
+
+
+UNAUTHORIZED_CODE = 401
+"""The code the firmware answers with when the password is wrong or missing."""
+
+
+def _rpc_error(error: dict) -> RPCError:
+    """Build the exception for an error payload from the device."""
+    message = error.get("message", "Unknown error")
+    code = error.get("code")
+    if code == UNAUTHORIZED_CODE:
+        return Unauthorized(message, code)
+    return RPCError(message, code)
 
 
 class Transport(ABC):
@@ -92,6 +105,8 @@ class Transport(ABC):
         :param params: Parameters to send with the command.
         :param timeout: Timeout for the call. Pass `None` to wait forever.
         :raise pytboss.exceptions.RPCError: If the device returns an error response.
+        :raise pytboss.exceptions.Unauthorized: If the device rejects the
+            password. This is an `RPCError`, so catching that still works.
         :raise TimeoutError: If `timeout` elapses before a response is received.
         """
         cmd = await self._prepare_command(method, params)
@@ -138,9 +153,7 @@ class Transport(ABC):
             return False
         if not future.cancelled():
             if "error" in payload:
-                future.set_exception(
-                    RPCError(payload["error"].get("message", "Unknown error"))
-                )
+                future.set_exception(_rpc_error(payload["error"]))
             else:
                 future.set_result(payload["result"])
         return True

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -10,7 +10,12 @@ from freezegun import freeze_time
 
 from pytboss import api, grills
 from pytboss.codec import decode, timed_key
-from pytboss.exceptions import InvalidGrill, Unauthorized, UnsupportedOperation
+from pytboss.exceptions import (
+    InvalidGrill,
+    RPCError,
+    Unauthorized,
+    UnsupportedOperation,
+)
 from pytboss.transport import Transport
 
 STATE_HEX = (
@@ -556,3 +561,37 @@ async def test_set_temperature_unit(pitboss: api.PitBoss, conn: FakeTransport):
 
     assert (await pitboss.set_temperature_unit(fahrenheit=True)) == {}
     assert conn.last_mcu_command == "set-fahrenheit()"
+
+
+async def test_a_rejected_password_raises_unauthorized():
+    """The 401 has to be distinguishable without matching on the message."""
+    conn = FakeTransport("thepassword")
+    pitboss = api.PitBoss(conn, "PBV4PS2", "wrongpassword")
+    await pitboss.start()
+
+    with pytest.raises(Unauthorized) as caught:
+        await pitboss.get_state()
+    assert caught.value.code == 401
+
+    # Still an RPCError, so anything already catching that keeps working.
+    assert isinstance(caught.value, RPCError)
+
+
+async def test_other_rpc_errors_keep_their_code():
+    conn = FakeTransport()
+    pitboss = api.PitBoss(conn, "PBV4PS2")
+    await pitboss.start()
+
+    with pytest.raises(RPCError) as caught:
+        await pitboss._conn.send_command("No.SuchMethod", {})
+    assert not isinstance(caught.value, Unauthorized)
+    assert caught.value.code == -1
+
+
+async def test_an_error_without_a_code_is_still_an_rpc_error():
+    """Nothing guarantees the device sends one."""
+    assert RPCError("boom").code is None
+    # And the message-only constructor still works, as does the bare
+    # `Unauthorized` that `auth` and the fake transport both raise.
+    assert str(RPCError("boom")) == "boom"
+    assert str(Unauthorized()) == ""

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -555,6 +555,7 @@ async def test_get_state_updates_the_cached_state(conn: FakeTransport, password:
     want.update(TEMPS_DICT)
     assert pitboss._state == want
 
+
 async def test_set_temperature_unit(pitboss: api.PitBoss, conn: FakeTransport):
     assert (await pitboss.set_temperature_unit(fahrenheit=False)) == {}
     assert conn.last_mcu_command == "set-celsius()"


### PR DESCRIPTION
Fixes #515.

You said either a dedicated exception type or preserving `error.code` would do it, and that you would rather not have me guess. It turns out the choice is smaller than it looked, because **`Unauthorized` already exists** — it is just never raised from the RPC path. `auth.py` raises it for rejected account credentials; `_on_command_response` throws a bare `RPCError` for everything, including the firmware's 401.

So this does both, without adding a public class:

- `RPCError` gains an optional `code`, so any error code is available rather than only this one.
- The 401 raises the existing `Unauthorized`, which now subclasses `RPCError`.

```python
except Unauthorized:          # the password was rejected
except RPCError as ex:        # still catches the above; ex.code is there
```

**On backwards compatibility**, since this is the public exception surface:

- `RPCError("boom")` still works; `code` defaults to `None`.
- `Unauthorized` moving from `Error` to `RPCError` only widens what catches it. Anything catching `Error`, or `Unauthorized` itself, is unaffected.
- The one genuine break was mine and mypy caught it: I first made `message` required, which breaks `raise Unauthorized` with no arguments — which your own fake transport does, at `tests/test_api.py:104`. `message` now defaults to `""`, so bare `Unauthorized()` behaves exactly as before.

The widening is the one thing worth your judgement: a caller doing `except RPCError` around `auth.login` would now catch a credentials rejection it previously did not. Different call path, so I think it is theoretical, but it is a real change and I would rather point at it than let you find it.

**Verified the tests fail for the right reason** rather than assuming: with `_rpc_error` reverted to the old single-line `RPCError(...)`, `test_a_rejected_password_raises_unauthorized` and `test_other_rpc_errors_keep_their_code` both fail; with it back, all three pass. I did that on a copy of the file rather than via `git checkout`, having destroyed four changes that way on a downstream PR earlier today.

702 tests, ruff and mypy clean.

**One unrelated thing, which is mine to own.** The second commit restores a blank line in `tests/test_api.py` that `ruff format` wants. It is already on `main`: it came from my conflict resolution on #520, where I merged two test functions and dropped the separator. `build-and-test.yml` runs `ruff check` but not `ruff format --check`, which is why it went in green. Happy to split it out if you would rather this PR were single-purpose — and if you want, adding `ruff format --check` to the workflow would stop the next one, though I did not want to change your CI uninvited.

Label: `enhancement`, or `bug` if you read the 401 being indistinguishable as a defect. Still cannot set one myself.
