### PR TITLE
Treat a silent grill as unreachable, and fix the discovery snippet

### DIFF
--- a/pytboss/http.py
+++ b/pytboss/http.py
@@ -13,7 +13,7 @@ here turns it on: `connect()` fails against a grill where it is off, and the
 caller is expected to have established that the endpoint exists first, over a
 transport that already works. `Config.Get` over Bluetooth reports it::
 
-    http = (await boss.config.get("http"))["http"]
+    http = await boss.config.get_config("http")
     if http["enable"]:
         ...  # an HttpConnection will work against this grill
 
@@ -137,10 +137,16 @@ class HttpConnection(Transport):
                     )
                 # Mongoose does not always set a JSON content type.
                 payload: Any = await resp.json(content_type=None)
-        except ClientError as ex:
+        except (ClientError, TimeoutError) as ex:
             # The grill is unreachable rather than refusing the call. Reported
             # as a lost connection so callers treat it the way they treat a
             # dropped websocket.
+            #
+            # `TimeoutError` as well as `ClientError`: a refused connection
+            # raises the latter, but a host that simply does not answer --
+            # unplugged, asleep, or on another network -- times out instead,
+            # and `ClientTimeout` surfaces that as `asyncio.TimeoutError`,
+            # which is not a `ClientError`. Silence is the common case.
             self._connected = False
             raise NotConnectedError(f"Could not reach {self._url}: {ex}") from ex
         _LOGGER.debug("<-- %s", payload)

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -232,3 +232,30 @@ async def test_state_callbacks_never_fire(host):
         assert seen == []
     finally:
         await conn.disconnect()
+
+
+async def test_a_silent_grill_is_reported_as_not_connected():
+    """Unreachable and unresponsive are the same thing to a caller.
+
+    A refused connection raises `ClientError`, but a host that answers
+    nothing times out instead, and `ClientTimeout` surfaces that as
+    `asyncio.TimeoutError` -- which is not a `ClientError`. Silence is the
+    common case: a grill that is unplugged, asleep or on another network does
+    not send a reset.
+    """
+
+    async def never_answers(request: web.Request) -> web.Response:
+        await asyncio.sleep(30)
+        raise AssertionError("unreachable")
+
+    app = web.Application()
+    app.router.add_post("/rpc", never_answers)
+    server = TestServer(app)
+    await server.start_server()
+    try:
+        conn = HttpConnection(f"{server.host}:{server.port}", timeout=0.1)
+        with pytest.raises(NotConnectedError):
+            await conn.connect()
+        assert conn.is_connected() is False
+    finally:
+        await server.close()


### PR DESCRIPTION
The two fixes from my review of #543, as a PR against that branch rather than a comment — merge it in if you want it, ignore it if you would rather write them yourself. I cannot push to `http-transport` directly, so this is the only shape I can offer them in.

Both were found by running #543 against a real grill (PB1600PS1, PBL, 0.5.7, `http.enable` on), and both fixes are verified against the same grill rather than only the test server.

**1. A silent grill now reports `NotConnectedError`.**

`ClientTimeout` surfaces as `asyncio.TimeoutError`, which is not a `ClientError`, so the existing handler did not see it:

```
192.168.1.253 (silent, nothing listening)  before: TimeoutError        after: NotConnectedError
127.0.0.1:9   (refused, RST)               before: NotConnectedError   after: unchanged
```

The silence case is the common one — a grill that is unplugged, asleep or on another network does not send a reset — and it also left `_connected` True, because the reset lives in the same handler.

Test is in your style, a real server whose handler never answers, so it exercises the aiohttp timeout path rather than a mocked raise. Verified it fails without the fix.

**2. The discovery snippet in the module docstring now runs.**

```diff
-    http = (await boss.config.get("http"))["http"]
+    http = await boss.config.get_config("http")
     if http["enable"]:
```

`Config` has no `get`, and `get_config("http")` returns the subtree itself rather than a dict keyed by section. Executed against the grill exactly as written now:

```
>>> http = await boss.config.get_config("http")
>>> http["enable"]
True
```

Worth being exact about because that snippet is the gate — it is what a Home Assistant config flow copies, and it decides whether the local option is offered to a grill where it cannot work.

**Nothing else changed.** I did not touch the id coercion, the session ownership, the callbacks-stay-silent behaviour or any of your tests; those all check out, including on hardware.

756 tests, ruff, `ruff format --check` and mypy clean. Re-ran the grill afterwards: `get_state()` still returns 26 fields.
