### PR TITLE
Pass the unit flag to temperature commands

### DIFF
--- a/pytboss/api.py
+++ b/pytboss/api.py
@@ -262,29 +262,37 @@ class PitBoss:
 
         :param temp: Target grill temperature, in the grill's own unit.
         """
-        fahrenheit = self._state.get("isFahrenheit", True)
+        fahrenheit = self._is_fahrenheit()
         if accepted := self.accepted_setpoints(fahrenheit):
             temp = min(accepted, key=lambda value: abs(value - temp))
-        return await self._send_command("set-temperature", temp)
+        # The unit flag travels with every temperature command: on eleven
+        # boards the MCU always speaks Fahrenheit, and the vendor's command
+        # routine converts a Celsius argument only when its second parameter
+        # is `false`. Sent alone, a Celsius setpoint is read as Fahrenheit
+        # (100C becomes 100F). Boards whose routine takes one parameter
+        # ignore the extra argument, as do fixed-hex commands.
+        return await self._send_command("set-temperature", temp, fahrenheit)
 
     async def set_probe_temperature(self, temp: int) -> dict:
         """Sets the target temperature for probe 1.
 
-        :param temp: Target probe temperature.
+        :param temp: Target probe temperature, in the grill's own unit.
         """
-        return await self._send_command("set-probe-1-temperature", temp)
+        return await self._send_command(
+            "set-probe-1-temperature", temp, self._is_fahrenheit()
+        )
 
     async def set_probe_2_temperature(self, temp: int) -> dict:
         """Sets the target temperature for probe 2.
 
-        :param temp: Target probe temperature.
+        :param temp: Target probe temperature, in the grill's own unit.
         :raise pytboss.exceptions.UnsupportedOperation: When probe 2's
             target temperature cannot be set.
         """
         cmd = "set-probe-2-temperature"
         if cmd not in self.spec.control_board.commands:
             raise UnsupportedOperation
-        return await self._send_command(cmd, temp)
+        return await self._send_command(cmd, temp, self._is_fahrenheit())
 
     def probe_target_command(self, probe_number: int) -> str | None:
         """The board command that sets this probe's target, if it has one.
@@ -314,7 +322,9 @@ class PitBoss:
             clears the store when the grill is switched off.
         """
         if self.probe_target_command(probe_number) is not None:
-            await self._send_command(f"set-probe-{probe_number}-temperature", temp)
+            await self._send_command(
+                f"set-probe-{probe_number}-temperature", temp, self._is_fahrenheit()
+            )
             return
         if not self._state.get("moduleIsOn"):
             raise UnsupportedOperation(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -297,21 +297,21 @@ async def test_set_password_with_old_password():
 
 async def test_set_grill_temperature(pitboss: api.PitBoss, conn: FakeTransport):
     assert (await pitboss.set_grill_temperature(225)) == {}
-    assert conn.last_mcu_command == "set-temperature(225,)"
+    assert conn.last_mcu_command == "set-temperature(225, True)"
 
 
 @pytest.mark.grill_params({"temp_increments": [180, 200, 220]})
 async def test_set_grill_temperature_high(pitboss: api.PitBoss, conn: FakeTransport):
     """Above the range, the highest accepted setpoint."""
     assert (await pitboss.set_grill_temperature(400)) == {}
-    assert conn.last_mcu_command == "set-temperature(220,)"
+    assert conn.last_mcu_command == "set-temperature(220, True)"
 
 
 @pytest.mark.grill_params({"temp_increments": [180, 200, 220]})
 async def test_set_grill_temperature_low(pitboss: api.PitBoss, conn: FakeTransport):
     """Below the range, the lowest accepted setpoint."""
     assert (await pitboss.set_grill_temperature(100)) == {}
-    assert conn.last_mcu_command == "set-temperature(180,)"
+    assert conn.last_mcu_command == "set-temperature(180, True)"
 
 
 @pytest.mark.grill_params({"temp_increments": [180, 200, 220]})
@@ -320,7 +320,7 @@ async def test_set_grill_temperature_snaps_to_the_nearest(
 ):
     """The board ignores anything that is not on its list."""
     assert (await pitboss.set_grill_temperature(206)) == {}
-    assert conn.last_mcu_command == "set-temperature(200,)"
+    assert conn.last_mcu_command == "set-temperature(200, True)"
 
 
 @pytest.mark.grill_params({"temp_increments": [180, 190, 200]})
@@ -331,7 +331,7 @@ async def test_set_grill_temperature_in_celsius(
     pitboss._state["isFahrenheit"] = False
     # 180/190/200F floor to 82/87/93C.
     assert (await pitboss.set_grill_temperature(88)) == {}
-    assert conn.last_mcu_command == "set-temperature(87,)"
+    assert conn.last_mcu_command == "set-temperature(87, False)"
 
 
 @pytest.mark.grill_params(
@@ -342,12 +342,12 @@ async def test_set_grill_temperature_prefers_a_declared_celsius_list(
 ):
     pitboss._state["isFahrenheit"] = False
     assert (await pitboss.set_grill_temperature(44)) == {}
-    assert conn.last_mcu_command == "set-temperature(45,)"
+    assert conn.last_mcu_command == "set-temperature(45, False)"
 
 
 async def test_set_probe_temperature(pitboss: api.PitBoss, conn: FakeTransport):
     assert (await pitboss.set_probe_temperature(225)) == {}
-    assert conn.last_mcu_command == "set-probe-1-temperature(225,)"
+    assert conn.last_mcu_command == "set-probe-1-temperature(225, True)"
 
 
 @pytest.mark.grill_params({"has_lights": True})
@@ -567,7 +567,7 @@ async def test_set_probe_2_temperature(
         "set-probe-2-temperature"
     )
     assert (await pitboss.set_probe_2_temperature(120)) == {}
-    assert conn.last_mcu_command == "set-probe-2-temperature(120,)"
+    assert conn.last_mcu_command == "set-probe-2-temperature(120, True)"
 
 
 async def test_get_firmware_version():
@@ -690,7 +690,7 @@ async def test_set_probe_target_uses_the_board_command_when_there_is_one(
     """The mock board declares `set-probe-1-temperature` and nothing else."""
     await pitboss.set_probe_target(1, 165)
 
-    assert conn.last_mcu_command == "set-probe-1-temperature(165,)"
+    assert conn.last_mcu_command == "set-probe-1-temperature(165, True)"
     assert conn.virtual_data == {}
 
 

--- a/tests/test_grills.py
+++ b/tests/test_grills.py
@@ -487,3 +487,31 @@ def test_each_thread_gets_its_own_interpreter():
         thread.join()
 
     assert results == [expected] * 4
+
+
+def test_set_temperature_converts_celsius_when_the_unit_flag_says_so():
+    """Boards whose MCU always speaks Fahrenheit convert in the command JS.
+
+    The vendor routine takes (temp, is_fahrenheit) and converts a Celsius
+    argument to Fahrenheit only when the flag is `false`. Without the flag
+    a Celsius setpoint is passed through and read as Fahrenheit.
+    """
+    # PB1000R1 is on PBV, whose temperature routine carries ftoc().
+    cmd = grills_lib.get_grill("PB1000R1").control_board.commands["set-temperature"]
+    assert cmd(225, True) == "FE0501020205FF"  # F mode: passthrough
+    assert cmd(100, False) == "FE0501020100FF"  # 100C -> 212F, snapped to 210
+    assert cmd(100) == "FE0501010000FF"  # no flag: passed through as 100F
+
+
+def test_probe_commands_convert_celsius_when_the_unit_flag_says_so():
+    # PB1020DX is on PBL3, whose probe routines carry the same flag.
+    board = grills_lib.get_grill("PB1020DX").control_board
+    cmd = board.commands["set-probe-1-temperature"]
+    assert cmd(160, True) == "FE0502010600FF"  # F mode: passthrough
+    assert cmd(70, False) == "FE0502010600FF"  # 70C -> 158F, snapped to 160
+
+
+def test_boards_without_the_unit_flag_ignore_it():
+    """PBL's routine takes one parameter; the extra flag must be harmless."""
+    cmd = grills_lib.get_grill("PB1600PS1").control_board.commands["set-temperature"]
+    assert cmd(110, False) == cmd(110)


