### PR TITLE
Wrap Sys.Reboot and PB.WiFiAwakeWDT

### DIFF
--- a/pytboss/api.py
+++ b/pytboss/api.py
@@ -363,7 +363,7 @@ class PitBoss:
         """
         await self._conn.send_command_without_answer("Sys.Reboot", {})
 
-    async def request_fast_updates(self) -> dict:
+    async def request_fast_updates(self) -> None:
         """Asks the grill to push status to the cloud faster, for 5 minutes.
 
         Despite the RPC's name (`PB.WiFiAwakeWDT`) this does not keep the WiFi
@@ -375,14 +375,23 @@ class PitBoss:
         the push timer, so the grill pushes immediately and then every 5
         seconds until the five minutes lapse. Calling again restarts them.
 
-        **It affects the cloud WebSocket only.** The push it accelerates is
-        `WS.send(wsConn, ...)`, so a Bluetooth or local connection sees no
-        difference. Useful for a client reading the grill through the Dansons
-        relay while a user is watching; a no-op for anything else.
+        Two conditions decide whether it does anything at all:
+
+        * **The cloud WebSocket only.** The push it accelerates is
+          `WS.send(wsConn, ...)`, so a Bluetooth or local connection sees no
+          difference.
+        * **Only while the grill is on**, or was on at the previous tick --
+          the firmware guards the push with `lastWasOn || moduleIsOn`. On a
+          cold grill the timer still reschedules to the fast interval and
+          nothing is sent.
+
+        Useful for a client reading the grill through the Dansons relay while
+        a user is watching; a no-op for anything else.
+
+        Returns nothing: the firmware handler ends in `return null`, so there
+        is no result to hand back.
         """
-        return await self._conn.send_command(
-            "PB.WiFiAwakeWDT", await self._authenticate({})
-        )
+        await self._conn.send_command("PB.WiFiAwakeWDT", await self._authenticate({}))
 
     async def set_temperature_unit(self, fahrenheit: bool) -> dict:
         """Switches the unit the grill itself works in.

