### PR TITLE
Decode file content once instead of per 512-byte chunk

### DIFF
--- a/pytboss/fs.py
+++ b/pytboss/fs.py
@@ -29,15 +29,17 @@ class FileSystem:
         """
         length = 512
         offset = 0
-        content = ""
+        content = bytearray()
         while True:
             resp = await self._conn.send_command(
                 "FS.Get", {"filename": filename, "offset": offset, "len": length}
             )
-            content += b64decode(resp["data"]).decode("utf-8")
+            content += b64decode(resp["data"])
             offset += length
             if resp["left"] == 0:
-                return content
+                # Decoded once, whole: a multi-byte character split across
+                # the chunk boundary is not valid UTF-8 on its own.
+                return content.decode("utf-8")
 
     async def set_file_content(self, filename: str, data: str, append: bool) -> dict:
         """Writes content to a file on the device.

--- a/tests/test_fs.py
+++ b/tests/test_fs.py
@@ -51,6 +51,18 @@ async def test_get_file_content_multiple_chunks(fs: FileSystem, conn: AsyncMock)
     )
 
 
+async def test_get_file_content_multibyte_split_across_chunks(
+    fs: FileSystem, conn: AsyncMock
+):
+    """A multi-byte character on the chunk boundary must survive the read."""
+    content = ("x" * 511 + "é" + "y").encode("utf-8")  # é spans bytes 511-512
+    conn.send_command.side_effect = [
+        {"data": b64encode(content[:512]).decode(), "left": len(content) - 512},
+        {"data": b64encode(content[512:]).decode(), "left": 0},
+    ]
+    assert await fs.get_file_content("test.txt") == "x" * 511 + "éy"
+
+
 async def test_set_file_content(fs: FileSystem, conn: AsyncMock):
     conn.send_command.return_value = {}
     assert await fs.set_file_content("test.txt", "data", True) == {}


### PR DESCRIPTION
## Problem

`FileSystem.get_file_content` decodes each 512-byte `FS.Get` chunk as UTF-8 individually. A multi-byte character that happens to fall across a chunk boundary is not valid UTF-8 on either side of the cut, so the read raises:

```
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xc3 in position 511: unexpected end of data
```

Verified with a repro: a file whose 512-byte boundary splits an `é`.

## Fix

Accumulate raw bytes and decode once at the end.

## Testing

- New test: `test_get_file_content_multibyte_split_across_chunks`.
- `pytest` (726 passed), `ruff check`, `ruff format --check`, `mypy .` all green at the CI-pinned versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)