### PR TITLE
Document why the uptime cache is stamped before the request

### DIFF
--- a/pytboss/api.py
+++ b/pytboss/api.py
@@ -457,12 +457,17 @@ class PitBoss:
         if self._last_uptime is None or now - self._last_uptime_check > _UPTIME_TTL:
             result = await self._conn.send_command("PB.GetTime", {})
             self._last_uptime = result.get("time", 0.0)
-            # Stamped after the reply: the grill computed its uptime then,
-            # not when the request went out. Stamping before the round trip
-            # inflates every later extrapolation by the RTT, and timed_key
-            # rounds to 10-second windows, so a slow link (BLE via a proxy)
-            # can push an authenticated command into the wrong window.
-            self._last_uptime_check = monotonic()
+            # Deliberately the pre-request timestamp, though the grill
+            # computed its uptime later, when the request reached it: every
+            # extrapolation therefore runs ahead of the grill by about one
+            # request latency, and ahead is the only direction the firmware
+            # forgives. checkPassword accepts a key built from its current
+            # 10-second bucket or the next one -- x or x + 1, never x - 1 --
+            # which absorbs a client running ahead but rejects one running
+            # behind. Stamping after the reply reads as more accurate and
+            # is not: it flips the bias behind, where a slow link draws
+            # spurious Unauthorized errors near bucket boundaries.
+            self._last_uptime_check = now
             return self._last_uptime
         return self._last_uptime + (now - self._last_uptime_check)
 

--- a/pytboss/api.py
+++ b/pytboss/api.py
@@ -457,7 +457,12 @@ class PitBoss:
         if self._last_uptime is None or now - self._last_uptime_check > _UPTIME_TTL:
             result = await self._conn.send_command("PB.GetTime", {})
             self._last_uptime = result.get("time", 0.0)
-            self._last_uptime_check = now
+            # Stamped after the reply: the grill computed its uptime then,
+            # not when the request went out. Stamping before the round trip
+            # inflates every later extrapolation by the RTT, and timed_key
+            # rounds to 10-second windows, so a slow link (BLE via a proxy)
+            # can push an authenticated command into the wrong window.
+            self._last_uptime_check = monotonic()
             return self._last_uptime
         return self._last_uptime + (now - self._last_uptime_check)
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -404,11 +404,14 @@ async def test_get_uptime_is_extrapolated_between_reads(pitboss: api.PitBoss):
         assert await pitboss.get_uptime() == first + sum(steps)
 
 
-async def test_get_uptime_extrapolation_excludes_the_rpc_round_trip():
-    """The grill computes its uptime when it replies, not when we ask.
+async def test_get_uptime_extrapolation_runs_ahead_not_behind():
+    """The RPC round trip biases extrapolations ahead of the grill, on purpose.
 
-    The cache timestamp therefore has to be taken after the round trip;
-    taking it before inflates every extrapolation by the RTT.
+    The firmware's checkPassword accepts a key built from its current
+    10-second bucket or the next one (x or x + 1, never x - 1), so an
+    estimate that runs ahead is forgiven and one that runs behind is
+    rejected. The cache timestamp is therefore taken before the request
+    goes out; stamping it after the reply would flip the bias behind.
     """
     conn = FakeTransport()
     pitboss = api.PitBoss(conn, "PBV4PS2")
@@ -416,13 +419,13 @@ async def test_get_uptime_extrapolation_excludes_the_rpc_round_trip():
     with freeze_time("2025-06-01 00:00:00") as ft:
 
         def slow_get_time(params: dict) -> dict:
-            ft.tick(5)  # the reply takes 5 seconds to arrive
+            ft.tick(5)  # the request takes 5 seconds to reach the grill
             return {"time": 100.0}
 
         conn._get_time = slow_get_time  # type: ignore[method-assign]
         assert await pitboss.get_uptime() == 100.0
-        # No time has passed since the reply, so nothing to extrapolate.
-        assert await pitboss.get_uptime() == 100.0
+        # The grill is at ~100s; the extrapolation must not lag behind it.
+        assert await pitboss.get_uptime() >= 100.0 + 5.0
 
 
 async def test_get_uptime_is_re_read_once_the_cache_is_stale(pitboss: api.PitBoss):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -404,6 +404,27 @@ async def test_get_uptime_is_extrapolated_between_reads(pitboss: api.PitBoss):
         assert await pitboss.get_uptime() == first + sum(steps)
 
 
+async def test_get_uptime_extrapolation_excludes_the_rpc_round_trip():
+    """The grill computes its uptime when it replies, not when we ask.
+
+    The cache timestamp therefore has to be taken after the round trip;
+    taking it before inflates every extrapolation by the RTT.
+    """
+    conn = FakeTransport()
+    pitboss = api.PitBoss(conn, "PBV4PS2")
+    await pitboss.start()
+    with freeze_time("2025-06-01 00:00:00") as ft:
+
+        def slow_get_time(params: dict) -> dict:
+            ft.tick(5)  # the reply takes 5 seconds to arrive
+            return {"time": 100.0}
+
+        conn._get_time = slow_get_time  # type: ignore[method-assign]
+        assert await pitboss.get_uptime() == 100.0
+        # No time has passed since the reply, so nothing to extrapolate.
+        assert await pitboss.get_uptime() == 100.0
+
+
 async def test_get_uptime_is_re_read_once_the_cache_is_stale(pitboss: api.PitBoss):
     """The fake grill counts up per read, so a fresh read is far lower."""
     with freeze_time("2025-06-01 00:00:00") as ft:


### PR DESCRIPTION
## What this is now

Originally this PR moved the uptime cache timestamp after the `PB.GetTime` round trip. Review showed the premise was inverted — see the discussion below — so it is now the change the review suggested instead: keep the pre-request stamp, and record **why** it is correct in a comment plus a regression test, so the "more accurate" version does not get re-proposed.

## Why the pre-request stamp is correct

`checkPassword` accepts a key built from the firmware's current 10-second bucket **or the next one** — `x` or `x + 1`, never `x - 1`. The tolerance is asymmetric on purpose: a client estimate that runs ahead is forgiven, one that runs behind is rejected. The pre-request stamp biases every extrapolation ahead by about one request latency, which is exactly the forgiven direction; stamping after the reply flips the bias behind, where a slow link draws spurious `Unauthorized` errors near bucket boundaries.

Verified against the vendor firmware images, not just `fake_firmware/init.js`: 0.5.6 (`init.js:496`), 0.5.7 (`init.js:489-497`), and 0.6.0 (`init.js:440-448`, via the `PSW` module) all try `x` then `x + 1` and nothing else. 0.2.3 predates password support.

## Testing

- New regression test `test_get_uptime_extrapolation_runs_ahead_not_behind` pins the bias direction.
- `pytest` (726 passed), `ruff check`, `ruff format --check`, `mypy .` all green at the CI-pinned versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)