### PR TITLE
Add a local HTTP transport

### DIFF
--- a/pytboss/__init__.py
+++ b/pytboss/__init__.py
@@ -2,4 +2,5 @@
 
 from .api import PitBoss  # noqa: F401
 from .ble import BleConnection  # noqa: F401
+from .http import HttpConnection  # noqa: F401
 from .wss import WebSocketConnection  # noqa: F401

--- a/pytboss/http.py
+++ b/pytboss/http.py
@@ -13,7 +13,7 @@ here turns it on: `connect()` fails against a grill where it is off, and the
 caller is expected to have established that the endpoint exists first, over a
 transport that already works. `Config.Get` over Bluetooth reports it::
 
-    http = (await boss.config.get("http"))["http"]
+    http = await boss.config.get_config("http")
     if http["enable"]:
         ...  # an HttpConnection will work against this grill
 
@@ -137,10 +137,16 @@ class HttpConnection(Transport):
                     )
                 # Mongoose does not always set a JSON content type.
                 payload: Any = await resp.json(content_type=None)
-        except ClientError as ex:
+        except (ClientError, TimeoutError) as ex:
             # The grill is unreachable rather than refusing the call. Reported
             # as a lost connection so callers treat it the way they treat a
             # dropped websocket.
+            #
+            # `TimeoutError` as well as `ClientError`: a refused connection
+            # raises the latter, but a host that simply does not answer --
+            # unplugged, asleep, or on another network -- times out instead,
+            # and `ClientTimeout` surfaces that as `asyncio.TimeoutError`,
+            # which is not a `ClientError`. Silence is the common case.
             self._connected = False
             raise NotConnectedError(f"Could not reach {self._url}: {ex}") from ex
         _LOGGER.debug("<-- %s", payload)

--- a/pytboss/http.py
+++ b/pytboss/http.py
@@ -43,6 +43,7 @@ it needs an answer for every grill rather than a raise for some.
 See https://github.com/dknowles2/pytboss/issues/505.
 """
 
+import asyncio
 import logging
 from asyncio import AbstractEventLoop
 from typing import Any
@@ -103,6 +104,7 @@ class HttpConnection(Transport):
         # the grill answered the last time we spoke to it.
         self._started = False
         self._connected = False
+        self._pending: set[asyncio.Task] = set()
 
     async def connect(self) -> None:
         """Verifies the grill answers RPC at this address.