--- a/pytboss/api.py
+++ b/pytboss/api.py
@@ -363,12 +363,22 @@ class PitBoss:
         """
         await self._conn.send_command_without_answer("Sys.Reboot", {})
 
-    async def wifi_awake_wdt(self) -> dict:
-        """Holds the WiFi module awake for five minutes.
+    async def request_fast_updates(self) -> dict:
+        """Asks the grill to push status to the cloud faster, for 5 minutes.
 
-        The firmware arms a watchdog (`wsWDT = 5 * 60`) that keeps the module
-        from dropping its connection, and each call restarts it. The timeout
-        is the firmware's; it is not configurable.
+        Despite the RPC's name (`PB.WiFiAwakeWDT`) this does not keep the WiFi
+        module awake. The firmware runs a one-second tick that counts `wsWDT`
+        down and, each time its push timer expires, reschedules it to
+        `wsFastInterval` while `wsWDT > 0` and `wsSlowInterval` otherwise --
+        5 and 60 seconds by default, both settable via
+        `PB.SetWiFiUpdateFrequency`. This call sets `wsWDT` to 300 and zeroes
+        the push timer, so the grill pushes immediately and then every 5
+        seconds until the five minutes lapse. Calling again restarts them.
+
+        **It affects the cloud WebSocket only.** The push it accelerates is
+        `WS.send(wsConn, ...)`, so a Bluetooth or local connection sees no
+        difference. Useful for a client reading the grill through the Dansons
+        relay while a user is watching; a no-op for anything else.
         """
         return await self._conn.send_command(
             "PB.WiFiAwakeWDT", await self._authenticate({})

--- a/pytboss/api.py
+++ b/pytboss/api.py
@@ -354,6 +354,26 @@ class PitBoss:
         """Whether the grill is currently working in Fahrenheit."""
         return self._state.get("isFahrenheit", True) is not False
 
+    async def reboot(self) -> None:
+        """Reboots the WiFi module.
+
+        The standard remedy when the module wedges: it drops its connections
+        and comes back, leaving the grill itself running. No response is
+        expected, since the board reboots before it can answer.
+        """
+        await self._conn.send_command_without_answer("Sys.Reboot", {})
+
+    async def wifi_awake_wdt(self) -> dict:
+        """Holds the WiFi module awake for five minutes.
+
+        The firmware arms a watchdog (`wsWDT = 5 * 60`) that keeps the module
+        from dropping its connection, and each call restarts it. The timeout
+        is the firmware's; it is not configurable.
+        """
+        return await self._conn.send_command(
+            "PB.WiFiAwakeWDT", await self._authenticate({})
+        )
+
     async def set_temperature_unit(self, fahrenheit: bool) -> dict:
         """Switches the unit the grill itself works in.
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -786,3 +786,26 @@ async def test_probe_target_command_reports_the_route(pitboss: api.PitBoss):
     assert pitboss.probe_target_command(1) == "set-probe-1-temperature"
     assert pitboss.probe_target_command(2) is None
     assert pitboss.probe_target_command(4) is None
+
+async def test_reboot():
+    conn = FakeTransport()
+    pitboss = api.PitBoss(conn, "PBV4PS2")
+    await pitboss.start()
+    with mock.patch.object(
+        conn, "send_command_without_answer", AsyncMock(return_value=None)
+    ) as send:
+        assert await pitboss.reboot() is None
+        # Without an answer: the board reboots before it could send one.
+        send.assert_awaited_once_with("Sys.Reboot", {})
+
+
+async def test_wifi_awake_wdt(pitboss: api.PitBoss, conn: FakeTransport):
+    with mock.patch.object(
+        conn, "send_command", AsyncMock(return_value={})
+    ) as send:
+        assert await pitboss.wifi_awake_wdt() == {}
+        method, params = send.await_args.args
+        assert method == "PB.WiFiAwakeWDT"
+        # Authenticated: the firmware checks the password on this one.
+        assert set(params) <= {"psw"}
+        assert ("psw" in params) is bool(pitboss._password)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -800,10 +800,9 @@ async def test_reboot():
 
 
 async def test_wifi_awake_wdt(pitboss: api.PitBoss, conn: FakeTransport):
-    with mock.patch.object(
-        conn, "send_command", AsyncMock(return_value={})
-    ) as send:
+    with mock.patch.object(conn, "send_command", AsyncMock(return_value={})) as send:
         assert await pitboss.wifi_awake_wdt() == {}
+        assert send.await_args is not None
         method, params = send.await_args.args
         assert method == "PB.WiFiAwakeWDT"
         # Authenticated: the firmware checks the password on this one.

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -800,9 +800,9 @@ async def test_reboot():
         send.assert_awaited_once_with("Sys.Reboot", {})
 
 
-async def test_wifi_awake_wdt(pitboss: api.PitBoss, conn: FakeTransport):
+async def test_request_fast_updates(pitboss: api.PitBoss, conn: FakeTransport):
     with mock.patch.object(conn, "send_command", AsyncMock(return_value={})) as send:
-        assert await pitboss.wifi_awake_wdt() == {}
+        assert await pitboss.request_fast_updates() == {}
         assert send.await_args is not None
         method, params = send.await_args.args
         assert method == "PB.WiFiAwakeWDT"

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -63,6 +63,7 @@ class FakeTransport(Transport):
 
     def __init__(self, password: str = ""):
         self.virtual_data: dict = {}
+        self.fast_updates_requested = False
         super().__init__()
         self.last_mcu_command: str | None = None
         self.password = password
@@ -91,6 +92,7 @@ class FakeTransport(Transport):
         dispatch = {
             "PB.GetTime": self._get_time,
             "PB.GetVirtualData": self._get_virtual_data,
+            "PB.WiFiAwakeWDT": self._wifi_awake_wdt,
             "PB.SetVirtualData": self._set_virtual_data,
             "PB.SetDevicePassword": self._set_password,
             "PB.SendMCUCommand": self._send_mcu_command,
@@ -121,6 +123,11 @@ class FakeTransport(Transport):
 
     def _get_time(self, params: dict) -> dict:
         return {"time": self._uptime()}
+
+    def _wifi_awake_wdt(self, params: dict) -> None:
+        """Password-checked, and ends in `return null` like the firmware."""
+        self._check_password(params)
+        self.fast_updates_requested = True
 
     def _get_virtual_data(self, params: dict) -> dict:
         self._check_password(params)
@@ -801,11 +808,13 @@ async def test_reboot():
 
 
 async def test_request_fast_updates(pitboss: api.PitBoss, conn: FakeTransport):
-    with mock.patch.object(conn, "send_command", AsyncMock(return_value={})) as send:
-        assert await pitboss.request_fast_updates() == {}
-        assert send.await_args is not None
-        method, params = send.await_args.args
-        assert method == "PB.WiFiAwakeWDT"
-        # Authenticated: the firmware checks the password on this one.
-        assert set(params) <= {"psw"}
-        assert ("psw" in params) is bool(pitboss._password)
+    """Reaches the grill, and returns nothing because the reply carries nothing.
+
+    Driven through the fake's own handler rather than a mocked
+    `send_command`: a mock returning a dict would be asserting on a reply no
+    grill sends, and one returning `None` would also break `PB.GetTime`,
+    which authentication needs. The fake refuses a wrong password, so the
+    `with_password` case proves this call is authenticated.
+    """
+    await pitboss.request_fast_updates()
+    assert conn.fast_updates_requested is True

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -787,6 +787,7 @@ async def test_probe_target_command_reports_the_route(pitboss: api.PitBoss):
     assert pitboss.probe_target_command(2) is None
     assert pitboss.probe_target_command(4) is None
 
+
 async def test_reboot():
     conn = FakeTransport()
     pitboss = api.PitBoss(conn, "PBV4PS2")


### PR DESCRIPTION
Fixes #529.

Two wrappers, nothing else:

```python
async def reboot(self) -> None: ...          # Sys.Reboot, no answer expected
async def wifi_awake_wdt(self) -> dict: ...  # PB.WiFiAwakeWDT, authenticated
```

**This duplicates part of your own #458, deliberately and narrowly.** #458 implements both alongside OTA, `PB.LoadMCUFirmware`, `PB.SetWifiCredentials` and `Wifi.Scan` — the RPCs where a wrong call bricks the board or locks the grill off its network, and which I decided never to expose from an integration for exactly that reason. Those deserve the careful review they are getting. These two do not, and two Home Assistant buttons are the only thing waiting.

**Close this without ceremony if you would rather land #458 in one piece.** I would rather lose the work than cut across your PR; the issue explains the reasoning and I am happy for it to end there.

**What is verified, and what is not:**

`PB.WiFiAwakeWDT` — present and identical in all nine mJS firmware versions (0.2.3 through 0.6.0), read from the vendor's public CDN. It is password-checked, so the wrapper authenticates, and the five minutes in the docstring is the firmware's own `wsWDT = 5 * 60` rather than an assumption. It returns `null`, so the wrapper returns whatever the transport gives back rather than promising a shape.

`Sys.Reboot` — **not independently verified, and I would rather flag that than let it read as checked.** It is absent from `init.js` because it is a Mongoose OS core RPC rather than one the app registers; the firmware's own `Sys.reboot` calls are the mJS API function, not the RPC method. `Sys.GetInfo` from that same core service works on my grill, so the service is enabled — but I have not sent `Sys.Reboot`, and I am not going to test it casually on a grill someone is cooking on. #458 makes the same call, so if it is wrong it is wrong in both.

`send_command_without_answer` is used for the reboot because the board goes down before it can reply — same as #458 does, and for the same reason.

709 tests, ruff, ruff format and mypy clean.

Label: `enhancement`. Still cannot set one myself.
