### PR TITLE
Reuse one JS interpreter per thread

### DIFF
--- a/pytboss/grills.py
+++ b/pytboss/grills.py
@@ -2,15 +2,40 @@
 
 import json
 import re
+import threading
 from collections.abc import Container, Iterable
 from dataclasses import dataclass, field
 from functools import cache
 from importlib import resources
 from typing import Any, TypedDict, cast
 
-from dukpy import evaljs
+from dukpy.evaljs import JSInterpreter
 
 from .exceptions import InvalidGrill
+
+_INTERPRETERS = threading.local()
+"""One JS interpreter per thread.
+
+`dukpy.evaljs()` builds a fresh interpreter for every call, and each one reads
+three runtime `.js` files from disk. Parsing a single state reply evaluates two
+routines, so a poll costs six file reads -- which an asyncio caller does on its
+event loop.
+
+Reusing one is safe here: the routines are self-contained functions evaluated
+as global scripts, and an interpreter survives a failed evaluation. It is kept
+thread-local rather than global because `get_grill()` is called through
+`asyncio.to_thread`, so parsing is not guaranteed to stay on one thread, and a
+QuickJS context is not documented as thread-safe.
+"""
+
+
+def _run_js(code: str, **kwargs: Any) -> Any:
+    """Evaluate `code` on this thread's interpreter."""
+    interpreter = getattr(_INTERPRETERS, "interpreter", None)
+    if interpreter is None:
+        interpreter = JSInterpreter()
+        _INTERPRETERS.interpreter = interpreter
+    return interpreter.evaljs(code, **kwargs)
 
 
 @cache
@@ -255,7 +280,7 @@ class Command:
         if self._js_func is None:
             raise NotImplementedError
 
-        return evaljs(_COMMAND_JS_TMPL % self._js_func, args=args)
+        return _run_js(_COMMAND_JS_TMPL % self._js_func, args=args)
 
 
 def _live_code(js: str | None) -> str:
@@ -301,7 +326,7 @@ class ControlBoard:
 
     def _evaljs(self, js_func: str, message: str) -> StateDict | None:
         js = _CONTROLLER_JS_TMPL % js_func
