### PR TITLE
Enforce ruff format in CI, and state the ruff config

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -48,6 +48,7 @@ jobs:
       - name: Run ruff
         run: |
           uv run ruff check --output-format=github .
+          uv run ruff format --check .
   mypy:
     runs-on: ubuntu-latest
     strategy:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,18 @@ exclude = ["fake_firmware"]
 [tool.setuptools_scm]
 write_to = "pytboss/_version.py"
 
+[tool.ruff]
+# Stated rather than inferred. `ruff format` decides where to wrap from
+# `line-length`, so CI and a local run have to agree on it, and the target
+# version is otherwise derived from `requires-python` at a distance.
+#
+# Deliberately no `[tool.ruff.lint] select`: ruff's default set is much wider
+# than the `E4, E7, E9, F` the docs describe -- it includes BLE, B, S, ASYNC
+# and more, which is why `# noqa: BLE001` appears in this tree at all. Naming
+# a narrower set here would silently switch rules off.
+line-length    = 88
+target-version = "py312"
+
 [tool.uv]
 default-groups = []
 


### PR DESCRIPTION
Raised by @trailro on #524, who offered to add this and rightly declined to change CI uninvited.

`build-and-test.yml` runs `ruff check` but not `ruff format --check`. They are separate tools — the linter and the formatter — so formatting drift merges green. That is exactly how a missing blank line got into `tests/test_api.py` through #520's conflict resolution and then needed a commit in #524 to undo and explain.

`main` is currently clean, so this enforces the status quo rather than changing it.

## The config

`line-length` and `target-version` are now stated rather than inferred. `ruff format` decides where to wrap from `line-length`, so CI and a local `ruff format` have to agree on it; `target-version` was being derived from `requires-python` at a distance.

**No `[tool.ruff.lint] select`, deliberately** — and this is worth recording, because I got it wrong first and CI caught it.

Ruff's documented default is `["E4", "E7", "E9", "F"]`. Writing that down produced a lint error that `main` does not have (`E402` in `scripts/update_readme.py`), because ruff 0.16's *actual* default set is far wider — it includes `BLE`, `B`, `S`, `ASYNC` and more. That is why `# noqa: BLE001` appears in this tree at all; under the documented default it would be inert.

So naming a set would have silently switched rules off while appearing to be a no-op. Leaving `select` unset preserves the real defaults exactly.

Verified: `ruff check`, `ruff format --check`, `mypy` and 722 tests all pass, and `--show-settings` resolves to the same `line_length = 88` / `target_version = 3.12` as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)