### PR TITLE
Make the websocket transport reusable

### DIFF
--- a/pytboss/wss.py
+++ b/pytboss/wss.py
@@ -48,8 +48,11 @@ class WebSocketConnection(Transport):
         :param base_url: Base URL to use for connections.
         """
         super().__init__(loop=loop)
-        self._session = session or ClientSession(loop=self._loop)
-        self._session_owned = session is None  # Track if we created the session
+        # A caller's session is theirs to close. Only one we made ourselves is
+        # ours, and `connect()` rebuilds it, so this transport is reusable
+        # after `disconnect()`.
+        self._session = session
+        self._session_owned = session is None
         self._sock_lock = Lock()  # Protects access to self._sock operations
         self._sock: ClientWebSocketResponse | None = None
         self._url = f"{base_url}/to/{grill_id}"
@@ -60,12 +63,39 @@ class WebSocketConnection(Transport):
         self._keep_running = False
 
     async def connect(self) -> None:
-        """Starts the connection to the device."""
+        """Starts the connection to the device.
+
+        Reusable: a transport that has been disconnected can be connected
+        again, and calling this twice does not strand the first subscribe
+        task.
+
+        :raise pytboss.exceptions.NotConnectedError: If a session was supplied
+            by the caller and has since been closed.
+        """
+        await self._stop_subscribing()
+        if self._session is None or self._session.closed:
+            if not self._session_owned:
+                raise NotConnectedError("The session given to this transport is closed")
+            self._session = ClientSession(loop=self._loop)
         self._sock = await self._ws_connect()
         self._keep_running = True
         self._stopping.clear()
         self._subscribe_task = self._loop.create_task(self._subscribe())
         await self._subscribed.wait()
+
+    async def _stop_subscribing(self) -> None:
+        """Wind down a running subscribe task, if there is one."""
+        if self._subscribe_task is None:
+            return
+        self._keep_running = False
+        self._stopping.set()
+        if self._sock is not None and not self._sock.closed:
+            await self._sock.close()
+        await self._subscribe_task
+        self._subscribe_task = None
+        # The event means "the loop is reading". Left set, the next
+        # `connect()` returns before that is true again.
+        self._subscribed.clear()
 
     async def disconnect(self) -> None:
         """Stops the connection to the device.
@@ -74,20 +104,19 @@ class WebSocketConnection(Transport):
         internally (i.e. no `session` was passed to `__init__`), and waits
         for the background reconnect/subscribe task to finish.
         """
-        self._keep_running = False
-        # Wake the subscribe task if it is waiting out a reconnect backoff;
+        # Wakes the subscribe task if it is waiting out a reconnect backoff;
         # otherwise this call blocks for the remainder of that sleep.
-        self._stopping.set()
-        if self._sock:
-            await self._sock.close()
-        # Only close the session if we created it (not if it was provided externally)
-        if self._session_owned and not self._session.closed:
-            await self._session.close()
-        if self._subscribe_task:
-            await self._subscribe_task
+        await self._stop_subscribing()
+        # Only a session we created is ours to close.
+        if self._session_owned and self._session is not None:
+            if not self._session.closed:
+                await self._session.close()
+            self._session = None
 
     async def _ws_connect(self) -> ClientWebSocketResponse:
         _LOGGER.debug("Connecting to WebSocket")
+        if self._session is None:
+            raise NotConnectedError("Not connected")
         try:
             return await self._session.ws_connect(self._url)
         except WSServerHandshakeError as ex:

--- a/tests/test_wss.py
+++ b/tests/test_wss.py
@@ -342,12 +342,90 @@ async def test_result_payload_no_vdata_callback(
 
 
 async def test_internal_session_closed():
-    """Test that internal sessions are closed when disconnect is called."""
-    # Create a connection without providing a session (it will create its own)
-    conn = wss.WebSocketConnection("_grill_id_")
+    """An owned session is closed and released on disconnect.
 