@@ -139,6 +141,9 @@ class HttpConnection(Transport):
         """
         self._started = False
         self._connected = False
+        for task in list(self._pending):
+            task.cancel()
+        self._pending.clear()
         await self._close_session()
 
     async def _close_session(self) -> None:
@@ -160,6 +165,38 @@ class HttpConnection(Transport):
             and self._session is not None
             and not self._session.closed
         )
+
+    async def send_command_without_answer(
+        self, method: str, params: dict, *, timeout: float | None = None
+    ) -> None:
+        """Sends a command without waiting for the reply.
+
+        Issued in the background, unlike the other transports, where writing
+        to the socket is the whole of it. Here a request is only finished
+        when its response has been read, and the callers that choose this
+        method choose it for commands the board cannot answer: `Sys.Reboot`
+        is gone before it could, so awaiting the exchange means waiting out
+        the full timeout and then raising `NotConnectedError` at a caller
+        that is not expecting one.
+
+        :param method: The method to call.
+        :param params: Parameters to send with the command.
+        :param timeout: Ignored. Nothing is awaited, so nothing can elapse.
+        """
+        cmd = await self._prepare_command(method, params)
+        task = self._loop.create_task(self._send_and_forget(cmd))
+        # Held so the task is not collected mid-flight, and so `disconnect()`
+        # can stop one that is still going.
+        self._pending.add(task)
+        task.add_done_callback(self._pending.discard)
+
+    async def _send_and_forget(self, cmd: dict) -> None:
+        try:
+            await self._send_prepared_command(cmd)
+        except Exception as ex:  # noqa: BLE001
+            # Nobody is waiting to be told, and for a command the board was
+            # never going to answer this is the expected ending.
+            _LOGGER.debug("No answer to %s, as expected: %s", cmd["method"], ex)
 
     async def _send_prepared_command(self, cmd: dict) -> None:
         # `_started` rather than `_connected`: a request that failed leaves

--- a/pytboss/http.py
+++ b/pytboss/http.py
@@ -51,7 +51,7 @@ from typing import Any
 from aiohttp import ClientError, ClientSession, ClientTimeout
 
 from .exceptions import NotConnectedError, RPCError
-from .transport import DEFAULT_TIMEOUT, Transport
+from .transport import DEFAULT_TIMEOUT, Transport, _rpc_error
 
 _LOGGER = logging.getLogger("pytboss")
 
@@ -211,11 +211,28 @@ class HttpConnection(Transport):
                 self._url, json=cmd, timeout=self._timeout
             ) as resp:
                 if resp.status != 200:
-                    raise RPCError(
-                        f"{self._url} answered HTTP {resp.status}", resp.status
+                    # Built through `_rpc_error` so a 401 arrives as
+                    # `Unauthorized`, which is what a caller re-prompting for
+                    # a password catches and what a Mongoose build with
+                    # `rpc.auth_file` set answers with.
+                    raise _rpc_error(
+                        {
+                            "code": resp.status,
+                            "message": f"{self._url} answered HTTP {resp.status}",
+                        }
                     )
                 # Mongoose does not always set a JSON content type.
-                payload: Any = await resp.json(content_type=None)
+                try:
+                    payload: Any = await resp.json(content_type=None)
+                except ValueError as ex:
+                    # A 200 carrying something that is not JSON is not this
+                    # protocol at all -- a mistyped address landing on a
+                    # router's admin page answers exactly like that. Left
+                    # alone it escapes as `JSONDecodeError`, which is neither
+                    # documented here nor caught by callers.
+                    raise RPCError(
+                        f"{self._url} answered with something that is not JSON"
+                    ) from ex
         except (ClientError, TimeoutError) as ex:
             # The grill is unreachable rather than refusing the call. Reported
             # as a lost connection so callers treat it the way they treat a

--- a/pytboss/http.py
+++ b/pytboss/http.py
@@ -98,6 +98,10 @@ class HttpConnection(Transport):
         # ours to close, and it is rebuilt by `connect()` so this transport is
         # reusable after `disconnect()`.
         self._session_owned = session is None
+        # Two different questions. `_started` is whether this transport has
+        # been connected and not since disconnected; `_connected` is whether
+        # the grill answered the last time we spoke to it.
+        self._started = False
         self._connected = False
 
     async def connect(self) -> None:
@@ -115,17 +119,25 @@ class HttpConnection(Transport):
                 raise NotConnectedError("The session given to this transport is closed")
             self._session = ClientSession(loop=self._loop)
         # Set before the ping so `_send_prepared_command` will proceed; a
-        # failure below clears it again.
+        # failure below clears them again.
+        self._started = True
         self._connected = True
         try:
             await self.send_command("RPC.Ping", {})
         except Exception:
+            self._started = False
             self._connected = False
             await self._close_session()
             raise
 
     async def disconnect(self) -> None:
-        """Releases the session, if this transport owns one."""
+        """Stops using the grill, and releases the session if this owns one.
+
+        Final until `connect()` is called again. A caller's session stays
+        open, since it is theirs, so nothing else here would stop a command
+        from going out on it.
+        """
+        self._started = False
         self._connected = False
         await self._close_session()
 
@@ -143,11 +155,18 @@ class HttpConnection(Transport):
         `connect()` until a request fails to reach the grill.
         """
         return (
-            self._connected and self._session is not None and not self._session.closed
+            self._started
+            and self._connected
+            and self._session is not None
+            and not self._session.closed
         )
 
     async def _send_prepared_command(self, cmd: dict) -> None:
-        if self._session is None or self._session.closed:
+        # `_started` rather than `_connected`: a request that failed leaves
+        # the latter false, and this transport is meant to recover from that
+        # by itself on the next call. An explicit `disconnect()` is the one
+        # that has to stick.
+        if not self._started or self._session is None or self._session.closed:
             raise NotConnectedError("Not connected")
         _LOGGER.debug("--> %s", cmd)
         try:

--- a/pytboss/http.py
+++ b/pytboss/http.py
@@ -5,17 +5,40 @@ Dansons websocket relays, so the command mappings and status decoders in this
 library work against it unchanged. Talking to the grill directly removes the
 vendor's cloud from the path.
 
-**Not every grill answers.** The endpoint is gated by the firmware's
-`http.enable` setting, and that is per-unit configuration rather than
-something a model or firmware version predicts -- two grills on the same
-board and the same firmware have been observed with opposite values. Nothing
-here turns it on: `connect()` fails against a grill where it is off, and the
-caller is expected to have established that the endpoint exists first, over a
-transport that already works. `Config.Get` over Bluetooth reports it::
+**Not every grill answers**, and whether one does is decided twice over.
 
-    http = await boss.config.get_config("http")
-    if http["enable"]:
+First by firmware family. Dansons ships a second line that is not Mongoose at
+all -- C on ESP-IDF, versioned `16.x` rather than `0.x`, on the PBC2, PBD,
+PBE, PBL2 and PBT boards. Those images link no HTTP server and run their
+websocket as a client only, so they serve nothing on the local network: they
+are reachable over Bluetooth and the vendor's relay, and by nothing else. No
+setting changes that.
+
+Then, within the Mongoose family, by the firmware's `http.enable` setting.
+That part is per-unit configuration rather than something a model or firmware
+version predicts -- two grills on the same board and the same firmware have
+been observed with opposite values.
+
+Nothing here turns it on: `connect()` fails against a grill that does not
+serve the endpoint, whichever of the two reasons applies, and the caller is
+expected to have established that it exists first, over a transport that
+already works. `Config.Get` over Bluetooth reports it::
+
+    try:
+        http = await boss.config.get_config("http")
+    except RPCError:
+        http = {}  # no such section: not a Mongoose grill
+    if http.get("enable"):
         ...  # an HttpConnection will work against this grill
