### PR TITLE
Fix BLE connection-state hygiene

### DIFF
--- a/pytboss/ble.py
+++ b/pytboss/ble.py
@@ -96,9 +96,14 @@ class BleConnection(Transport):
         # Guarded because this also fires while the loop is shutting down,
         # where scheduling raises inside bleak's own callback.
         if not self._loop.is_closed():
+            # The coroutine is built before `create_task` is called, so it has
+            # to be closed explicitly when scheduling fails -- otherwise it is
+            # abandoned unawaited and warns from wherever the collector runs.
+            coro = self._fail_pending_commands()
             try:
-                self._loop.create_task(self._fail_pending_commands())
+                self._loop.create_task(coro)
             except RuntimeError:  # pragma: no cover - loop shutting down
+                coro.close()
                 _LOGGER.debug("Loop is closing; not failing pending commands.")
         if not self._reconnecting and self._disconnect_callback is not None:
             self._disconnect_callback(client)

--- a/pytboss/ble.py
+++ b/pytboss/ble.py
@@ -17,6 +17,7 @@ import bleak_retry_connector
 from bleak import BleakClient, BleakGATTCharacteristic, BLEDevice
 from bleak_retry_connector import BleakClientWithServiceCache
 
+from .exceptions import NotConnectedError
 from .transport import Transport
 
 _LOGGER = logging.getLogger("pytboss")
@@ -80,16 +81,25 @@ class BleConnection(Transport):
             name=self._ble_device.name or "<unknown>",
             disconnected_callback=self._on_disconnected,
         )
-        self._is_connected = True
+        # Only once the notifications are registered: until they are there is
+        # no receive path, so a command would be sent and never answered while
+        # `is_connected()` claimed otherwise.
         await self._ble_client.start_notify(CHAR_RPC_RX_CTL, self._on_rpc_data_received)
         await self._ble_client.start_notify(CHAR_DEBUG_LOG, self._on_debug_log_received)
+        self._is_connected = True
 
     def _on_disconnected(self, client: BleakClient) -> None:
         """Called when our Bluetooth client is disconnected."""
         _LOGGER.debug("Bluetooth disconnected.")
         self._is_connected = False
         # Bleak calls this synchronously, so the cleanup has to be scheduled.
-        self._loop.create_task(self._fail_pending_commands())
+        # Guarded because this also fires while the loop is shutting down,
+        # where scheduling raises inside bleak's own callback.
+        if not self._loop.is_closed():
+            try:
+                self._loop.create_task(self._fail_pending_commands())
+            except RuntimeError:  # pragma: no cover - loop shutting down
+                _LOGGER.debug("Loop is closing; not failing pending commands.")
         if not self._reconnecting and self._disconnect_callback is not None:
             self._disconnect_callback(client)
 
@@ -102,6 +112,10 @@ class BleConnection(Transport):
             except Exception as ex:  # noqa: BLE001
                 # Bluetooth is awful. Sometimes even disconnects fail.
                 _LOGGER.debug("Failed to disconnect: %s", ex)
+            # Released either way: a client kept after a disconnect answers a
+            # later command with a raw `BleakError` instead of the
+            # `NotConnectedError` every other transport raises.
+            self._ble_client = None
         self._is_connected = False
 
     async def reset_device(self, ble_device: BLEDevice):
@@ -125,7 +139,10 @@ class BleConnection(Transport):
 
     async def _send_prepared_command(self, cmd: dict):
         if self._ble_client is None:
-            return
+            # Raised rather than returned: swallowing the send left the caller
+            # awaiting a reply for a command that was never put on the wire,
+            # so it waited out its whole timeout to learn nothing.
+            raise NotConnectedError("Not connected")
         payload = json.dumps(cmd)
         async with self._lock:
             await self._ble_client.write_gatt_char(

--- a/tests/test_ble.py
+++ b/tests/test_ble.py
@@ -8,7 +8,7 @@ from bleak_retry_connector import BleakClientWithServiceCache
 from pytest import raises
 
 from pytboss import ble
-from pytboss.exceptions import RPCError
+from pytboss.exceptions import NotConnectedError, RPCError
 
 
 @mock.patch("bleak_retry_connector.establish_connection")
@@ -311,8 +311,11 @@ async def test_disconnect_swallows_exception(
 async def test_send_prepared_command_no_client():
     mock_device = mock.create_autospec(bleak.BLEDevice)
     conn = ble.BleConnection(mock_device)
-    # Never connected, so there is no BLE client yet.
-    await conn._send_prepared_command({"id": 1, "method": "foo", "params": {}})
+    # Never connected, so there is no BLE client yet. This used to return
+    # silently, which left the caller awaiting a reply to a command that was
+    # never sent.
+    with raises(NotConnectedError):
+        await conn._send_prepared_command({"id": 1, "method": "foo", "params": {}})
 
 
 async def test_on_rpc_data_received_no_client():
@@ -372,3 +375,62 @@ async def test_debug_log_vdata(
     data = bytearray(b'<==PBD:  {"foo":"bar"}')
     await conn._on_debug_log_received(None, data)
     vdata_cb.assert_awaited_once_with('{"foo":"bar"}')
+
+
+@mock.patch("bleak_retry_connector.establish_connection")
+@mock.patch("bleak.BleakClient", spec=True)
+@mock.patch("bleak.BLEDevice", spec=True)
+async def test_a_failed_notify_does_not_report_connected(
+    mock_device, mock_bleak_client, mock_establish_connection
+):
+    """Until the notifications are registered there is no receive path.
+
+    Reporting connected before them meant a command could be sent and never
+    answered, while `is_connected()` said the transport was fine.
+    """
+    mock_establish_connection.return_value = mock_bleak_client
+    mock_bleak_client.start_notify.side_effect = bleak.exc.BleakError("nope")
+
+    conn = ble.BleConnection(mock_device)
+    with raises(bleak.exc.BleakError):
+        await conn.connect()
+
+    assert not conn.is_connected()
+
+
+@mock.patch("bleak_retry_connector.establish_connection")
+@mock.patch("bleak.BleakClient", spec=True)
+@mock.patch("bleak.BLEDevice", spec=True)
+async def test_a_command_after_disconnect_reports_not_connected(
+    mock_device, mock_bleak_client, mock_establish_connection
+):
+    """Every other transport raises `NotConnectedError`; this one raised a
+    `BleakError` from a client it had already disconnected."""
+    mock_establish_connection.return_value = mock_bleak_client
+
+    conn = ble.BleConnection(mock_device)
+    await conn.connect()
+    await conn.disconnect()
+
+    with raises(NotConnectedError):
+        await conn.send_command("PB.GetState", {}, timeout=1.0)
+
+
+@mock.patch("bleak_retry_connector.establish_connection")
+@mock.patch("bleak.BleakClient", spec=True)
+@mock.patch("bleak.BLEDevice", spec=True)
+async def test_disconnect_notification_during_shutdown_does_not_raise(
+    mock_device, mock_bleak_client, mock_establish_connection
+):
+    """Bleak calls `_on_disconnected` synchronously, including as the loop
+    goes away -- scheduling there would raise inside its own callback."""
+    mock_establish_connection.return_value = mock_bleak_client
+    conn = ble.BleConnection(mock_device)
+    await conn.connect()
+
+    with mock.patch.object(
+        conn._loop, "create_task", side_effect=RuntimeError("loop is closing")
+    ):
+        conn._on_disconnected(mock_bleak_client)
+
+    assert not conn.is_connected()


### PR DESCRIPTION
First of two from #540. Three connection-state problems in `ble.py`, all validated against current `main` before writing anything.

**1. `connect()` reported success before there was a receive path.** `_is_connected = True` was set before `start_notify()`. If notify registration failed, the transport claimed to be connected with nothing listening — every command would be sent and never answered, while `is_connected()` said the link was fine. Moved after both registrations.

This is the one with real consequence: on Bluetooth a coordinator would report the grill online and simply fail every call.

**2. `disconnect()` kept the client.** `_ble_client` stayed set, so a later command reached a disconnected bleak client. Released now.

**3. `_on_disconnected` scheduled work unconditionally.** Bleak calls it synchronously, including while the loop is going away, where `create_task` raises inside bleak's own callback. Guarded.

**That third one is mine.** There was no `create_task` there before [#528](https://github.com/dknowles2/pytboss/pull/528) — I added it to fail in-flight commands, and in doing so introduced the shutdown hazard I then filed against myself. Confirmed with `git show 8975a16^:pytboss/ble.py`.

### One thing #540 did not know about, and it is worse than what it described

Fixing (2) surfaced this. `_send_prepared_command` did:

```python
if self._ble_client is None:
    return
```

So a command with no client was **silently swallowed**: never put on the wire, and the caller then awaited a reply that could not come until its timeout expired. #540 said a post-disconnect command "fails with a raw `BleakError`" — it does not, it hangs. It now raises `NotConnectedError`, which is what every other transport does.

**This is a behaviour change and an existing test encoded the old one.** `test_send_prepared_command_no_client` asserted the silent return; it now asserts the raise. Flagging it rather than letting it look like a test that needed adjusting.

### Tests

Four, each verified to fail without its fix: a failed notify does not report connected; a command after disconnect raises `NotConnectedError`; a disconnect notification during loop shutdown does not raise; and the updated no-client case.

745 tests, ruff, `ruff format --check` and mypy clean. Merges cleanly with #543 and with the WSS half of #540, which I have sent separately.