-    # Disconnect should close the internal session
+    It is now created by `connect()` rather than by the constructor, so a
+    transport that was never connected has none to close -- and building one
+    no longer leaves an aiohttp session behind for the caller to clean up.
+    """
+    conn = wss.WebSocketConnection("_grill_id_")
+    assert conn._session is None
+
+    session = ClientSession()
+    conn._session = session
     await conn.disconnect()
 
-    # The internal session should be closed
-    assert conn._session.closed
+    assert session.closed
+    assert conn._session is None
+
+
+async def test_the_transport_is_reusable_after_disconnect(fake_server: TestServer):
+    """A transport that has been disconnected can be connected again.
+
+    `disconnect()` used to close a session the constructor had built and
+    never rebuild it, so a second `connect()` failed on a closed session.
+    """
+    async with fake_server:
+        conn = wss.WebSocketConnection(
+            "_grill_id_", base_url=str(fake_server.make_url("")), app_id="_app_id_"
+        )
+        await conn.connect()
+        await conn.disconnect()
+
+        await conn.connect()
+        assert conn._session is not None
+        assert not conn._session.closed
+        await conn.disconnect()
+
+
+async def test_a_closed_caller_session_is_reported(fake_server: TestServer):
+    """A session the caller owns is theirs to manage; we do not rebuild it."""
+    async with fake_server:
+        session = ClientSession()
+        conn = wss.WebSocketConnection(
+            "_grill_id_",
+            session=session,
+            base_url=str(fake_server.make_url("")),
+            app_id="_app_id_",
+        )
+        await session.close()
+
+        with raises(NotConnectedError):
+            await conn.connect()
+
+
+async def test_connecting_twice_does_not_strand_the_first_task(
+    fake_server: TestServer,
+):
+    """The second `connect()` used to overwrite `_subscribe_task`."""
+    async with fake_server:
+        conn = wss.WebSocketConnection(
+            "_grill_id_", base_url=str(fake_server.make_url("")), app_id="_app_id_"
+        )
+        await conn.connect()
+        first = conn._subscribe_task
+
+        await conn.connect()
+
+        assert first is not None
+        assert first.done()
+        assert conn._subscribe_task is not first
+        await conn.disconnect()
+
+
+async def test_disconnect_clears_the_subscribed_flag(fake_server: TestServer):
+    """The flag means "the loop is reading", and after a disconnect it is not.
+
+    Left set, the next `connect()` returns from its wait before the new
+    subscribe task has started reading.
+    """
+    async with fake_server:
+        conn = wss.WebSocketConnection(
+            "_grill_id_", base_url=str(fake_server.make_url("")), app_id="_app_id_"
+        )
+        await conn.connect()
+        assert conn._subscribed.is_set()
+
+        await conn.disconnect()
+
+        assert not conn._subscribed.is_set()


### PR DESCRIPTION
Second of two from #540. Makes `WebSocketConnection` reusable after `disconnect()`, which it was not.

Three problems, all validated against current `main`:

**1. The owned session was closed and never rebuilt.** The constructor did `session or ClientSession(...)`, `disconnect()` closed it when owned, and `connect()` never made another — so a second `connect()` failed on a closed session. The session is now built by `connect()` and released by `disconnect()`.

That also means **constructing a `WebSocketConnection` no longer creates an aiohttp session**, so building one you never connect does not leave a session for the caller to clean up.

**2. `_subscribed` was never cleared.** #536 cleared `_stopping` on connect but not this, so `connect()` returned from its wait before the new subscribe task had started reading. It is cleared when the task winds down, since the flag means "the loop is reading" and after a disconnect it is not — which also makes it directly testable.

**3. `connect()` twice stranded the first task.** `_subscribe_task` was overwritten without cancelling or awaiting the previous one. Both `connect()` and `disconnect()` now go through one `_stop_subscribing()`.

This is the same shape as the guards you wrote in `http.py` for #543 — session ownership on one side, state cleared on the other. I followed that rather than inventing a different pattern.

### The one existing test that changed

`test_internal_session_closed` asserted `conn._session.closed` on a transport that had never connected. With lazy creation there is nothing to close there, so it now asserts what the change actually guarantees: an owned session is closed **and released**, and a fresh transport has none. Calling that out rather than letting an edited assertion pass unremarked.

### Tests

Four, each verified to fail without its fix — including one that took two minutes to fail rather than failing fast, which is itself the symptom: a stranded subscribe task keeps the loop alive.

- reusable after disconnect
- a caller-supplied session that has been closed is reported rather than rebuilt
- connecting twice does not strand the first task
- disconnect clears the subscribed flag

746 tests, ruff, `ruff format --check` and mypy clean. Merges cleanly with #543 and with #547.

### What is left in #540

The BLE debug-log parser. `data.decode().split()` assumes no spaces in the payload; it holds today because mJS `print` inserts the separator and `JSON.stringify` is compact, so nothing in the payload has one. I have not sent a fix because I cannot write a test that fails without synthesising a payload the firmware does not emit — hardening a working parser with no reproducible trigger seemed the wrong trade. Happy to send it if you would rather have the belt.