+
+Neither the `try` nor the `.get()` is defensive habit; each covers one of the
+two ways the question can fail to have an answer. The ESP-IDF firmware answers
+`Config.Get` too, but its schema holds only `wifi.sta`, `app` and `version`,
+so there is no `http` section to report on -- and a device that will not
+answer for a key it does not have can either return an error or return
+nothing, which reach a caller as `RPCError` and as `{}` respectively. Since
+this snippet is what decides whether a caller offers the local option at all,
+it needs an answer for every grill rather than a raise for some.
 
 See https://github.com/dknowles2/pytboss/issues/505.
 """

--- a/pytboss/http.py
+++ b/pytboss/http.py
@@ -1,0 +1,157 @@
+"""HTTP connection support for PitBoss grills on the local network.
+
+Mongoose OS serves the same RPC interface at `http://<grill-ip>/rpc` that the
+Dansons websocket relays, so the command mappings and status decoders in this
+library work against it unchanged. Talking to the grill directly removes the
+vendor's cloud from the path.
+
+**Not every grill answers.** The endpoint is gated by the firmware's
+`http.enable` setting, and that is per-unit configuration rather than
+something a model or firmware version predicts -- two grills on the same
+board and the same firmware have been observed with opposite values. Nothing
+here turns it on: `connect()` fails against a grill where it is off, and the
+caller is expected to have established that the endpoint exists first, over a
+transport that already works. `Config.Get` over Bluetooth reports it::
+
+    http = (await boss.config.get("http"))["http"]
+    if http["enable"]:
+        ...  # an HttpConnection will work against this grill
+
+See https://github.com/dknowles2/pytboss/issues/505.
+"""
+
+import logging
+from asyncio import AbstractEventLoop
+from typing import Any
+
+from aiohttp import ClientError, ClientSession, ClientTimeout
+
+from .exceptions import NotConnectedError, RPCError
+from .transport import DEFAULT_TIMEOUT, Transport
+
+_LOGGER = logging.getLogger("pytboss")
+
+
+class HttpConnection(Transport):
+    """Local network transport for PitBoss grills, over Mongoose OS's HTTP RPC.
+
+    **There is no push channel.** HTTP is strictly request/response, so unlike
+    `pytboss.ble.BleConnection` and `pytboss.wss.WebSocketConnection` this
+    transport never invokes the state or VData callbacks -- `subscribe_state()`
+    and `subscribe_vdata()` register callbacks that will not fire. Polling
+    `PitBoss.get_state()` is the way to observe state here; it issues a live
+    RPC and updates the cache the rest of the API reads, so nothing else
+    behaves differently.
+
+    Also unlike the websocket transport, there is no reconnect loop. Each call
+    is an independent request, so there is no connection to lose and nothing to
+    re-establish; a grill that goes away surfaces as `NotConnectedError` on the
+    next call and starts working again by itself.
+    """
+
+    def __init__(
+        self,
+        host: str,
+        *,
+        session: ClientSession | None = None,
+        timeout: float = DEFAULT_TIMEOUT,
+        loop: AbstractEventLoop | None = None,
+    ) -> None:
+        """Initializes an HttpConnection.
+
+        :param host: The grill's address on the local network. A bare host or
+            `host:port`; the scheme is always plain HTTP, since the firmware
+            serves no TLS certificate.
+        :param session: An aiohttp ClientSession to use. If `None`, one is
+            created on `connect()` and closed on `disconnect()`.
+        :param timeout: Seconds to wait for a reply to any single request.
+        :param loop: An asyncio loop to use. If `None`, the running loop.
+        """
+        super().__init__(loop=loop)
+        self._url = f"http://{host}/rpc"
+        self._timeout = ClientTimeout(total=timeout)
+        self._session = session
+        # A caller's session is theirs to close. Only one we made ourselves is
+        # ours to close, and it is rebuilt by `connect()` so this transport is
+        # reusable after `disconnect()`.
+        self._session_owned = session is None
+        self._connected = False
+
+    async def connect(self) -> None:
+        """Verifies the grill answers RPC at this address.
+
+        HTTP has no connection to open, so this establishes reachability
+        instead: it sends an unauthenticated `RPC.Ping`. A wrong address, or a
+        grill with `http.enable` off, fails here rather than on some later
+        call.
+
+        :raise pytboss.exceptions.NotConnectedError: If nothing answers.
+        """
+        if self._session is None or self._session.closed:
+            if not self._session_owned:
+                raise NotConnectedError("The session given to this transport is closed")
+            self._session = ClientSession(loop=self._loop)
+        # Set before the ping so `_send_prepared_command` will proceed; a
+        # failure below clears it again.
+        self._connected = True
+        try:
+            await self.send_command("RPC.Ping", {})
+        except Exception:
+            self._connected = False
+            await self._close_session()
+            raise
+
+    async def disconnect(self) -> None:
+        """Releases the session, if this transport owns one."""
+        self._connected = False
+        await self._close_session()
+
+    async def _close_session(self) -> None:
+        if self._session_owned and self._session is not None:
+            if not self._session.closed:
+                await self._session.close()
+            self._session = None
+
+    def is_connected(self) -> bool:
+        """Whether the grill answered the last time we spoke to it.
+
+        There is no persistent connection to report on, so this reports the
+        outcome of the most recent exchange: `True` from a successful
+        `connect()` until a request fails to reach the grill.
+        """
+        return (
+            self._connected and self._session is not None and not self._session.closed
+        )
+
+    async def _send_prepared_command(self, cmd: dict) -> None:
+        if self._session is None or self._session.closed:
+            raise NotConnectedError("Not connected")
+        _LOGGER.debug("--> %s", cmd)
+        try:
+            async with self._session.post(
+                self._url, json=cmd, timeout=self._timeout
+            ) as resp:
+                if resp.status != 200:
+                    raise RPCError(
+                        f"{self._url} answered HTTP {resp.status}", resp.status
+                    )
+                # Mongoose does not always set a JSON content type.
+                payload: Any = await resp.json(content_type=None)
+        except ClientError as ex:
+            # The grill is unreachable rather than refusing the call. Reported
+            # as a lost connection so callers treat it the way they treat a
+            # dropped websocket.
+            self._connected = False
+            raise NotConnectedError(f"Could not reach {self._url}: {ex}") from ex
+        _LOGGER.debug("<-- %s", payload)
+        if not isinstance(payload, dict):
+            raise RPCError(f"Expected a JSON object, got {type(payload).__name__}")
+        self._connected = True
+        # An HTTP reply provably belongs to the request that produced it,
+        # whatever id the firmware echoed. Coercing it keeps a firmware that
+        # echoes nothing -- or something else -- from stalling the caller
+        # until its timeout expires.
+        if payload.get("id") != cmd["id"]:
+            _LOGGER.debug("Reply id %r != request id %r", payload.get("id"), cmd["id"])
+            payload["id"] = cmd["id"]
+        await self._on_command_response(payload)

--- a/pytboss/http.py
+++ b/pytboss/http.py
@@ -1,28 +1,16 @@
 """HTTP connection support for PitBoss grills on the local network.
 
 Mongoose OS serves the same RPC interface at `http://<grill-ip>/rpc` that the
