### PR TITLE
Annotate send_command as returning dict or None

### DIFF
--- a/pytboss/api.py
+++ b/pytboss/api.py
@@ -217,12 +217,12 @@ class PitBoss:
         psw = encode(self._password, key=timed_key(await self.get_uptime())).hex()
         return {**params, "psw": psw}
 
-    async def _send_hex_command(self, cmd: str) -> dict:
+    async def _send_hex_command(self, cmd: str) -> dict | None:
         return await self._conn.send_command(
             "PB.SendMCUCommand", await self._authenticate({"command": cmd})
         )
 
-    async def _send_command(self, slug: str, *args) -> dict:
+    async def _send_command(self, slug: str, *args) -> dict | None:
         cmd = self.spec.control_board.commands[slug]
         return await self._send_hex_command(cmd(*args))
 
@@ -254,7 +254,7 @@ class PitBoss:
         # they floor, so 190F is 87C to the grill rather than 88.
         return [floor((v - 32) / 1.8) for v in increments]
 
-    async def set_grill_temperature(self, temp: int) -> dict:
+    async def set_grill_temperature(self, temp: int) -> dict | None:
         """Sets the target grill temperature.
 
         Snapped to the nearest value the control board accepts, expressed in
@@ -273,7 +273,7 @@ class PitBoss:
         # ignore the extra argument, as do fixed-hex commands.
         return await self._send_command("set-temperature", temp, fahrenheit)
 
-    async def set_probe_temperature(self, temp: int) -> dict:
+    async def set_probe_temperature(self, temp: int) -> dict | None:
         """Sets the target temperature for probe 1.
 
         :param temp: Target probe temperature, in the grill's own unit.
@@ -282,7 +282,7 @@ class PitBoss:
             "set-probe-1-temperature", temp, self._is_fahrenheit()
         )
 
-    async def set_probe_2_temperature(self, temp: int) -> dict:
+    async def set_probe_2_temperature(self, temp: int) -> dict | None:
         """Sets the target temperature for probe 2.
 
         :param temp: Target probe temperature, in the grill's own unit.
@@ -403,7 +403,7 @@ class PitBoss:
         """
         await self._conn.send_command("PB.WiFiAwakeWDT", await self._authenticate({}))
 
-    async def set_temperature_unit(self, fahrenheit: bool) -> dict:
+    async def set_temperature_unit(self, fahrenheit: bool) -> dict | None:
         """Switches the unit the grill itself works in.
 
         This is the grill's own setting -- the one shown on its panel and
@@ -415,19 +415,19 @@ class PitBoss:
             "set-fahrenheit" if fahrenheit else "set-celsius"
         )
 
-    async def turn_light_on(self) -> dict:
+    async def turn_light_on(self) -> dict | None:
         """Turns the light on if the grill has a light."""
         if not self.spec.has_lights:
             return {}
         return await self._send_command("turn-light-on")
 
-    async def turn_light_off(self) -> dict:
+    async def turn_light_off(self) -> dict | None:
         """Turns the light off if the grill has a light."""
         if not self.spec.has_lights:
             return {}
         return await self._send_command("turn-light-off")
 
-    async def turn_grill_on(self) -> dict:
+    async def turn_grill_on(self) -> dict | None:
         """Lights the grill.
 
         **This starts a fire in an appliance nobody may be standing next to.**
@@ -463,15 +463,15 @@ class PitBoss:
         """
         return await self._send_hex_command("FE0101FF")
 
-    async def turn_grill_off(self) -> dict:
+    async def turn_grill_off(self) -> dict | None:
         """Turns the grill off."""
         return await self._send_command("turn-off")
 
-    async def turn_primer_motor_on(self) -> dict:
+    async def turn_primer_motor_on(self) -> dict | None:
         """Turns the primer motor on."""
         return await self._send_command("turn-primer-motor-on")
 
-    async def turn_primer_motor_off(self) -> dict:
+    async def turn_primer_motor_off(self) -> dict | None:
         """Turns the primer motor off."""
         return await self._send_command("turn-primer-motor-off")
 
@@ -483,8 +483,9 @@ class PitBoss:
         anything relying on it stays correct on a connection that only ever
         polls.
         """
