### PR TITLE
Add probe target routing and stop leaking the password into payloads

### DIFF
--- a/pytboss/api.py
+++ b/pytboss/api.py
@@ -430,6 +430,11 @@ class PitBoss:
         verbatim, so an authenticated write leaves the encoded password in the
         scratchpad and it would otherwise be handed back as if it were data.
 
+        This is the only thing that removes it, rather than a belt-and-braces
+        measure. Firmware 0.6.0 attempts the same strip and misses -- it
+        clears `vData.pws` while `checkPassword` reads `params.psw` -- and the
+        eight earlier mJS versions do not attempt it at all.
+
         :meta private:
         """
         data = await self._conn.send_command(

--- a/pytboss/api.py
+++ b/pytboss/api.py
@@ -34,6 +34,23 @@ VDataCallback = Callable[[dict], Awaitable[None] | None]
 """A callback function that receives updated VData."""
 
 
+def _to_fahrenheit(temp: int, already_fahrenheit: bool) -> int:
+    """Convert a grill-unit temperature for the virtual data store.
+
+    The store is always Fahrenheit, whatever unit the grill is set to.
+    """
+    if already_fahrenheit:
+        return temp
+    return round(temp * 9 / 5 + 32)
+
+
+def _from_fahrenheit(temp: float, want_fahrenheit: bool) -> int:
+    """Convert a virtual data temperature into the grill's own unit."""
+    if want_fahrenheit:
+        return round(temp)
+    return round((temp - 32) * 5 / 9)
+
+
 class PitBoss:
     """API for interacting with PitBoss grills over Bluetooth LE."""
 
@@ -172,11 +189,16 @@ class PitBoss:
                     callback(vdata)
 
     async def _authenticate(self, params: dict) -> dict:
-        if self._password:
-            params["psw"] = encode(
-                self._password, key=timed_key(await self.get_uptime())
-            ).hex()
-        return params
+        """Return `params` with the encoded password added.
+
+        A copy: the caller's dict is left alone. `PB.SetVirtualData` hands its
+        whole params object to the firmware, so mutating in place put the
+        encoded password into the caller's payload as well as on the wire.
+        """
+        if not self._password:
+            return params
+        psw = encode(self._password, key=timed_key(await self.get_uptime())).hex()
+        return {**params, "psw": psw}
 
     async def _send_hex_command(self, cmd: str) -> dict:
         return await self._conn.send_command(
@@ -246,6 +268,74 @@ class PitBoss:
         if cmd not in self.spec.control_board.commands:
             raise UnsupportedOperation
         return await self._send_command(cmd, temp)
+
+    def probe_target_command(self, probe_number: int) -> str | None:
+        """The board command that sets this probe's target, if it has one.
+
+        Across the catalogue only `set-probe-1-temperature` (42 of 137 models)
+        and `set-probe-2-temperature` (26) exist; no board declares anything
+        for probes 3 or 4. Which route a probe takes is a fact about the
+        board, so callers should not have to work it out.
+        """
+        command = f"set-probe-{probe_number}-temperature"
+        if command in self.spec.control_board.commands:
+            return command
+        return None
+
+    async def set_probe_target(self, probe_number: int, temp: int) -> None:
+        """Sets the target temperature for a probe.
+
+        Uses the board's command where one exists and the grill's virtual data
+        store otherwise, which is what the vendor's own app does. The grill
+        acts only on the control probe; a target stored in virtual data is a
+        note to whoever is watching, not something the board enforces.
+
+        :param probe_number: The probe to set a target for, counting from 1.
+        :param temp: Target probe temperature, in the grill's own unit.
+        :raise pytboss.exceptions.UnsupportedOperation: If the grill is off.
+            The firmware rejects virtual data writes unless `moduleIsOn`, and
+            clears the store when the grill is switched off.
+        """
+        if self.probe_target_command(probe_number) is not None:
+            await self._send_command(f"set-probe-{probe_number}-temperature", temp)
+            return
+        if not self._state.get("moduleIsOn"):
+            raise UnsupportedOperation(
+                "Virtual data cannot be written while the grill is off"
+            )
+        # The firmware assigns the payload wholesale, so everything already
+        # there has to be sent back or it is lost.
+        data = await self.get_virtual_data()
+        data[f"p{probe_number}T"] = _to_fahrenheit(temp, self._is_fahrenheit())
+        await self.set_virtual_data(data)
+
+    async def get_probe_targets(self) -> dict[int, int]:
+        """Returns the target temperature set for each probe.
+
+        Values are in the grill's own unit. Targets the board reports itself
+        win over the virtual data store: `p1Target` is reported by every
+        model and `p2Target` by 26 of them, and those are what the board is
+        actually working to.
+
+        Probes with no target set are absent rather than present as `None`.
+        """
+        fahrenheit = self._is_fahrenheit()
+        targets: dict[int, int] = {}
+        if self._state.get("moduleIsOn"):
+            data = await self.get_virtual_data()
+            for probe_number in range(1, (self.spec.meat_probes or 0) + 1):
+                raw = data.get(f"p{probe_number}T")
+                if isinstance(raw, (int, float)):
+                    targets[probe_number] = _from_fahrenheit(raw, fahrenheit)
+        for probe_number in range(1, (self.spec.meat_probes or 0) + 1):
+            reported = self._state.get(f"p{probe_number}Target")
+            if isinstance(reported, (int, float)):
+                targets[probe_number] = int(reported)
+        return targets
+
+    def _is_fahrenheit(self) -> bool:
+        """Whether the grill is currently working in Fahrenheit."""
+        return self._state.get("isFahrenheit", True) is not False
 
     async def set_temperature_unit(self, fahrenheit: bool) -> dict:
         """Switches the unit the grill itself works in.
@@ -333,14 +423,21 @@ class PitBoss:
             "PB.SetVirtualData", await self._authenticate(data)
         )
 
-    async def get_virtual_data(self):
+    async def get_virtual_data(self) -> dict:
         """Retrieves virtual data previously set with `set_virtual_data()`.
+
+        `psw` is removed: the firmware stores the params of the last write
+        verbatim, so an authenticated write leaves the encoded password in the
+        scratchpad and it would otherwise be handed back as if it were data.
 
         :meta private:
         """
-        return await self._conn.send_command(
+        data = await self._conn.send_command(
             "PB.GetVirtualData", await self._authenticate({})
         )
+        if isinstance(data, dict):
+            return {k: v for k, v in data.items() if k != "psw"}
+        return {}
 
     async def get_uptime(self) -> float:
         """Returns the device's uptime, in seconds.

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -606,6 +606,7 @@ async def test_an_error_without_a_code_is_still_an_rpc_error():
     assert str(RPCError("boom")) == "boom"
     assert str(Unauthorized()) == ""
 
+
 @pytest.mark.grill_params({"meat_probes": 4})
 async def test_set_probe_target_uses_the_board_command_when_there_is_one(
     pitboss: api.PitBoss, conn: FakeTransport

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -61,6 +61,7 @@ class FakeTransport(Transport):
     """Fake implementation of a transport protocol."""
 
     def __init__(self, password: str = ""):
+        self.virtual_data: dict = {}
         super().__init__()
         self.last_mcu_command: str | None = None
         self.password = password
@@ -89,6 +90,7 @@ class FakeTransport(Transport):
         dispatch = {
             "PB.GetTime": self._get_time,
             "PB.GetVirtualData": self._get_virtual_data,
+            "PB.SetVirtualData": self._set_virtual_data,
             "PB.SetDevicePassword": self._set_password,
             "PB.SendMCUCommand": self._send_mcu_command,
             "PB.GetState": self._get_state,
@@ -121,6 +123,12 @@ class FakeTransport(Transport):
 
     def _get_virtual_data(self, params: dict) -> dict:
         self._check_password(params)
+        return dict(self.virtual_data)
+
+    def _set_virtual_data(self, params: dict) -> dict:
+        """Assign the payload wholesale, as the firmware does."""
+        self._check_password(params)
+        self.virtual_data = dict(params)
         return {}
 
     def _set_password(self, params: dict) -> dict:
@@ -194,6 +202,7 @@ def my_grill(
         has_lights=kwargs.get("has_lights", False),
         temp_increments=kwargs.get("temp_increments", []),
         celsius_temp_increments=kwargs.get("celsius_temp_increments", []),
+        meat_probes=kwargs.get("meat_probes", 0),
     )
 
 
@@ -596,3 +605,107 @@ async def test_an_error_without_a_code_is_still_an_rpc_error():
     # `Unauthorized` that `auth` and the fake transport both raise.
     assert str(RPCError("boom")) == "boom"
     assert str(Unauthorized()) == ""
+
+@pytest.mark.grill_params({"meat_probes": 4})
+async def test_set_probe_target_uses_the_board_command_when_there_is_one(
+    pitboss: api.PitBoss, conn: FakeTransport
+):
+    """The mock board declares `set-probe-1-temperature` and nothing else."""
+    await pitboss.set_probe_target(1, 165)
+
+    assert conn.last_mcu_command == "set-probe-1-temperature(165,)"
+    assert conn.virtual_data == {}
+
+
+@pytest.mark.grill_params({"meat_probes": 4})
+async def test_set_probe_target_falls_back_to_virtual_data(
+    pitboss: api.PitBoss, conn: FakeTransport
+):
+    pitboss._state["moduleIsOn"] = True
+
+    await pitboss.set_probe_target(2, 165)
+
+    assert conn.virtual_data["p2T"] == 165
+    assert conn.last_mcu_command is None
+
+
+@pytest.mark.grill_params({"meat_probes": 4})
+async def test_virtual_data_writes_preserve_what_is_already_there(
+    pitboss: api.PitBoss, conn: FakeTransport
+):
+    """The firmware assigns wholesale, so a write must merge client-side."""
+    conn.virtual_data = {"p2T": 165}
+    pitboss._state["moduleIsOn"] = True
+
+    await pitboss.set_probe_target(3, 190)
+
+    assert conn.virtual_data["p2T"] == 165
+    assert conn.virtual_data["p3T"] == 190
+
+
+@pytest.mark.grill_params({"meat_probes": 4})
+async def test_virtual_data_is_always_fahrenheit(
+    pitboss: api.PitBoss, conn: FakeTransport
+):
+    """Whatever unit the grill itself is working in."""
+    pitboss._state["moduleIsOn"] = True
+    pitboss._state["isFahrenheit"] = False
+
+    await pitboss.set_probe_target(2, 74)
+
+    assert conn.virtual_data["p2T"] == 165
+    # ...and comes back in the grill's unit, round-tripping.
+    assert (await pitboss.get_probe_targets())[2] == 74
+
+
+@pytest.mark.grill_params({"meat_probes": 4})
+async def test_set_probe_target_refuses_while_the_grill_is_off(
+    pitboss: api.PitBoss, conn: FakeTransport
+):
+    """The firmware rejects the write and wipes the store at power-off."""
+    pitboss._state["moduleIsOn"] = False
+
+    with pytest.raises(UnsupportedOperation):
+        await pitboss.set_probe_target(2, 165)
+    assert conn.virtual_data == {}
+
+
+@pytest.mark.grill_params({"meat_probes": 4})
+async def test_a_reported_target_wins_over_virtual_data(
+    pitboss: api.PitBoss, conn: FakeTransport
+):
+    conn.virtual_data = {"p1T": 200}
+    pitboss._state["moduleIsOn"] = True
+    pitboss._state["p1Target"] = 165
+
+    assert (await pitboss.get_probe_targets())[1] == 165
+
+
+@pytest.mark.grill_params({"meat_probes": 4})
+async def test_the_password_never_reaches_the_scratchpad_as_data(
+    pitboss: api.PitBoss, conn: FakeTransport
+):
+    """`_authenticate` used to mutate the caller's payload."""
+    pitboss._state["moduleIsOn"] = True
+
+    payload = {"p2T": 165}
+    await pitboss.set_virtual_data(payload)
+
+    # The caller's dict is untouched...
+    assert payload == {"p2T": 165}
+    # ...and reads never hand the credential back as if it were data.
+    assert "psw" not in await pitboss.get_virtual_data()
+    # It does still reach the device, though: the firmware stores the params
+    # of the last write verbatim and authentication travels in that same
+    # object, so this is a protocol constraint rather than something the
+    # library can avoid. Stripping it on read is what keeps it out of every
+    # consumer's hands.
+    if pitboss._password:
+        assert "psw" in conn.virtual_data
+
+
+@pytest.mark.grill_params({"meat_probes": 4})
+async def test_probe_target_command_reports_the_route(pitboss: api.PitBoss):
+    assert pitboss.probe_target_command(1) == "set-probe-1-temperature"
+    assert pitboss.probe_target_command(2) is None
+    assert pitboss.probe_target_command(4) is None


### PR DESCRIPTION
Raised from review of [ha-pitboss#341](https://github.com/dknowles2/ha-pitboss/pull/341), where the reviewer's position was that this belongs here rather than in the integration. Agreed on all of it — the protocol facts are true with no Home Assistant anywhere near them.

Two things: a probe target API that owns the routing, and a password bug this turned up.

## `set_probe_target` / `get_probe_targets`

`set_probe_temperature` and `set_probe_2_temperature` cover the two boards' commands. Across the catalogue that is 42 of 137 models for probe 1 and 26 for probe 2 — counted through `get_grills()`, not the raw JSON, which misses `_COMMAND_SLUG_OVERRIDES` and counts the shadow-variant keys. **No board declares anything for probes 3 or 4.** So a four-probe grill can be given two targets at most, and on 95 models it can be given none.

The vendor's app does not use a command for the rest. It writes them into the control board's virtual data store under `p1T`..`p4T`, and does the comparing itself; the board never acts on those values. `set_probe_target` routes on `probe_target_command()` and falls back to the store, so a caller does not have to know which route a board supports.

Protocol facts now owned here rather than by each consumer:

- keys are `p1T`..`p4T`
- values are **always Fahrenheit**, whatever unit the grill is working in
- the firmware assigns the payload wholesale, so a write must send back everything already there
- writes are rejected unless `moduleIsOn`, and the store is wiped at power-off — hence `UnsupportedOperation` rather than a silent no-op
- board-reported targets win: `p1Target` is reported by all 137 models, `p2Target` by 26

Verified across all seven mJS firmware versions (0.2.3 to 0.6.0), which implement both RPCs identically including the power-off wipe. The ESP-IDF generation ships both RPCs as well, though there I can confirm presence and not behaviour, since it is a compiled binary.

## The password bug

`_authenticate` did `params["psw"] = ...` on the dict it was handed and returned the same object, and `set_virtual_data` passes the caller's dict straight into it. So calling it left the encoded password in the **caller's** payload. Downstream that ended up stored on a coordinator attribute; the review caught it there.

`_authenticate` now returns a copy, and `get_virtual_data` strips `psw` so a read never hands the credential back as if it were data.

**One thing I could not fix, and want to be exact about.** The password still reaches the grill's store. `PB.SetVirtualData` takes authentication in the same params object the firmware assigns wholesale, so an authenticated write necessarily leaves `psw` in the scratchpad. I found this because my own test asserted the payload was clean and failed on the `with_password` fixture — the fake was right and I was wrong. Sending it unauthenticated is not an option on a password-protected grill.

So this is a protocol constraint, not something the library can avoid, and the test says so rather than asserting something untrue. What the library *can* do is make sure no consumer ever sees it or has to know — which is the argument for the routing living here at all.

I verified the mutation test fails on the old `_authenticate` rather than assuming it would.

## Notes

`_from_fahrenheit` rounds rather than flooring. That is deliberate and different from `set_grill_temperature`, which floors to match what the boards do in their own conversion routine: nothing converts the virtual data store, so the only requirement is that a value round-trips, and rounding is what does that. 74 °C → 165 °F → 74 °C.

`get_probe_targets` omits probes with no target rather than mapping them to `None`, so `targets.get(n)` is the natural read.

`set_virtual_data` and `get_virtual_data` keep their `:meta private:` markers. I had claimed downstream that they were public; they are not, and that claim was wrong.

715 tests, ruff, ruff format and mypy clean. The fake transport now keeps a real scratchpad and assigns wholesale, so these exercise the protocol rather than a mock.

Label: `enhancement`, plus `bug` for the `_authenticate` half if you split them that way. Still cannot set one myself.
