### PR TITLE
Keep the WSS receive loop alive through bad payloads and callbacks

### DIFF
--- a/pytboss/wss.py
+++ b/pytboss/wss.py
@@ -3,12 +3,14 @@
 import asyncio
 import logging
 from asyncio import AbstractEventLoop, Event, Lock, Task
+from contextlib import suppress
 from typing import Any
 from uuid import uuid4
 
 from aiohttp import (
     ClientSession,
     ClientWebSocketResponse,
+    WSMsgType,
     WSServerHandshakeError,
 )
 
@@ -54,12 +56,14 @@ class WebSocketConnection(Transport):
         self._app_id = app_id or str(uuid4()).split("-")[-1]
         self._subscribe_task: Task | None = None
         self._subscribed = Event()
+        self._stopping = Event()
         self._keep_running = False
 
     async def connect(self) -> None:
         """Starts the connection to the device."""
         self._sock = await self._ws_connect()
         self._keep_running = True
+        self._stopping.clear()
         self._subscribe_task = self._loop.create_task(self._subscribe())
         await self._subscribed.wait()
 
@@ -71,6 +75,9 @@ class WebSocketConnection(Transport):
         for the background reconnect/subscribe task to finish.
         """
         self._keep_running = False
+        # Wake the subscribe task if it is waiting out a reconnect backoff;
+        # otherwise this call blocks for the remainder of that sleep.
+        self._stopping.set()
         if self._sock:
             await self._sock.close()
         # Only close the session if we created it (not if it was provided externally)
@@ -99,7 +106,7 @@ class WebSocketConnection(Transport):
                 except GrillUnavailable as ex:
                     _LOGGER.debug("Failed to connect (attempt %d): %s", attempt, ex)
                     _LOGGER.debug("Will try again in %.2fs", backoff)
-                    await asyncio.sleep(backoff)
+                    await self._backoff_wait(backoff)
                     attempt += 1
                     backoff = min(_MAX_BACKOFF_TIME, backoff * 2)
                     continue
@@ -111,10 +118,24 @@ class WebSocketConnection(Transport):
                 _LOGGER.debug("Waiting for payloads")
                 self._subscribed.set()
                 async for msg in self._sock:
-                    async with self._sock_lock:
+                    # One bad payload or subscriber must not tear down the
+                    # stream: an exception escaping this loop would end the
+                    # task, and with it the automatic reconnects this class
+                    # promises, while leaving in-flight commands to wait out
+                    # their full timeout.
+                    if msg.type is not WSMsgType.TEXT:
+                        _LOGGER.debug("Ignoring %s frame", msg.type.name)
+                        continue
+                    try:
                         payload = msg.json()
-                        _LOGGER.debug("WSS payload: %s", payload)
+                    except ValueError:
+                        _LOGGER.warning("Ignoring malformed payload: %s", msg.data)
+                        continue
+                    _LOGGER.debug("WSS payload: %s", payload)
+                    try:
                         await self._handle_message(payload)
+                    except Exception:
+                        _LOGGER.exception("Error handling payload: %s", payload)
                 _LOGGER.debug("WebSocket closed")
 
             self._sock = None
@@ -124,6 +145,17 @@ class WebSocketConnection(Transport):
             self._loop.is_running(),
             self._keep_running,
         )
+
+    async def _backoff_wait(self, backoff: float) -> None:
+        """Wait out a reconnect backoff.
+
+        Interruptible: `disconnect()` sets `_stopping` so it does not have to
+        wait for the remainder of the backoff, which reaches
+        `_MAX_BACKOFF_TIME` seconds.
+        """
+        with suppress(TimeoutError):
+            async with asyncio.timeout(backoff):
+                await self._stopping.wait()
 
     async def _handle_message(self, payload: dict[str, Any]) -> None:
         if "app_id" in payload and payload["app_id"] != self._app_id:
@@ -156,9 +188,13 @@ class WebSocketConnection(Transport):
         return self._sock is not None and not self._sock.closed
 
     async def _send_prepared_command(self, cmd: dict) -> None:
-        if not self.is_connected():
-            raise NotConnectedError
         cmd["app_id"] = self._app_id
         _LOGGER.debug("Sending command: %s", cmd)
         async with self._sock_lock:
-            await self._sock.send_json(cmd)  # type: ignore
+            # Re-read under the lock: the subscribe loop clears `_sock` when
+            # the stream ends, so a check made before acquiring the lock can
+            # be stale by the time the send happens.
+            sock = self._sock
+            if sock is None or sock.closed:
+                raise NotConnectedError
+            await sock.send_json(cmd)

--- a/tests/test_wss.py
+++ b/tests/test_wss.py
@@ -1,4 +1,4 @@
-from asyncio import Event, Queue, create_task
+from asyncio import Event, Queue, create_task, sleep, timeout
 from collections.abc import AsyncGenerator
 from unittest.mock import AsyncMock, call, patch
 
@@ -38,7 +38,12 @@ async def fake_server(
 
         async def pump_status():
             while True:
-                await ws.send_json(await state_payloads.get())
+                payload = await state_payloads.get()
+                if isinstance(payload, str):
+                    # A raw frame, for exercising malformed payloads.
+                    await ws.send_str(payload)
+                else:
+                    await ws.send_json(payload)
                 state_payloads.task_done()
 
         task = create_task(pump_status())
@@ -122,8 +127,8 @@ async def test_connect_server_error(session: ClientSession) -> None:
             await conn.connect()
 
 
-@patch("asyncio.sleep")
-async def test_reconnect_backoff(mock_sleep: AsyncMock, session: ClientSession) -> None:
+@patch.object(wss.WebSocketConnection, "_backoff_wait")
+async def test_reconnect_backoff(mock_wait: AsyncMock, session: ClientSession) -> None:
     responses = [True, False, False, False, False, False, False, False, True]
 
     async def handler(request: Request):
@@ -154,7 +159,7 @@ async def test_reconnect_backoff(mock_sleep: AsyncMock, session: ClientSession) 
         await conn.connect()
         await done.wait()
         await conn.disconnect()
-    mock_sleep.assert_has_awaits(
+    mock_wait.assert_has_awaits(
         [call(1.0), call(2.0), call(4.0), call(8.0), call(16.0), call(30.0), call(30.0)]
     )
 
@@ -216,6 +221,87 @@ async def test_command_wrong_app_id(
 
     state_callback.assert_not_awaited()
     vdata_callback.assert_not_awaited()
+
+
+async def test_malformed_payload_does_not_kill_the_stream(
+    conn: wss.WebSocketConnection, state_payloads: Queue
+) -> None:
+    state_callback = MockCallback(1)
+    conn.set_state_callback(state_callback)
+    async with conn:
+        await state_payloads.put("this is not json")
+        await state_payloads.put({"status": ["state"]})
+        async with timeout(5):
+            await state_callback.wait()
+    state_callback.assert_awaited_once_with("state")
+
+
+async def test_subscriber_exception_does_not_kill_the_stream(
+    conn: wss.WebSocketConnection, state_payloads: Queue
+) -> None:
+    state_callback = MockCallback(2)
+    state_callback.mock.side_effect = [RuntimeError("boom"), None]
+    conn.set_state_callback(state_callback)
+    async with conn:
+        await state_payloads.put({"status": ["first"]})
+        await state_payloads.put({"status": ["second"]})
+        async with timeout(5):
+            await state_callback.wait()
+    assert state_callback.mock.await_count == 2
+
+
+async def test_state_callback_may_send_commands(
+    conn: wss.WebSocketConnection,
+    state_payloads: Queue,
+) -> None:
+    """The receive loop must not hold the send lock while dispatching.
+
+    Awaiting the *response* inside a callback can never complete -- the
+    response is read by the very loop the callback is blocking -- but the
+    send itself must go through rather than deadlock the stream forever.
+    """
+    done = Event()
+
+    async def state_cb(
+        status_payload: str | None, temperatures_payload: str | None = None
+    ) -> None:
+        await conn.send_command_without_answer("cmd", {})
+        done.set()
+
+    conn.set_state_callback(state_cb)
+    async with conn:
+        await state_payloads.put({"status": ["state"]})
+        async with timeout(5):
+            await done.wait()
+
+
+async def test_send_when_the_socket_is_gone_raises_not_connected(
+    conn: wss.WebSocketConnection,
+) -> None:
+    async with conn:
+        sock = conn._sock
+        # Simulate the subscribe loop having dropped the socket.
+        conn._sock = None
+        with raises(NotConnectedError):
+            await conn.send_command("cmd", {}, timeout=1)
+        conn._sock = sock  # so disconnect() can close it cleanly
+
+
+async def test_disconnect_does_not_wait_out_the_backoff(
+    fake_server: TestServer, session: ClientSession
+) -> None:
+    async with fake_server, session:
+        conn = make_conn(fake_server, session)
+        await conn.connect()
+        assert conn._sock is not None
+        # Make the server unreachable so the subscribe loop enters a backoff
+        # sleep after the socket drops.
+        with patch.object(conn, "_ws_connect", side_effect=GrillUnavailable("gone")):
+            await conn._sock.close()
+            await sleep(0.2)  # let the loop reach the backoff wait
+            # The first backoff is 1.0s; disconnect() must not wait it out.
+            async with timeout(0.5):
+                await conn.disconnect()
 
 
 async def test_external_session_not_closed():


### PR DESCRIPTION
## Problems

Four related weaknesses in `WebSocketConnection`, all verified with repros:

1. **Any exception on the receive path permanently kills the connection.** The subscribe loop only catches `GrillUnavailable` from reconnect attempts. A non-JSON frame (`msg.json()` raising), an exception escaping a subscriber callback, or a `KeyError` from response handling ends the task silently: no further reconnects (despite the class docstring promising them), no `_fail_pending_commands()`, and the task's exception surfaces only at `disconnect()`.

2. **A subscriber that sends a command during dispatch deadlocks the transport.** The loop held `_sock_lock` across `_handle_message()` (and therefore across subscriber callbacks), while `_send_prepared_command()` needs the same lock. Repro: a state callback issuing any send blocks the receive loop forever.

3. **`disconnect()` can block for up to 30 seconds.** If the subscribe loop is in its reconnect backoff sleep, nothing interrupts it; `disconnect()` awaits the task for the remainder of the sleep. Measured: exactly the remaining backoff.

4. **`AttributeError` instead of `NotConnectedError`.** The loop clears `_sock` without the lock, so a sender that passed `is_connected()` and then waited on `_sock_lock` could find `_sock is None` and crash on `None.send_json`.

## Fix

- Per-message try/except in the receive loop: malformed frames and subscriber exceptions are logged and skipped; non-TEXT frames are ignored.
- `_sock_lock` is now held only around the actual send; message dispatch runs without it. (Awaiting a full command round-trip *inside* a callback still cannot complete — the response is read by the loop the callback blocks — but it now fails via its own timeout instead of wedging the stream forever; fire-and-forget sends work.)
- The backoff sleep moved into `_backoff_wait()`, interruptible by `disconnect()` via a `_stopping` event. The existing `test_reconnect_backoff` was updated to patch `_backoff_wait` instead of `asyncio.sleep`; its asserted 1→2→4→…→30 progression is unchanged.
- `_send_prepared_command` re-reads `_sock` under the lock and raises `NotConnectedError` when it is gone.

## Testing

- New tests: malformed payload survival, subscriber-exception survival, send-from-callback (deadlock regression), `NotConnectedError` on a vanished socket, and disconnect-during-backoff.
- `pytest` (730 passed), `ruff check`, `ruff format --check`, `mypy .` all green at the CI-pinned versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)