### PR TITLE
Treat an RPC response without a result as a successful empty reply

### DIFF
--- a/pytboss/transport.py
+++ b/pytboss/transport.py
@@ -173,5 +173,7 @@ class Transport(ABC):
             if "error" in payload:
                 future.set_exception(_rpc_error(payload["error"]))
             else:
-                future.set_result(payload["result"])
+                # Mongoose OS omits `result` when a handler returns nothing,
+                # so its absence is a successful empty reply, not an error.
+                future.set_result(payload.get("result"))
         return True

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -39,6 +39,18 @@ async def test_on_command_response_unknown_id():
     assert handled is False
 
 
+async def test_response_without_result_resolves_the_command():
+    """Mongoose OS omits `result` when a handler returns nothing."""
+    conn = FakeTransport()
+    task = asyncio.create_task(conn.send_command("Sys.Reboot", {}, timeout=None))
+    await asyncio.sleep(0)  # let it register its future
+
+    handled = await conn._on_command_response({"id": 1})
+
+    assert handled is True
+    assert await task is None
+
+
 async def test_send_command_gives_up_instead_of_waiting_forever():
     """A reply that never arrives must not block the caller indefinitely."""
     conn = FakeTransport()


### PR DESCRIPTION
## Problem

`Transport._on_command_response` indexes `payload["result"]` unconditionally. Mongoose OS omits the `result` field when an RPC handler returns nothing (e.g. `Sys.Reboot`, and some `Config.*` handlers), so a perfectly valid success reply raises `KeyError` — and it raises on the **receive path**, not at the caller:

- On BLE, the notification handler errors out, the response is lost, and the caller waits out its full 30s timeout.
- On WSS, the exception propagates into the subscribe loop and kills the connection (no further reconnects).

Verified with a minimal repro: a queued `send_command()` answered with `{"id": N}` (no `result`, no `error`) raises `KeyError: 'result'` from `_on_command_response` while the caller keeps waiting.

## Fix

`payload.get("result")` — the future resolves to `None` for a result-less success, which callers that issue fire-and-forget-style commands simply ignore.

## Testing

- New test: `test_response_without_result_resolves_the_command`.
- `pytest` (726 passed), `ruff check`, `ruff format --check`, `mypy .` all green at the CI-pinned versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)