-        resp = await self._conn.send_command(
-            "PB.GetState", await self._authenticate({})
+        resp = (
+            await self._conn.send_command("PB.GetState", await self._authenticate({}))
+            or {}
         )
         status = self.spec.control_board.parse_status(resp["sc_11"]) or {}
         status.update(self.spec.control_board.parse_temperatures(resp["sc_12"]) or {})
@@ -495,9 +496,11 @@ class PitBoss:
 
     async def get_firmware_version(self) -> dict:
         """Returns the firmware version installed on the grill."""
-        return await self._conn.send_command("PB.GetFirmwareVersion", {})
+        # `or {}`: the handler answers with an object in every vendor image,
+        # so the empty dict stands in only for a broken exchange.
+        return await self._conn.send_command("PB.GetFirmwareVersion", {}) or {}
 
-    async def set_mcu_update_timer(self, frequency=2):
+    async def set_mcu_update_timer(self, frequency=2) -> dict | None:
         """Sets how often (in seconds) the MCU sends status updates.
 
         :meta private:
@@ -506,7 +509,7 @@ class PitBoss:
             "PB.SetMCU_UpdateFrequency", {"frequency": frequency}
         )
 
-    async def set_wifi_update_frequency(self, fast=5, slow=60):
+    async def set_wifi_update_frequency(self, fast=5, slow=60) -> dict | None:
         """Sets how often (in seconds) the device sends WiFi status updates.
 
         :meta private:
@@ -516,7 +519,7 @@ class PitBoss:
             await self._authenticate({"slow": slow, "fast": fast}),
         )
 
-    async def set_virtual_data(self, data: dict):
+    async def set_virtual_data(self, data: dict) -> dict | None:
         """Sets arbitrary virtual data on the device.
 
         :meta private:
@@ -557,7 +560,7 @@ class PitBoss:
         """
         now = monotonic()
         if self._last_uptime is None or now - self._last_uptime_check > _UPTIME_TTL:
-            result = await self._conn.send_command("PB.GetTime", {})
+            result = await self._conn.send_command("PB.GetTime", {}) or {}
             self._last_uptime = result.get("time", 0.0)
             # Deliberately the pre-request timestamp, though the grill
             # computed its uptime later, when the request reached it: every
@@ -573,7 +576,7 @@ class PitBoss:
             return self._last_uptime
         return self._last_uptime + (now - self._last_uptime_check)
 
-    async def ping(self, timeout: float | None = None) -> dict:
+    async def ping(self, timeout: float | None = None) -> dict | None:
         """Pings the device.
 
         :param timeout: Time (in seconds) after which to abandon the RPC.

--- a/pytboss/config.py
+++ b/pytboss/config.py
@@ -20,7 +20,7 @@ class Config:
 
     async def get_info(self) -> dict:
         """Returns system information."""
-        return await self._conn.send_command("Sys.GetInfo", {})
+        return await self._conn.send_command("Sys.GetInfo", {}) or {}
 
     async def get_config(self, key: str | None = None) -> dict:
         """Retrieves device configuration subtree.
@@ -30,7 +30,7 @@ class Config:
         params = {}
         if key:
             params["key"] = key
-        return await self._conn.send_command("Config.Get", params)
+        return await self._conn.send_command("Config.Get", params) or {}
 
     async def save_config(self, reboot: bool = True):
         """Writes an existing device configuration on flash.
@@ -42,11 +42,11 @@ class Config:
             fn = self._conn.send_command_without_answer
         await fn("Config.Save", {"reboot": reboot})
 
-    async def set(self, **kwargs):
+    async def set(self, **kwargs) -> dict | None:
         """Sets device configuration parameters."""
         return await self._conn.send_command("Config.Set", {"config": kwargs})
 
-    async def set_wifi_credentials(self, ssid: str, password: str) -> dict:
+    async def set_wifi_credentials(self, ssid: str, password: str) -> dict | None:
         """Sets the WiFi credentials on the device.
 
         :param ssid: The SSID to connect to.