### PR DESCRIPTION
## Problem

On eleven boards — LFS, PBA, PBE, PBL3, PBM, PBM2, PBT, PBV, PBV2, PBVA, PBX1 — the MCU always speaks Fahrenheit. Two things in the vendor's own routines show it:

1. Their `temperature_function` reports Fahrenheit and converts to Celsius **for display** with `ftoc()` when the frame's unit flag says the panel is in C-mode.
2. Their `set-temperature` (and, on PBA/PBE/PBL3/PBT/PBX1, `set-probe-N-temperature`) routines take a second parameter: `(temp, is_fahrenheit)`, and convert a Celsius argument to Fahrenheit when it is `false`. All 20 such routines in `grills.json` share the identical branch; PBVA even ships a calibrated C→F lookup table (`cval`/`fval`).

pytboss calls these routines with the temperature alone, so `arguments[1]` is `undefined`, the `=== false` branch never fires, and on a grill set to Celsius the setpoint goes through unconverted — **read as Fahrenheit by the MCU**:

| call | wire | grill actually set to |
|---|---|---|
| `set-temperature(100)` — pytboss today, user wants 100 °C | `FE0501 01 00 00 FF` | 100 °F ≈ 38 °C |
| `set-temperature(100, false)` — vendor app, C-mode | `FE0501 02 01 00 FF` | 210 °F ≈ 99 °C |

Probe targets are off the same way: PBL3 `set-probe-1-temperature(70)` sends 70 (°F, ~21 °C) where the app sends 160 °F for 70 °C.

Fahrenheit mode is unaffected (passthrough is the intended path), which is presumably why this has gone unnoticed — it only bites grills whose panel is set to Celsius.

## Fix

`set_grill_temperature`, `set_probe_temperature`, `set_probe_2_temperature` and the board-command path of `set_probe_target` now pass the grill's current unit as the routine's second argument. Safe uniformly: routines without the branch ignore extra arguments, fixed-hex commands ignore arguments entirely, and when no state has arrived yet the flag defaults to `True` (passthrough — exactly today's behavior).

## Testing

- New tests in `test_grills.py` execute the real vendor JS for PBV and PBL3 in both modes and pin the conversion (plus one proving the flag is harmless on PBL, which takes one parameter).
- `test_api.py` assertions updated to expect the flag; new behavior covered by the existing Celsius-mode tests.
- `pytest` (739 passed), `ruff check`, `ruff format --check`, `mypy .` green at the CI-pinned versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)