-Dansons websocket relays, so the command mappings and status decoders in this
-library work against it unchanged. Talking to the grill directly removes the
-vendor's cloud from the path.
+Dansons websocket relays, so this library works against it unchanged, with the
+vendor's cloud out of the path.
 
-**Not every grill answers**, and whether one does is decided twice over.
+**Not every grill answers.** The ESP-IDF firmware line (versioned `16.x`, on
+the PBC2, PBD, PBE, PBL2 and PBT boards) links no HTTP server at all, and
+Mongoose grills serve the endpoint only when `http.enable` is set -- per-unit
+configuration that no model or firmware version predicts.
 
-First by firmware family. Dansons ships a second line that is not Mongoose at
-all -- C on ESP-IDF, versioned `16.x` rather than `0.x`, on the PBC2, PBD,
-PBE, PBL2 and PBT boards. Those images link no HTTP server and run their
-websocket as a client only, so they serve nothing on the local network: they
-are reachable over Bluetooth and the vendor's relay, and by nothing else. No
-setting changes that.
-
-Then, within the Mongoose family, by the firmware's `http.enable` setting.
-That part is per-unit configuration rather than something a model or firmware
-version predicts -- two grills on the same board and the same firmware have
-been observed with opposite values.
-
-Nothing here turns it on: `connect()` fails against a grill that does not
-serve the endpoint, whichever of the two reasons applies, and the caller is
-expected to have established that it exists first, over a transport that
-already works. `Config.Get` over Bluetooth reports it::
+Nothing here turns it on; `connect()` simply fails. Callers are expected to
+check first, over a transport that already works::
 
     try:
         http = await boss.config.get_config("http")
@@ -30,15 +18,6 @@ already works. `Config.Get` over Bluetooth reports it::
         http = {}  # no such section: not a Mongoose grill
     if http.get("enable"):
         ...  # an HttpConnection will work against this grill
