### PR TITLE
Dispatch subscriber callbacks without holding the api lock

### DIFF
--- a/pytboss/api.py
+++ b/pytboss/api.py
@@ -7,6 +7,7 @@ import logging
 from collections.abc import Awaitable, Callable
 from math import floor
 from time import monotonic
+from typing import Any
 
 from .codec import encode, timed_key
 from .config import Config
@@ -51,6 +52,19 @@ def _from_fahrenheit(temp: float, want_fahrenheit: bool) -> int:
     return round((temp - 32) * 5 / 9)
 
 
+async def _invoke(callback: Callable[[Any], Awaitable[None] | None], arg: Any) -> None:
+    """Call a subscriber, awaiting the result when there is one to await.
+
+    Decided from the returned value rather than the callback:
+    `inspect.iscoroutinefunction` cannot see through `functools.partial` or
+    an object with an `async __call__`, and calling those without awaiting
+    silently discards their coroutine.
+    """
+    result = callback(arg)
+    if inspect.isawaitable(result):
+        await result
+
+
 class PitBoss:
     """API for interacting with PitBoss grills over Bluetooth LE."""
 
@@ -88,7 +102,8 @@ class PitBoss:
         self._conn.set_state_callback(self._on_state_received)
         self._conn.set_vdata_callback(self._on_vdata_received)
         self._password = password.encode("utf-8")
-        self._lock = asyncio.Lock()  # protects callbacks and state.
+        self._lock = asyncio.Lock()  # protects state and the subscriber lists.
+        self._callback_lock = asyncio.Lock()  # serializes subscriber dispatch.
         self._state_callbacks: list[StateCallback] = []
         self._vdata_callbacks: list[VDataCallback] = []
         self._state = StateDict()
@@ -168,25 +183,27 @@ class PitBoss:
 
         async with self._lock:
             self._state.update(state)
+            callbacks = list(self._state_callbacks)
+        # Dispatched outside `_lock`: a subscriber that calls back into the
+        # API (`get_state()` takes the same lock) would otherwise deadlock.
+        # The dedicated lock keeps one update's callbacks from interleaving
+        # with the next one's, which holding `_lock` used to guarantee.
+        async with self._callback_lock:
             # TODO: Run callbacks concurrently
             # TODO: Send copies of state so subscribers can't modify it
-            for callback in self._state_callbacks:
-                if inspect.iscoroutinefunction(callback):
-                    await callback(self._state)
-                else:
-                    callback(self._state)
+            for callback in callbacks:
+                await _invoke(callback, self._state)
 
     async def _on_vdata_received(self, payload: str):
         vdata = json.loads(payload)
         _LOGGER.debug("VData received: %s", vdata)
         async with self._lock:
+            callbacks = list(self._vdata_callbacks)
+        async with self._callback_lock:
             # TODO: Run callbacks concurrently
             # TODO: Send copies of state so subscribers can't modify it
-            for callback in self._vdata_callbacks:
-                if inspect.iscoroutinefunction(callback):
-                    await callback(vdata)
-                else:
-                    callback(vdata)
+            for callback in callbacks:
+                await _invoke(callback, vdata)
 
     async def _authenticate(self, params: dict) -> dict:
         """Return `params` with the encoded password added.

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 from collections.abc import Generator
 from itertools import count
@@ -457,6 +458,57 @@ async def test_on_state_received_async_callback():
     await pitboss.subscribe_state(cb)
     await conn.send_state(STATE_HEX)
     assert received == [STATE_DICT]
+
+
+async def test_state_callback_may_call_back_into_the_api():
+    """`get_state()` takes the api lock, so dispatch must not hold it."""
+    conn = FakeTransport()
+    pitboss = api.PitBoss(conn, "PBV4PS2")
+    await pitboss.start()
+    seen = []
+
+    async def cb(state):
+        seen.append(await pitboss.get_state())
+
+    await pitboss.subscribe_state(cb)
+    await asyncio.wait_for(conn.send_state(STATE_HEX), timeout=5)
+    assert len(seen) == 1
+
+
+async def test_state_callback_may_subscribe_another():
+    """`subscribe_state()` takes the api lock, so dispatch must not hold it."""
+    conn = FakeTransport()
+    pitboss = api.PitBoss(conn, "PBV4PS2")
+    await pitboss.start()
+
+    async def late(state):
+        pass
+
+    async def cb(state):
+        await pitboss.subscribe_state(late)
+
+    await pitboss.subscribe_state(cb)
+    await asyncio.wait_for(conn.send_state(STATE_HEX), timeout=5)
+    assert late in pitboss._state_callbacks
+
+
+async def test_state_subscriber_with_async_call_method():
+    """`iscoroutinefunction` cannot see through an `async __call__`."""
+
+    class Subscriber:
+        def __init__(self):
+            self.seen = []
+
+        async def __call__(self, state):
+            self.seen.append(dict(state))
+
+    conn = FakeTransport()
+    pitboss = api.PitBoss(conn, "PBV4PS2")
+    await pitboss.start()
+    subscriber = Subscriber()
+    await pitboss.subscribe_state(subscriber)
+    await conn.send_state(STATE_HEX)
+    assert subscriber.seen == [STATE_DICT]
 
 
 async def test_on_vdata_received():


### PR DESCRIPTION
## Problem

`_on_state_received` / `_on_vdata_received` await subscriber callbacks while holding `PitBoss._lock`. The lock is not reentrant, so any subscriber that calls back into the API deadlocks permanently:

- `get_state()` takes `_lock` to update the cached state → deadlock.
- `subscribe_state()` / `subscribe_vdata()` take `_lock` to append → deadlock.

Verified with a repro: a state subscriber that awaits `get_state()` hangs forever (bounded only by an external `wait_for`).

Separately, the dispatch decision used `inspect.iscoroutinefunction()`, which cannot see through `functools.partial` or an object with an `async __call__` — those were called synchronously and their coroutine silently discarded (plus a `RuntimeWarning`).

## Fix

- State and the subscriber list are updated under `_lock`; callbacks are dispatched **outside** it, under a dedicated `_callback_lock` that preserves the existing guarantee that one update's callbacks finish before the next update's start.
- Whether to await is decided from the returned value (`inspect.isawaitable`) rather than from the callback object.

No public API or behavioral change for existing subscribers: same shared `StateDict` instance, same ordering.

## Testing

- New tests: reentrant `get_state()` from a subscriber, reentrant `subscribe_state()`, and a subscriber object with `async __call__`.
- `pytest` (728 passed), `ruff check`, `ruff format --check`, `mypy .` all green at the CI-pinned versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)