### PR TITLE
Parse the debug log without splitting the payload

### DIFF
--- a/pytboss/ble.py
+++ b/pytboss/ble.py
@@ -175,23 +175,29 @@ class BleConnection(Transport):
         self, unused_char: BleakGATTCharacteristic, data: bytearray
     ):
         _LOGGER.debug("Debug log received: %s", data)
-        parts = data.decode("utf-8").split()
-        if len(parts) == 3:
-            head, payload, tail = parts
-            checksum = int(tail[1 : len(tail) - 1])
-            if len(payload) != checksum:
-                # Bad payload; ignore.
-                _LOGGER.debug(
-                    "Ignoring message with bad checksum (%d != %d)",
-                    len(payload),
-                    checksum,
-                )
-                return
-        elif len(parts) == 2:
-            head, payload = parts
-        else:
+        # Split off the head and an optional trailing "[len]" rather than on
+        # every space: a virtual data payload is JSON, and any string value in
+        # it with a space in it would otherwise either be dropped or parsed as
+        # the length. Both are reachable through `set_virtual_data`, since the
+        # grill echoes back what was written.
+        head, _, rest = data.decode("utf-8").strip().partition(" ")
+        payload = rest.strip()
+        if not payload:
             # Unknown payload; ignore.
             return
+        if payload.endswith("]"):
+            body, _, tail = payload.rpartition("[")
+            if body and tail[:-1].isdigit():
+                payload = body.strip()
+                checksum = int(tail[:-1])
+                if len(payload) != checksum:
+                    # Bad payload; ignore.
+                    _LOGGER.debug(
+                        "Ignoring message with bad checksum (%d != %d)",
+                        len(payload),
+                        checksum,
+                    )
+                    return
         if head == "<==PB:" and self._state_callback:
             status_payload = temperatures_payload = None
             match payload[:4]:

--- a/tests/test_ble.py
+++ b/tests/test_ble.py
@@ -434,3 +434,47 @@ async def test_disconnect_notification_during_shutdown_does_not_raise(
         conn._on_disconnected(mock_bleak_client)
 
     assert not conn.is_connected()
+
+
+@mock.patch("bleak_retry_connector.establish_connection")
+@mock.patch("bleak.BleakClient", spec=True)
+@mock.patch("bleak.BLEDevice", spec=True)
+async def test_debug_log_vdata_with_a_space(
+    mock_device, mock_bleak_client, mock_establish_connection
+):
+    """A JSON string value with a space in it is still one payload.
+
+    Reachable through `set_virtual_data`: the grill echoes back what was
+    written, so a consumer storing any string with a space made this parse
+    raise `ValueError` inside the notification callback.
+    """
+    mock_establish_connection.return_value = mock_bleak_client
+    conn = ble.BleConnection(mock_device)
+    vdata_cb = mock.AsyncMock()
+    conn.set_vdata_callback(vdata_cb)
+    await conn.connect()
+
+    data = bytearray(b'<==PBD:  {"note":"hello world"}')
+    await conn._on_debug_log_received(None, data)
+
+    vdata_cb.assert_awaited_once_with('{"note":"hello world"}')
+
+
+@mock.patch("bleak_retry_connector.establish_connection")
+@mock.patch("bleak.BleakClient", spec=True)
+@mock.patch("bleak.BLEDevice", spec=True)
+async def test_debug_log_checksum_counts_the_whole_payload(
+    mock_device, mock_bleak_client, mock_establish_connection
+):
+    """A payload with a space is measured whole, not up to the first one."""
+    mock_establish_connection.return_value = mock_bleak_client
+    conn = ble.BleConnection(mock_device)
+    vdata_cb = mock.AsyncMock()
+    conn.set_vdata_callback(vdata_cb)
+    await conn.connect()
+
+    payload = '{"note":"hello world"}'
+    data = bytearray(f"<==PBD:  {payload} [{len(payload)}]".encode())
+    await conn._on_debug_log_received(None, data)
+
+    vdata_cb.assert_awaited_once_with(payload)


### PR DESCRIPTION
The last item in #540, and **I was wrong to say it should be left.**

I argued it was speculative hardening I could not test without synthesising a payload the firmware does not emit. That was wrong on both counts: the payload is reachable through the library's own API, and the parser is a pure function of its input, so testing it with an input a consumer can cause is entirely fair. I talked myself out of it on a bad premise.

**It is reachable through `set_virtual_data`.** The grill echoes back what was written, so storing any string with a space in it produces a debug-log line the parser cannot handle:

```
>>> await conn._on_debug_log_received(None, bytearray(b'<==PBD:  {"note":"hello world"}'))
ValueError: invalid literal for int() with base 10: 'orld"'
```

Raised inside the bleak notification callback. Split on every space, `{"note":"hello world"}` becomes two parts, the second is read as the length field, and `int()` gets `orld"`.

The other shape is quieter and worse: a payload with two spaces gives four parts, falls through to the `else`, and is dropped with no log line at all.

**The fix stops splitting the payload.** Head comes off at the first space, an optional trailing `[len]` comes off the end, and everything between is the payload — spaces and all.

Two tests, both verified to fail against `main`:

- a JSON string value with a space arrives intact
- the checksum measures the whole payload rather than the run up to the first space

Note the length marker is `[5]`, square brackets. I assumed parentheses first and the existing `test_debug_log_bad_checksum` caught it immediately — the old `tail[1:-1]` worked for either, which is why nothing in the code says which it is.

**The `# TODO: I think we want to decode this?` on the vdata path is untouched.** It is a separate question — whether the callback should receive parsed JSON rather than a string — and it changes a public callback's contract, so it did not belong here.

751 tests, ruff, `ruff format --check` and mypy clean. With this, #540 has nothing left in it.
