### PR TITLE
Let a transport fail its in-flight commands when the link drops

### DIFF
--- a/pytboss/ble.py
+++ b/pytboss/ble.py
@@ -88,6 +88,8 @@ class BleConnection(Transport):
         """Called when our Bluetooth client is disconnected."""
         _LOGGER.debug("Bluetooth disconnected.")
         self._is_connected = False
+        # Bleak calls this synchronously, so the cleanup has to be scheduled.
+        self._loop.create_task(self._fail_pending_commands())
         if not self._reconnecting and self._disconnect_callback is not None:
             self._disconnect_callback(client)
 

--- a/pytboss/transport.py
+++ b/pytboss/transport.py
@@ -14,7 +14,7 @@ from typing import Any, Protocol, Self
 
 from mypy_extensions import DefaultNamedArg
 
-from .exceptions import RPCError, Unauthorized
+from .exceptions import NotConnectedError, RPCError, Unauthorized
 
 DEFAULT_TIMEOUT = 30.0
 """Seconds to wait for a reply before giving up."""
@@ -122,6 +122,24 @@ class Transport(ABC):
             # behind forever.
             async with self._lock:
                 self._rpc_futures.pop(cmd["id"], None)
+
+    async def _fail_pending_commands(self, ex: Exception | None = None) -> None:
+        """Fail commands still waiting for a reply that can no longer arrive.
+
+        A subclass calls this wherever it notices the link has gone -- usually
+        its receive loop rather than `disconnect()`, since a drop is not
+        normally an explicit disconnect. Without it, a caller waits out the
+        full `timeout` for a reply the device can no longer send.
+
+        :param ex: The exception to fail them with. Defaults to
+            `NotConnectedError`.
+        """
+        async with self._lock:
+            futures = list(self._rpc_futures.values())
+            self._rpc_futures.clear()
+        for future in futures:
+            if not future.done():
+                future.set_exception(ex or NotConnectedError())
 
     async def send_command_without_answer(
         self, method: str, params: dict, *, timeout: float | None = None

--- a/pytboss/wss.py
+++ b/pytboss/wss.py
@@ -118,6 +118,7 @@ class WebSocketConnection(Transport):
                 _LOGGER.debug("WebSocket closed")
 
             self._sock = None
+            await self._fail_pending_commands()
         _LOGGER.debug(
             "Exiting subscribe loop. is_running=%s, keep_running=%s",
             self._loop.is_running(),

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -1,5 +1,8 @@
+import asyncio
+
 import pytest
 
+from pytboss.exceptions import GrillUnavailable, NotConnectedError
 from pytboss.transport import Transport
 
 
@@ -42,4 +45,34 @@ async def test_send_command_gives_up_instead_of_waiting_forever():
     with pytest.raises(TimeoutError):
         await conn.send_command("PB.GetState", {}, timeout=0.01)
     # And the abandoned future must not be left behind.
+    assert conn._rpc_futures == {}
+
+
+async def test_fail_pending_commands_wakes_the_caller():
+    """A reply that can no longer arrive must not be waited out."""
+    conn = FakeTransport()
+    task = asyncio.create_task(conn.send_command("PB.GetState", {}, timeout=None))
+    await asyncio.sleep(0)  # let it register its future
+
+    await conn._fail_pending_commands()
+
+    with pytest.raises(NotConnectedError):
+        await task
+    assert conn._rpc_futures == {}
+
+
+async def test_fail_pending_commands_can_carry_a_reason():
+    conn = FakeTransport()
+    task = asyncio.create_task(conn.send_command("PB.GetState", {}, timeout=None))
+    await asyncio.sleep(0)
+
+    await conn._fail_pending_commands(GrillUnavailable("gone"))
+
+    with pytest.raises(GrillUnavailable):
+        await task
+
+
+async def test_fail_pending_commands_with_nothing_in_flight():
+    conn = FakeTransport()
+    await conn._fail_pending_commands()
     assert conn._rpc_futures == {}


### PR DESCRIPTION
Fixes #526.

Adds `Transport._fail_pending_commands(ex=None)` and calls it from both shipped transports, so a dropped link fails the commands waiting on it instead of leaving them to time out.

**Wired into the two existing transports, not just made available.** That was the part of the issue I cared about — the gap is theirs, not only a local transport's:

- `ble.py` — from `_on_disconnected`. Bleak calls that synchronously, so the cleanup is scheduled on the loop rather than awaited.
- `wss.py` — from `_subscribe`, right where it clears `self._sock` after the socket closes and before it starts backing off. That is the point where the reply provably cannot arrive: the reconnect gets a new socket, and the device does not resend.

`disconnect()` is deliberately not the hook. A drop is usually noticed by the receive loop, not by an explicit disconnect, so hooking `disconnect()` would miss the case that matters.

**Before this**, on both transports, a command in flight when the link went away waited out `DEFAULT_TIMEOUT` — 30s since #518, and forever before it. For a caller polling every 10s that is three polls of stall for a reply that cannot come.

The `ex` parameter is there because the two callers have different information: `wss` knows the socket closed, `ble` knows the adapter dropped, and a future caller may know the grill went away rather than the link. Defaults to `NotConnectedError`, which is what both use today.

**Verified it is the hook doing the work**, not the timeout: with the body replaced by `return`, a caller with `timeout=None` stays blocked past a two-second bound; with it restored, it wakes with `NotConnectedError`. The tests themselves pass `timeout=None` so they cannot pass by accident on a short timeout.

705 tests, ruff, ruff format and mypy clean.

This is the last thing standing between the transport in #505 and one that touches no private API — it carries this exact snippet today, reaching into `_rpc_futures` and `_lock` from outside. But the two shipped transports are the ones that get the behaviour change.

Label: `bug` seems right, since both transports stall today. Still cannot set one myself.