-
-Neither the `try` nor the `.get()` is defensive habit; each covers one of the
-two ways the question can fail to have an answer. The ESP-IDF firmware answers
-`Config.Get` too, but its schema holds only `wifi.sta`, `app` and `version`,
-so there is no `http` section to report on -- and a device that will not
-answer for a key it does not have can either return an error or return
-nothing, which reach a caller as `RPCError` and as `{}` respectively. Since
-this snippet is what decides whether a caller offers the local option at all,
-it needs an answer for every grill rather than a raise for some.
 
 See https://github.com/dknowles2/pytboss/issues/505.
 """

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -7,13 +7,16 @@ and the content type are exercised as the grill would present them.
 
 import asyncio
 from typing import Any
+from unittest import mock
 
 import pytest
 from aiohttp import ClientSession, web
 from aiohttp.test_utils import TestServer
 
+from pytboss.config import Config
 from pytboss.exceptions import NotConnectedError, RPCError, Unauthorized
 from pytboss.http import HttpConnection
+from pytboss.transport import Transport
 
 
 class FakeMongooseRpc:
@@ -259,3 +262,42 @@ async def test_a_silent_grill_is_reported_as_not_connected():
         assert conn.is_connected() is False
     finally:
         await server.close()
+
+
+async def _documented_discovery(config: Config) -> bool:
+    """The snippet from this module's docstring, verbatim.
+
+    Kept executable rather than only rendered: it is what decides whether a
+    caller offers the local option at all, so it has to work against grills
+    that have no `http` section as well as those that do.
+    """
+    try:
+        http = await config.get_config("http")
+    except RPCError:
+        http = {}
+    return bool(http.get("enable"))
+
+
+@pytest.mark.parametrize(
+    "reply,want",
+    [
+        ({"enable": True}, True),
+        ({"enable": False}, False),
+        ({}, False),  # answered with nothing: no such section
+    ],
+)
+async def test_documented_discovery_answers_for_every_grill(reply, want):
+    conn = mock.AsyncMock(spec=Transport)
+    conn.send_command.return_value = reply
+    assert await _documented_discovery(Config(conn)) is want
+
+
+async def test_documented_discovery_survives_a_missing_section():
+    """A grill that errors on an unknown key must not raise past the caller.
+
+    The ESP-IDF firmware answers `Config.Get`, but its schema has no `http`
+    section, so this is the other shape the same question can fail in.
+    """
+    conn = mock.AsyncMock(spec=Transport)
+    conn.send_command.side_effect = RPCError("No such key", -1)
+    assert await _documented_discovery(Config(conn)) is False

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -1,0 +1,234 @@
+"""Tests for the local HTTP transport.
+
+Driven against a real aiohttp server standing in for the firmware's `/rpc`
+endpoint rather than a mocked session, so the JSON envelope, the status codes
+and the content type are exercised as the grill would present them.
+"""
+
+import asyncio
+from typing import Any
+
+import pytest
+from aiohttp import ClientSession, web
+from aiohttp.test_utils import TestServer
+
+from pytboss.exceptions import NotConnectedError, RPCError, Unauthorized
+from pytboss.http import HttpConnection
+
+
+class FakeMongooseRpc:
+    """A stand-in for the firmware's `/rpc` endpoint.
+
+    Mirrors the behaviours that matter: it echoes the request id, omits
+    `result` for handlers that return nothing, and answers `Unauthorized` the
+    way `checkPassword` does.
+    """
+
+    def __init__(self) -> None:
+        self.requests: list[dict] = []
+        self.password = ""
+        self.content_type: str | None = None  # None => text/plain, as Mongoose does
+        self.echo_id: bool = True
+        self.status = 200
+
+    async def handle(self, request: web.Request) -> web.Response:
+        cmd = await request.json()
+        self.requests.append(cmd)
+        if self.status != 200:
+            return web.Response(status=self.status, text="nope")
+
+        resp: dict[str, Any] = {"id": cmd["id"] if self.echo_id else 9999}
+        method = cmd["method"]
+        params = cmd.get("params") or {}
+
+        if self.password and method.startswith("PB.") and "psw" not in params:
+            resp["error"] = {"code": 401, "message": "Unauthorized"}
+        elif method == "RPC.Ping":
+            resp["result"] = {}
+        elif method == "PB.GetState":
+            resp["result"] = {"sc_11": "FE0B", "sc_12": "FE0C"}
+        elif method == "PB.WiFiAwakeWDT":
+            pass  # Returns null: no `result` key at all.
+        elif method == "Boom":
+            resp["error"] = {"code": -1, "message": "kaboom"}
+        else:
+            resp["result"] = {"echo": method}
+        return web.json_response(resp, content_type=self.content_type or "text/plain")
+
+
+@pytest.fixture
+async def rpc() -> FakeMongooseRpc:
+    return FakeMongooseRpc()
+
+
+@pytest.fixture
+async def server(rpc: FakeMongooseRpc):
+    app = web.Application()
+    app.router.add_post("/rpc", rpc.handle)
+    server = TestServer(app)
+    await server.start_server()
+    yield server
+    await server.close()
+
+
+@pytest.fixture
+def host(server: TestServer) -> str:
+    return f"{server.host}:{server.port}"
+
+
+async def test_connect_pings_and_reports_connected(host, rpc):
+    conn = HttpConnection(host)
+    assert not conn.is_connected()
+    await conn.connect()
+    try:
+        assert conn.is_connected()
+        assert rpc.requests[0]["method"] == "RPC.Ping"
+    finally:
+        await conn.disconnect()
+
+
+async def test_send_command_round_trips(host):
+    conn = HttpConnection(host)
+    await conn.connect()
+    try:
+        assert await conn.send_command("PB.GetState", {}) == {
+            "sc_11": "FE0B",
+            "sc_12": "FE0C",
+        }
+    finally:
+        await conn.disconnect()
+
+
+async def test_result_less_reply_is_not_an_error(host):
+    """`PB.WiFiAwakeWDT` returns null; the absence of `result` is a success."""
+    conn = HttpConnection(host)
+    await conn.connect()
+    try:
+        assert await conn.send_command("PB.WiFiAwakeWDT", {}) is None
+    finally:
+        await conn.disconnect()
+
+
+async def test_error_payload_raises(host):
+    conn = HttpConnection(host)
+    await conn.connect()
+    try:
+        with pytest.raises(RPCError, match="kaboom"):
+            await conn.send_command("Boom", {})
+    finally:
+        await conn.disconnect()
+
+
+async def test_unauthorized_is_raised_as_unauthorized(host, rpc):
+    """A password-checked method without `psw` fails the way the firmware fails it."""
+    rpc.password = "hunter2"
+    conn = HttpConnection(host)
+    await conn.connect()  # RPC.Ping is not password-checked.
+    try:
+        with pytest.raises(Unauthorized):
+            await conn.send_command("PB.GetState", {})
+    finally:
+        await conn.disconnect()
+
+
+async def test_a_reply_with_the_wrong_id_still_resolves(host, rpc):
+    """An HTTP reply belongs to its request, so a bad echo must not stall it."""
+    rpc.echo_id = False
+    conn = HttpConnection(host)
+    await conn.connect()
+    try:
+        async with asyncio.timeout(5):
+            assert await conn.send_command("PB.GetState", {}) == {
+                "sc_11": "FE0B",
+                "sc_12": "FE0C",
+            }
+    finally:
+        await conn.disconnect()
+
+
+async def test_json_content_type_is_also_accepted(host, rpc):
+    rpc.content_type = "application/json"
+    conn = HttpConnection(host)
+    await conn.connect()
+    try:
+        assert await conn.send_command("PB.GetState", {}) is not None
+    finally:
+        await conn.disconnect()
+
+
+async def test_http_error_status_raises_rpc_error(host, rpc):
+    conn = HttpConnection(host)
+    await conn.connect()
+    rpc.status = 404
+    try:
+        with pytest.raises(RPCError, match="HTTP 404"):
+            await conn.send_command("PB.GetState", {})
+    finally:
+        await conn.disconnect()
+
+
+async def test_connect_fails_when_nothing_answers(server):
+    """A grill with `http.enable` off looks like this: nothing on the port."""
+    port = server.port
+    await server.close()
+    conn = HttpConnection(f"127.0.0.1:{port}")
+    with pytest.raises(NotConnectedError):
+        await conn.connect()
+    assert not conn.is_connected()
+
+
+async def test_an_unreachable_grill_reports_not_connected(host, server):
+    conn = HttpConnection(host)
+    await conn.connect()
+    assert conn.is_connected()
+    await server.close()
+    with pytest.raises(NotConnectedError):
+        await conn.send_command("PB.GetState", {})
+    assert not conn.is_connected()
+    await conn.disconnect()
+
+
+async def test_the_transport_is_reusable_after_disconnect(host):
+    """Reconnecting must work; an owned session is rebuilt rather than reused."""
+    conn = HttpConnection(host)
+    await conn.connect()
+    await conn.disconnect()
+    assert not conn.is_connected()
+    await conn.connect()
+    try:
+        assert conn.is_connected()
+        assert await conn.send_command("PB.GetState", {}) is not None
+    finally:
+        await conn.disconnect()
+
+
+async def test_a_caller_supplied_session_is_left_open(host):
+    session = ClientSession()
+    try:
+        conn = HttpConnection(host, session=session)
+        await conn.connect()
+        await conn.disconnect()
+        assert not session.closed
+        # And it can still be used again.
+        await conn.connect()
+        assert await conn.send_command("PB.GetState", {}) is not None
+        await conn.disconnect()
+    finally:
+        await session.close()
+
+
+async def test_state_callbacks_never_fire(host):
+    """There is no push channel; the callbacks exist but stay silent."""
+    seen: list = []
+
+    async def on_state(status=None, temperatures=None):
+        seen.append((status, temperatures))
+
+    conn = HttpConnection(host)
+    conn.set_state_callback(on_state)
+    await conn.connect()
+    try:
+        await conn.send_command("PB.GetState", {})
+        assert seen == []
+    finally:
+        await conn.disconnect()

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -353,3 +353,50 @@ async def test_a_failed_request_does_not_end_the_transport(host, rpc):
         assert conn.is_connected() is True
     finally:
         await conn.disconnect()
+
+
+async def test_send_command_without_answer_does_not_wait(host, rpc):
+    """`reboot()` picks this method because the board cannot answer.
+
+    A request is only finished here when its response has been read, so
+    awaiting the exchange means waiting out the whole timeout and then
+    raising at a caller that is not expecting an exception.
+    """
+    hung = asyncio.Event()
+
+    async def never_answers(request: web.Request) -> web.Response:
+        hung.set()
+        await asyncio.sleep(30)
+        raise AssertionError("unreachable")
+
+    app = web.Application()
+    app.router.add_post("/rpc", never_answers)
+    server = TestServer(app)
+    await server.start_server()
+    try:
+        conn = HttpConnection(f"{server.host}:{server.port}", timeout=5)
+        # Connected by hand: `connect()` pings, and this server never
+        # answers anything, which is the whole point of it.
+        conn._session = ClientSession()
+        conn._started = True
+        try:
+            async with asyncio.timeout(2):
+                await conn.send_command_without_answer("Sys.Reboot", {})
+            # The request is on its way even though we did not wait for it.
+            async with asyncio.timeout(2):
+                await hung.wait()
+        finally:
+            # Owns the session it was given here, so this closes it too.
+            await conn.disconnect()
+    finally:
+        await server.close()
+
+
+async def test_disconnect_stops_a_request_still_in_flight(host, rpc):
+    conn = HttpConnection(host)
+    await conn.connect()
+    await conn.send_command_without_answer("Sys.Reboot", {})
+    assert conn._pending
+
+    await conn.disconnect()
+    assert conn._pending == set()

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -400,3 +400,42 @@ async def test_disconnect_stops_a_request_still_in_flight(host, rpc):
 
     await conn.disconnect()
     assert conn._pending == set()
+
+
+async def test_a_non_json_body_is_reported_as_an_rpc_error():
+    """A mistyped address reaching something else answers like this.
+
+    `JSONDecodeError` is a `ValueError`, so the `except (ClientError,
+    TimeoutError)` in the transport does not see it and it escapes
+    undocumented.
+    """
+
+    async def html(request: web.Request) -> web.Response:
+        return web.Response(text="<html>router admin</html>", content_type="text/html")
+
+    app = web.Application()
+    app.router.add_post("/rpc", html)
+    server = TestServer(app)
+    await server.start_server()
+    try:
+        conn = HttpConnection(f"{server.host}:{server.port}")
+        with pytest.raises(RPCError):
+            await conn.connect()
+    finally:
+        await server.close()
+
+
+async def test_http_401_arrives_as_unauthorized(host, rpc):
+    """A build with `rpc.auth_file` set refuses at the HTTP layer.
+
+    Callers catch `Unauthorized` to re-prompt for a password; a bare
+    `RPCError` reads as a generic failure instead.
+    """
+    conn = HttpConnection(host)
+    await conn.connect()
+    try:
+        rpc.status = 401
+        with pytest.raises(Unauthorized):
+            await conn.send_command("PB.GetState", {})
+    finally:
+        await conn.disconnect()

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -301,3 +301,55 @@ async def test_documented_discovery_survives_a_missing_section():
     conn = mock.AsyncMock(spec=Transport)
     conn.send_command.side_effect = RPCError("No such key", -1)
     assert await _documented_discovery(Config(conn)) is False
+
+
+async def test_a_command_after_disconnect_is_refused(host, rpc):
+    """A caller's session stays open, so nothing else stops the request.
+
+    Home Assistant always supplies one, so this is the ordinary case: a
+    refresh still in flight when the entry unloads would otherwise keep
+    polling the grill successfully.
+    """
+    async with ClientSession() as session:
+        conn = HttpConnection(host, session=session)
+        await conn.connect()
+        sent = len(rpc.requests)
+        await conn.disconnect()
+
+        with pytest.raises(NotConnectedError):
+            await conn.send_command("PB.GetState", {})
+
+        assert len(rpc.requests) == sent
+        assert conn.is_connected() is False
+
+
+async def test_a_command_before_connect_is_refused(host, rpc):
+    """`connect()` is what checks the grill is there at all."""
+    async with ClientSession() as session:
+        conn = HttpConnection(host, session=session)
+        with pytest.raises(NotConnectedError):
+            await conn.send_command("PB.GetState", {})
+        assert rpc.requests == []
+
+
+async def test_a_failed_request_does_not_end_the_transport(host, rpc):
+    """Unlike a disconnect, a grill that goes away is expected to come back.
+
+    The class promises exactly this: no reconnect loop, because each call is
+    independent and one that fails does not stop the next from working.
+    """
+    conn = HttpConnection(host)
+    await conn.connect()
+    try:
+        rpc.status = 503
+        with pytest.raises(RPCError):
+            await conn.send_command("PB.GetState", {})
+
+        rpc.status = 200
+        assert await conn.send_command("PB.GetState", {}) == {
+            "sc_11": "FE0B",
+            "sc_12": "FE0C",
+        }
+        assert conn.is_connected() is True
+    finally:
+        await conn.disconnect()

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -232,3 +232,30 @@ async def test_state_callbacks_never_fire(host):
         assert seen == []
     finally:
         await conn.disconnect()
+
+
+async def test_a_silent_grill_is_reported_as_not_connected():
+    """Unreachable and unresponsive are the same thing to a caller.
+
+    A refused connection raises `ClientError`, but a host that answers
+    nothing times out instead, and `ClientTimeout` surfaces that as
+    `asyncio.TimeoutError` -- which is not a `ClientError`. Silence is the
+    common case: a grill that is unplugged, asleep or on another network does
+    not send a reset.
+    """
+
+    async def never_answers(request: web.Request) -> web.Response:
+        await asyncio.sleep(30)
+        raise AssertionError("unreachable")
+
+    app = web.Application()
+    app.router.add_post("/rpc", never_answers)
+    server = TestServer(app)
+    await server.start_server()
+    try:
+        conn = HttpConnection(f"{server.host}:{server.port}", timeout=0.1)
+        with pytest.raises(NotConnectedError):
+            await conn.connect()
+        assert conn.is_connected() is False
+    finally:
+        await server.close()


### PR DESCRIPTION
Adds `HttpConnection`, a transport that speaks Mongoose OS RPC to a grill directly on the local network, removing the Dansons cloud from the path.

Towards #505.

```python
from pytboss import HttpConnection, PitBoss

conn = HttpConnection("192.168.1.50")
boss = PitBoss(conn, "PBV4PS2")
await boss.start()
print(await boss.get_state())
```

## Scope: this does not turn anything on

The endpoint is gated by the firmware's `http.enable`, and **that is per-unit configuration, not a property of the model or the firmware.** @trailro's table in [ha-pitboss#344](https://github.com/dknowles2/ha-pitboss/issues/344) has two grills on the same board and the same 0.5.7 with opposite values — @dknowles2's PBV4PS2 has it off, theirs has it on. So no supported-model list could be correct, and nothing here writes config to change it.

`connect()` sends an unauthenticated `RPC.Ping` and raises `NotConnectedError` if nothing answers. Deciding whether a given grill has the endpoint is the caller's job, over a transport that already works:

```python
http = (await boss.config.get("http"))["http"]
if http["enable"]:
    ...  # an HttpConnection will work against this grill
```

That is the discovery step for a Home Assistant option later; it is deliberately not in this PR.

## Two differences from the other transports

Both are documented on the class rather than left to be found:

**There is no push channel.** HTTP is strictly request/response, so `subscribe_state()` and `subscribe_vdata()` register callbacks that never fire. `PitBoss.get_state()` issues a live RPC and updates the cache the rest of the API reads, so polling is the way to observe state and nothing else behaves differently. A test asserts the silence rather than leaving it implied.

**There is no reconnect loop**, because there is no connection to lose. An unreachable grill raises `NotConnectedError` on the next call and starts working again by itself when it returns.

## A reply is matched to its request, not to the echoed id

Over HTTP the response provably belongs to the request that produced it. So a firmware that echoes a different id — or none — cannot leave the caller waiting out a 30-second timeout for a reply already in hand. Confirmed by mutation: removing that coercion turns `test_a_reply_with_the_wrong_id_still_resolves` from a 0.04s pass into a timeout failure.

## Testing

Driven against a **real aiohttp server** standing in for `/rpc` rather than a mocked `ClientSession`, so the JSON envelope, status codes and content type are exercised as the firmware presents them — including Mongoose's habit of not setting a JSON content type.

13 tests covering: the ping on connect, round-tripping, `Unauthorized` on a password-checked method, an error payload, a non-200 status, an unreachable host, the id mismatch above, both content types, callbacks staying silent, and reuse after `disconnect()`.

That last one is worth naming. #540 records that `WebSocketConnection` cannot be reconnected after `disconnect()`, because it closes a session it owns and then reuses it. This transport rebuilds an owned session on `connect()` **and** clears it on `disconnect()` — two independent guards, so I checked the test has teeth by breaking both, at which point it fails as it should. Breaking either one alone still passes, which is the point of having two.

A result-less reply is also covered (`PB.WiFiAwakeWDT` returns null), which is #542's territory: `send_command` is annotated `-> dict` and returns `None` here. This PR does not change that annotation — it just does not pretend otherwise.

755 tests pass, `ruff check`, `ruff format --check` and `mypy .` clean.

## What is not verified

**No real grill has answered this.** @dknowles2's has `http.enable` off, and I have no access to one that has it on. The envelope shape, `/rpc` path and error format come from Mongoose's documented RPC service and from the probe script in `scripts/probe_local_rpc.py`; the decoders are the same ones the websocket transport already feeds, which is the part #505 set out to establish.

@trailro and @Giordano22 both have grills with the endpoint enabled — a single `HttpConnection(...)` + `get_state()` against real hardware would settle it, and is worth more than any test here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