@@ -54,14 +54,14 @@ class Config:
         """
         return await self._conn.send_command("Config.Set", _wifi_params(ssid, password))
 
-    async def set_wifi_ssid(self, ssid):
+    async def set_wifi_ssid(self, ssid) -> dict | None:
         """Sets the WiFi SSID.
 
         :param ssid: The SSID to connect to.
         """
         return await self._conn.send_command("Config.Set", _wifi_params(ssid=ssid))
 
-    async def set_wifi_password(self, password):
+    async def set_wifi_password(self, password) -> dict | None:
         """Sets the WiFi password.
 
         :param password: The password for the WiFi network.

--- a/pytboss/fs.py
+++ b/pytboss/fs.py
@@ -18,7 +18,7 @@ class FileSystem:
         """
         self._conn = conn
 
-    async def get_file_list(self) -> dict:
+    async def get_file_list(self) -> dict | None:
         """Lists files present on the device's filesystem."""
         return await self._conn.send_command("FS.List", {})
 
@@ -31,8 +31,11 @@ class FileSystem:
         offset = 0
         content = bytearray()
         while True:
-            resp = await self._conn.send_command(
-                "FS.Get", {"filename": filename, "offset": offset, "len": length}
+            resp = (
+                await self._conn.send_command(
+                    "FS.Get", {"filename": filename, "offset": offset, "len": length}
+                )
+                or {}
             )
             content += b64decode(resp["data"])
             offset += length
@@ -41,7 +44,9 @@ class FileSystem:
                 # the chunk boundary is not valid UTF-8 on its own.
                 return content.decode("utf-8")
 
-    async def set_file_content(self, filename: str, data: str, append: bool) -> dict:
+    async def set_file_content(
+        self, filename: str, data: str, append: bool
+    ) -> dict | None:
         """Writes content to a file on the device.
 
         :param filename: Path of the file to write.
@@ -54,7 +59,7 @@ class FileSystem:
             {"filename": filename, "data": data, "append": append},
         )
 
-    async def rename_file(self, src: str, dst: str) -> dict:
+    async def rename_file(self, src: str, dst: str) -> dict | None:
         """Renames a file on the device.
 
         :param src: Existing filename.
@@ -62,7 +67,7 @@ class FileSystem:
         """
         return await self._conn.send_command("FS.Rename", {"src": src, "dst": dst})
 
-    async def delete_file(self, filename: str) -> dict:
+    async def delete_file(self, filename: str) -> dict | None:
         """Deletes a file from the device.
 
         :param filename: Path of the file to delete.

--- a/pytboss/transport.py
+++ b/pytboss/transport.py
@@ -98,8 +98,13 @@ class Transport(ABC):
 
     async def send_command(
         self, method: str, params: dict, *, timeout: float | None = DEFAULT_TIMEOUT
-    ) -> dict:
+    ) -> dict[Any, Any] | None:
         """Sends a comand to the device.
+
+        Returns the reply's `result`, which is `None` for the handlers that
+        return nothing: every vendor firmware image resolves the setter RPCs
+        (`PB.SendMCUCommand`, `PB.SetVirtualData`, ...) with `null`, and only
+        the getters answer with an object.
 
         :param method: The method to call.
         :param params: Parameters to send with the command.

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -100,7 +100,11 @@ class FakeTransport(Transport):
         }
         resp = {"id": cmd["id"]}
         try:
-            resp["result"] = dispatch[cmd["method"]](cmd["params"])
+            # Like the firmware: handlers that return null produce a reply
+            # without a `result` key.
+            result = dispatch[cmd["method"]](cmd["params"])
+            if result is not None:
+                resp["result"] = result
         except Unauthorized:
             resp["error"] = {"code": 401, "message": "Unauthorized"}
         except Exception as ex:  # noqa: BLE001
@@ -133,20 +137,21 @@ class FakeTransport(Transport):
         self._check_password(params)
         return dict(self.virtual_data)
 
-    def _set_virtual_data(self, params: dict) -> dict:
-        """Assign the payload wholesale, as the firmware does."""
+    def _set_virtual_data(self, params: dict) -> None:
+        """Assign the payload wholesale and return nothing, as the firmware
+        does (its success path has no return statement at all)."""
         self._check_password(params)
         self.virtual_data = dict(params)
-        return {}
 
-    def _set_password(self, params: dict) -> dict:
+    def _set_password(self, params: dict) -> None:
+        """Ends in `return null` in every vendor image."""
         self._check_password(params)
         if "newPassword" not in params:
             raise KeyError(f"newPassword not in {params}")
         self.password = decode(bytes.fromhex(params["newPassword"])).decode()
-        return {}
 
-    def _send_mcu_command(self, params: dict) -> dict:
+    def _send_mcu_command(self, params: dict) -> None:
+        """Ends in `return null` in every vendor image."""
         self._check_password(params)
         if "command" not in params:
             raise KeyError("Command parameter missing")
@@ -154,7 +159,6 @@ class FakeTransport(Transport):
         if not command:
             raise ValueError("Empty command")
         self.last_mcu_command = bytes.fromhex(params["command"]).decode()
-        return {}
 
     def _get_state(self, params: dict) -> dict:
         self._check_password(params)
@@ -303,21 +307,21 @@ async def test_set_password_with_old_password():
 
 
 async def test_set_grill_temperature(pitboss: api.PitBoss, conn: FakeTransport):
-    assert (await pitboss.set_grill_temperature(225)) == {}
+    assert (await pitboss.set_grill_temperature(225)) is None
     assert conn.last_mcu_command == "set-temperature(225, True)"
 
 
 @pytest.mark.grill_params({"temp_increments": [180, 200, 220]})
 async def test_set_grill_temperature_high(pitboss: api.PitBoss, conn: FakeTransport):
     """Above the range, the highest accepted setpoint."""
-    assert (await pitboss.set_grill_temperature(400)) == {}
+    assert (await pitboss.set_grill_temperature(400)) is None
     assert conn.last_mcu_command == "set-temperature(220, True)"
 
 
 @pytest.mark.grill_params({"temp_increments": [180, 200, 220]})
 async def test_set_grill_temperature_low(pitboss: api.PitBoss, conn: FakeTransport):
     """Below the range, the lowest accepted setpoint."""
-    assert (await pitboss.set_grill_temperature(100)) == {}
+    assert (await pitboss.set_grill_temperature(100)) is None
     assert conn.last_mcu_command == "set-temperature(180, True)"
 
 
@@ -326,7 +330,7 @@ async def test_set_grill_temperature_snaps_to_the_nearest(
     pitboss: api.PitBoss, conn: FakeTransport
 ):
     """The board ignores anything that is not on its list."""
-    assert (await pitboss.set_grill_temperature(206)) == {}
+    assert (await pitboss.set_grill_temperature(206)) is None
     assert conn.last_mcu_command == "set-temperature(200, True)"
 
 
@@ -337,7 +341,7 @@ async def test_set_grill_temperature_in_celsius(
     """A grill reporting Celsius is sent Celsius, not a Fahrenheit bound."""
     pitboss._state["isFahrenheit"] = False
     # 180/190/200F floor to 82/87/93C.
-    assert (await pitboss.set_grill_temperature(88)) == {}
+    assert (await pitboss.set_grill_temperature(88)) is None
     assert conn.last_mcu_command == "set-temperature(87, False)"
 
 
@@ -348,18 +352,18 @@ async def test_set_grill_temperature_prefers_a_declared_celsius_list(
     pitboss: api.PitBoss, conn: FakeTransport
 ):
     pitboss._state["isFahrenheit"] = False
-    assert (await pitboss.set_grill_temperature(44)) == {}
+    assert (await pitboss.set_grill_temperature(44)) is None
     assert conn.last_mcu_command == "set-temperature(45, False)"
 
 
 async def test_set_probe_temperature(pitboss: api.PitBoss, conn: FakeTransport):
-    assert (await pitboss.set_probe_temperature(225)) == {}
+    assert (await pitboss.set_probe_temperature(225)) is None
     assert conn.last_mcu_command == "set-probe-1-temperature(225, True)"
 
 
 @pytest.mark.grill_params({"has_lights": True})
 async def test_turn_light_on(pitboss: api.PitBoss, conn: FakeTransport):
-    assert (await pitboss.turn_light_on()) == {}
+    assert (await pitboss.turn_light_on()) is None
     assert conn.last_mcu_command == "turn-light-on()"
 
 
@@ -370,7 +374,7 @@ async def test_turn_light_on_no_lights(pitboss: api.PitBoss, conn: FakeTransport
 
 @pytest.mark.grill_params({"has_lights": True})
 async def test_turn_light_off(pitboss: api.PitBoss, conn: FakeTransport):
-    assert (await pitboss.turn_light_off()) == {}
+    assert (await pitboss.turn_light_off()) is None
     assert conn.last_mcu_command == "turn-light-off()"
 
 
@@ -388,7 +392,7 @@ async def test_turn_light_off_no_lights(pitboss: api.PitBoss, conn: FakeTranspor
     ],
 )
 async def test_grill_functions(slug, method, pitboss: api.PitBoss, conn: FakeTransport):
-    assert (await getattr(pitboss, method)()) == {}
+    assert (await getattr(pitboss, method)()) is None
     assert conn.last_mcu_command == f"{slug}()"
 
 
@@ -573,7 +577,7 @@ async def test_set_probe_2_temperature(
     mock_control_board.commands["set-probe-2-temperature"] = make_cmd(
         "set-probe-2-temperature"
     )
-    assert (await pitboss.set_probe_2_temperature(120)) == {}
+    assert (await pitboss.set_probe_2_temperature(120)) is None
     assert conn.last_mcu_command == "set-probe-2-temperature(120, True)"
 
 
@@ -593,9 +597,9 @@ async def test_set_mcu_update_timer():
     pitboss = api.PitBoss(conn, "PBV4PS2")
     await pitboss.start()
     with mock.patch.object(
-        conn, "send_command", AsyncMock(return_value={})
+        conn, "send_command", AsyncMock(return_value=None)
     ) as send_command:
-        assert await pitboss.set_mcu_update_timer(frequency=3) == {}
+        assert await pitboss.set_mcu_update_timer(frequency=3) is None
         send_command.assert_awaited_once_with(
             "PB.SetMCU_UpdateFrequency", {"frequency": 3}
         )
@@ -606,9 +610,9 @@ async def test_set_wifi_update_frequency():
     pitboss = api.PitBoss(conn, "PBV4PS2")
     await pitboss.start()
     with mock.patch.object(
-        conn, "send_command", AsyncMock(return_value={})
+        conn, "send_command", AsyncMock(return_value=None)
     ) as send_command:
-        assert await pitboss.set_wifi_update_frequency(fast=1, slow=10) == {}
+        assert await pitboss.set_wifi_update_frequency(fast=1, slow=10) is None
         send_command.assert_awaited_once_with(
             "PB.SetWifiUpdateFrequency", {"slow": 10, "fast": 1}
         )
@@ -619,9 +623,9 @@ async def test_set_virtual_data():
     pitboss = api.PitBoss(conn, "PBV4PS2")
     await pitboss.start()
     with mock.patch.object(
-        conn, "send_command", AsyncMock(return_value={})
+        conn, "send_command", AsyncMock(return_value=None)
     ) as send_command:
-        assert await pitboss.set_virtual_data({"foo": "bar"}) == {}
+        assert await pitboss.set_virtual_data({"foo": "bar"}) is None
         send_command.assert_awaited_once_with("PB.SetVirtualData", {"foo": "bar"})
 
 
@@ -649,10 +653,10 @@ async def test_get_state_updates_the_cached_state(conn: FakeTransport, password:
 
 
 async def test_set_temperature_unit(pitboss: api.PitBoss, conn: FakeTransport):
-    assert (await pitboss.set_temperature_unit(fahrenheit=False)) == {}
+    assert (await pitboss.set_temperature_unit(fahrenheit=False)) is None
     assert conn.last_mcu_command == "set-celsius()"
 
-    assert (await pitboss.set_temperature_unit(fahrenheit=True)) == {}
+    assert (await pitboss.set_temperature_unit(fahrenheit=True)) is None
     assert conn.last_mcu_command == "set-fahrenheit()"
 
 
@@ -827,9 +831,9 @@ async def test_turn_grill_on(pitboss: api.PitBoss, conn: FakeTransport):
     identifies it -- FE0101FF against FE0102FF for off.
     """
     with mock.patch.object(
-        conn, "send_command", AsyncMock(return_value={})
+        conn, "send_command", AsyncMock(return_value=None)
     ) as send_command:
-        assert (await pitboss.turn_grill_on()) == {}
+        assert (await pitboss.turn_grill_on()) is None
         assert send_command.await_args is not None
         method, params = send_command.await_args.args
         assert method == "PB.SendMCUCommand"


### PR DESCRIPTION
Fixes #542, taking option 1 — the union is the true type, per the firmware audit posted there.

## What the vendor images established

Across all seven mJS versions (0.2.3–0.6.0): **every setter handler the library wraps returns `null` on success in every version where it exists** — `PB.SendMCUCommand` included, which sits under every MCU command wrapper in `api.py` — and **every getter answers with an object in every version**. So the split is clean and universally safe:

- **`Transport.send_command` → `dict[Any, Any] | None`.** The `SendCommandFn` alias a few lines above already declared exactly this union; only the method's own annotation disagreed.
- **Setter wrappers** (`set_grill_temperature`, `set_probe_*`, `turn_*`, `set_temperature_unit`, `set_virtual_data`, `set_mcu_update_timer`, `set_wifi_update_frequency`, `Config.set`/`set_wifi_*`, `FS.Put`/`Rename`/`Remove`, `ping`) → `dict | None`. On real firmware these have been resolving `None` all along; the fake returning `{}` was what the tests were asserting.
- **Getters narrow at their own call sites** (`get_state`, `get_uptime`, `get_firmware_version`, `get_file_content`, `Config.get_info`, `get_config`) — their handlers answer with an object in every image, so `None` there only ever means a broken exchange, and callers keep the `dict` contract they had.

## The test you called for

`FakeTransport._send_prepared_command` now omits the `result` key when a handler returns nothing — the exact shape #534 fixed — and `_send_mcu_command` / `_set_virtual_data` / `_set_password` return `None` to match their firmware counterparts (`PB.SetVirtualData`'s success path has no return statement at all). Every MCU-command test now drives a result-less reply through the real request/response machinery and asserts `is None`; mocks returning `{}` on setter paths are gone.

## Compatibility

Runtime behavior is unchanged everywhere — this is annotations plus boundary narrowing. ha-pitboss consumes exactly four return values (`get_firmware_version`, `config.get_info`, `get_virtual_data`, `get_state`); all four are getters and keep returning a guaranteed dict. Setter results are not consumed there.

## Testing

`pytest` (751 passed), `ruff check`, `ruff format --check`, `mypy .` green at the CI-pinned versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)