-        return evaljs(js, message=message)
+        return _run_js(js, message=message)
 
     @property
     def converts_temperatures_to_celsius(self) -> bool:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -550,6 +550,7 @@ async def test_get_state_updates_the_cached_state(conn: FakeTransport, password:
     want.update(TEMPS_DICT)
     assert pitboss._state == want
 
+
 async def test_set_temperature_unit(pitboss: api.PitBoss, conn: FakeTransport):
     assert (await pitboss.set_temperature_unit(fahrenheit=False)) == {}
     assert conn.last_mcu_command == "set-celsius()"

--- a/tests/test_grills.py
+++ b/tests/test_grills.py
@@ -5,6 +5,7 @@ from contextlib import contextmanager
 from math import floor
 
 import pytest
+from dukpy import JSRuntimeError
 
 from pytboss import grills as grills_lib
 from pytboss.exceptions import InvalidGrill
@@ -463,7 +464,7 @@ def test_the_interpreter_survives_a_failed_evaluation():
     message = "FE0B" + "0" * 60
     expected = board.parse_status(message)
 
-    with pytest.raises(Exception):
+    with pytest.raises(JSRuntimeError):
         grills_lib._run_js("throw new Error('boom');")
 
     assert board.parse_status(message) == expected

--- a/tests/test_grills.py
+++ b/tests/test_grills.py
@@ -1,4 +1,6 @@
+import builtins
 import re
+import threading
 from contextlib import contextmanager
 from math import floor
 
@@ -416,3 +418,71 @@ def test_converts_to_celsius_is_per_routine():
     board = grills_lib.ControlBoard("PBx", {}, "return {};", "ftoc(1);")
     assert board.converts_temperatures_to_celsius is True
     assert board.converts_status_to_celsius is False
+
+
+@contextmanager
+def _count_js_reads():
+    """Count reads of dukpy's runtime `.js` assets."""
+    reads: list[str] = []
+    real_open = builtins.open
+
+    def counting_open(path, *args, **kwargs):
+        if str(path).endswith(".js"):
+            reads.append(str(path))
+        return real_open(path, *args, **kwargs)
+
+    builtins.open = counting_open
+    try:
+        yield reads
+    finally:
+        builtins.open = real_open
+
+
+def test_the_interpreter_is_reused_across_parses():
+    """A fresh interpreter per parse reads three runtime files each time."""
+    board = grills_lib.get_grill("PBV4PS2").control_board
+    message = "FE0B" + "0" * 60
+    board.parse_status(message)  # warm this thread's interpreter
+
+    with _count_js_reads() as reads:
+        for _ in range(10):
+            board.parse_status(message)
+    assert reads == []
+
+
+def test_reuse_does_not_change_the_result():
+    board = grills_lib.get_grill("PBV4PS2").control_board
+    message = "FE0B" + "0" * 60
+    first = board.parse_status(message)
+    assert [board.parse_status(message) for _ in range(20)] == [first] * 20
+
+
+def test_the_interpreter_survives_a_failed_evaluation():
+    """One bad message must not poison every parse that follows."""
+    board = grills_lib.get_grill("PBV4PS2").control_board
+    message = "FE0B" + "0" * 60
+    expected = board.parse_status(message)
+
+    with pytest.raises(Exception):
+        grills_lib._run_js("throw new Error('boom');")
+
+    assert board.parse_status(message) == expected
+
+
+def test_each_thread_gets_its_own_interpreter():
+    """`get_grill` runs under `asyncio.to_thread`, so parsing can move."""
+    board = grills_lib.get_grill("PBV4PS2").control_board
+    message = "FE0B" + "0" * 60
+    expected = board.parse_status(message)
+    results: list[object] = []
+
+    def parse_on_this_thread() -> None:
+        results.append(board.parse_status(message))
+
+    threads = [threading.Thread(target=parse_on_this_thread) for _ in range(4)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert results == [expected] * 4


### PR DESCRIPTION
Fixes #511.

You held this back because you could not tell whether the parse routines ever run off the event loop thread, and a shared interpreter would not be safe if so. That is the right question, and the answer is that they can: `PitBoss.start` resolves the spec through `asyncio.to_thread(get_grill, ...)`, so parsing is not guaranteed to stay on one thread.

So this keeps the interpreter **thread-local** rather than global. That sidesteps the question entirely instead of answering it: each thread gets its own QuickJS context, so nothing is shared across threads and no assumption about QuickJS thread-safety is needed.

**The cost today, measured rather than estimated.** `dukpy.evaljs()` builds a fresh `JSInterpreter` per call, and `JSInterpreter.__init__` evaluates three runtime shims, each via `open()` — process, console and commonjs. So it is three file reads per eval, not one:

```
20 evals, dukpy.evaljs directly : 60 file reads
20 parses, this branch          :  3 file reads   (once per thread)
```

Parsing one state reply evaluates two routines, so a poll costs six reads on the event loop. Downstream that is about to get worse rather than better: adaptive polling at 10s instead of 30s triples the rate.

**What I checked before proposing reuse**, since "cache it" is only safe if the interpreter is actually reusable:

- **No state leaks between evals.** 200 sequential evals return identical results, and alternating the status and temperatures routines does not perturb either. The routines are self-contained functions evaluated as global scripts.
- **Reuse matches fresh.** Byte-identical results against a per-call interpreter.
- **A failed evaluation does not poison it.** Both a thrown `Error` and a syntax error raise `JSRuntimeError` and leave the interpreter working — I checked this because one malformed frame silently breaking every subsequent parse is the failure mode that would make caching a bad trade.
- **Concurrent threads agree.** Four threads parsing the same message get the same answer.

There are tests for each of those, and I verified the reuse test fails on the old behaviour rather than assuming it would.

The import moves from `dukpy.evaljs` to `dukpy.evaljs.JSInterpreter`; nothing public changes.

**The alternative I did not take** was running the eval in an executor. It leaves the per-call construction cost in place, and it would make `parse_status` async, which is a public API change for something that is otherwise a pure function. Happy to switch if you would rather have that.

One thing this does not do: the interpreter is never released, so a thread that parses once holds a QuickJS context for its lifetime. With `to_thread` that is a pool thread, so the count is bounded by the pool. I judged that cheaper than the reads, but say the word if you would rather it were a `WeakValueDictionary` or explicitly disposed.

703 tests, ruff, ruff format and mypy clean. Label: `enhancement` — still cannot set one myself.
