### PR TITLE
Serialize the BLE connection lifecycle and coalesce duplicate resets

### DIFF
--- a/pytboss/ble.py
+++ b/pytboss/ble.py
@@ -64,12 +64,26 @@ class BleConnection(Transport):
         self._disconnect_callback = disconnect_callback
         self._is_connected = False
         self._reconnecting = False
+        # Serializes connect/disconnect/reset_device. Establishing a
+        # connection takes seconds, and a consumer driving reconnects from
+        # discovery -- Home Assistant schedules a reset per advertisement
+        # while `is_connected()` is False -- piles several up in exactly that
+        # window. Unserialized, their disconnect/connect steps interleave on
+        # the same object and the losing `establish_connection` leaks a
+        # connected client. Distinct from `self._lock`, which serializes GATT
+        # I/O; holding that one for the length of a connect would stall the
+        # receive path.
+        self._lifecycle_lock = asyncio.Lock()
 
     async def connect(self) -> None:
         """Starts the connection to the device.
 
         Does nothing if already connected or if no BLE device was set.
         """
+        async with self._lifecycle_lock:
+            await self._connect_locked()
+
+    async def _connect_locked(self) -> None:
         if self._is_connected:
             _LOGGER.warning("Already connected. Ignoring call to connect().")
             return
@@ -110,6 +124,10 @@ class BleConnection(Transport):
 
     async def disconnect(self) -> None:
         """Stops the connection to the device."""
+        async with self._lifecycle_lock:
+            await self._disconnect_locked()
+
+    async def _disconnect_locked(self) -> None:
         _LOGGER.debug("Disconnecting from device.")
         if self._ble_client:
             try:
@@ -126,17 +144,32 @@ class BleConnection(Transport):
     async def reset_device(self, ble_device: BLEDevice):
         """Resets the BLE device used for transport.
 
+        A reset that arrives while already connected to the same device --
+        by address -- only adopts the fresher `BLEDevice` and keeps the
+        connection. Discovery-driven consumers queue a reset per
+        advertisement seen while disconnected, and by the time the later
+        ones run, the first has already connected; tearing that connection
+        down to rebuild it against the same grill was pure churn.
+
         :param ble_device: BLE device to use for transport.
         """
-        self._reconnecting = True
-        _LOGGER.debug("Resetting device to: %s", ble_device)
-        try:
-            await self.disconnect()
-            self._is_connected = False
-            self._ble_device = ble_device
-            await self.connect()
-        finally:
-            self._reconnecting = False
+        async with self._lifecycle_lock:
+            if (
+                self._is_connected
+                and self._ble_device is not None
+                and self._ble_device.address == ble_device.address
+            ):
+                _LOGGER.debug("Already connected to %s; keeping it", ble_device)
+                self._ble_device = ble_device
+                return
+            self._reconnecting = True
+            _LOGGER.debug("Resetting device to: %s", ble_device)
+            try:
+                await self._disconnect_locked()
+                self._ble_device = ble_device
+                await self._connect_locked()
+            finally:
+                self._reconnecting = False
 
     def is_connected(self) -> bool:
         """Whether the device is currently connected."""

--- a/tests/test_ble.py
+++ b/tests/test_ble.py
@@ -118,6 +118,91 @@ async def test_reset_device_connect_failure_resets_reconnecting_flag(
 
 
 @mock.patch("bleak_retry_connector.establish_connection")
+async def test_concurrent_resets_run_one_at_a_time(mock_establish_connection):
+    """Two resets racing must not interleave their disconnect/connect steps.
+
+    Establishing a connection takes seconds, and a consumer driving resets
+    from discovery schedules one per advertisement seen while disconnected --
+    so several are queued in exactly that window. Unserialized, the losing
+    `establish_connection` leaked a connected client.
+    """
+    device_a = mock.create_autospec(bleak.BLEDevice)
+    device_b = mock.create_autospec(bleak.BLEDevice)
+    device_a.name = device_b.name = "GRILL"
+
+    in_flight = 0
+    max_in_flight = 0
+
+    async def slow_establish(**kwargs):
+        nonlocal in_flight, max_in_flight
+        in_flight += 1
+        max_in_flight = max(max_in_flight, in_flight)
+        # Yield so the racing reset gets its chance to interleave.
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        in_flight -= 1
+        return mock.create_autospec(bleak.BleakClient)
+
+    mock_establish_connection.side_effect = slow_establish
+
+    conn = ble.BleConnection(device_a)
+    await asyncio.gather(conn.reset_device(device_a), conn.reset_device(device_b))
+
+    assert max_in_flight == 1
+    assert conn.is_connected()
+
+
+@mock.patch("bleak_retry_connector.establish_connection")
+async def test_a_queued_duplicate_reset_keeps_the_fresh_connection(
+    mock_establish_connection,
+):
+    """Resets queued for the same grill coalesce instead of churning.
+
+    By the time the later ones run, the first has already connected; tearing
+    that connection down to rebuild it against the same address was pure
+    churn. The fresher `BLEDevice` is still adopted.
+    """
+    first_seen = mock.create_autospec(bleak.BLEDevice)
+    readvertised = mock.create_autospec(bleak.BLEDevice)
+    first_seen.name = readvertised.name = "GRILL"
+    first_seen.address = readvertised.address = "AA:BB:CC:DD:EE:FF"
+    mock_bleak_client = mock.create_autospec(bleak.BleakClient)
+    mock_establish_connection.return_value = mock_bleak_client
+
+    conn = ble.BleConnection(first_seen)
+    await asyncio.gather(conn.reset_device(first_seen), conn.reset_device(readvertised))
+
+    assert conn.is_connected()
+    mock_establish_connection.assert_awaited_once()
+    mock_bleak_client.disconnect.assert_not_awaited()
+    assert conn._ble_device is readvertised
+
+
+@mock.patch("bleak_retry_connector.establish_connection")
+async def test_reset_to_a_different_address_still_reconnects(
+    mock_establish_connection,
+):
+    """Coalescing is by address; a different device still gets a full reset."""
+    device_a = mock.create_autospec(bleak.BLEDevice)
+    device_b = mock.create_autospec(bleak.BLEDevice)
+    device_a.name = device_b.name = "GRILL"
+    device_a.address = "AA:BB:CC:DD:EE:FF"
+    device_b.address = "11:22:33:44:55:66"
+    client_a = mock.create_autospec(bleak.BleakClient)
+    client_b = mock.create_autospec(bleak.BleakClient)
+    mock_establish_connection.side_effect = [client_a, client_b]
+
+    conn = ble.BleConnection(device_a)
+    await conn.connect()
+    await conn.reset_device(device_b)
+
+    assert conn.is_connected()
+    client_a.disconnect.assert_awaited_once()
+    assert conn._ble_device is device_b
+    assert mock_establish_connection.await_count == 2
+
+
+@mock.patch("bleak_retry_connector.establish_connection")
 @mock.patch("bleak.BleakClient", spec=True)
 @mock.patch("bleak.BLEDevice", spec=True)
 async def test_subscribe_debug_logs(

--- a/tests/test_ble.py
+++ b/tests/test_ble.py
@@ -153,6 +153,44 @@ async def test_concurrent_resets_run_one_at_a_time(mock_establish_connection):
 
 
 @mock.patch("bleak_retry_connector.establish_connection")
+async def test_connect_racing_a_reset_runs_one_at_a_time(mock_establish_connection):
+    """`connect()` takes the lifecycle lock in its own right, not via reset.
+
+    The reachable interleaving: a consumer connects through `reset_device`
+    (discovery), the link drops before its follow-up `connect()` call runs,
+    and the drop queues another reset -- so `connect()` and `reset_device`
+    race on a disconnected transport. Without the lock on `connect()`, both
+    run `establish_connection` concurrently and the loser leaks.
+    """
+    device_a = mock.create_autospec(bleak.BLEDevice)
+    device_b = mock.create_autospec(bleak.BLEDevice)
+    device_a.name = device_b.name = "GRILL"
+    device_a.address = "AA:BB:CC:DD:EE:FF"
+    device_b.address = "AA:BB:CC:DD:EE:FF"
+
+    in_flight = 0
+    max_in_flight = 0
+
+    async def slow_establish(**kwargs):
+        nonlocal in_flight, max_in_flight
+        in_flight += 1
+        max_in_flight = max(max_in_flight, in_flight)
+        # Yield so the racing call gets its chance to interleave.
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        in_flight -= 1
+        return mock.create_autospec(bleak.BleakClient)
+
+    mock_establish_connection.side_effect = slow_establish
+
+    conn = ble.BleConnection(device_a)
+    await asyncio.gather(conn.connect(), conn.reset_device(device_b))
+
+    assert max_in_flight == 1
+    assert conn.is_connected()
+
+
+@mock.patch("bleak_retry_connector.establish_connection")
 async def test_a_queued_duplicate_reset_keeps_the_fresh_connection(
     mock_establish_connection,
 ):


### PR DESCRIPTION
Fixes #552.

A `_lifecycle_lock` now serializes `connect`, `disconnect` and `reset_device`; the public methods take the lock and delegate to `_connect_locked` / `_disconnect_locked`, and `reset_device` holds it once across its whole disconnect/connect pair. It is deliberately distinct from `self._lock` (GATT I/O): holding that one for the length of an `establish_connection` would stall the receive path.

Serialization alone would still run every queued reset in turn, each starting with a `disconnect()` that tears down the connection the previous one just built against the same grill. So a reset that finds the transport already connected to the same **address** now only adopts the fresher `BLEDevice` — advertisements carry updated metadata worth keeping — and returns without touching the connection. A reset for a *different* address still does the full teardown; the coalescing key is the address, nothing else.

Behaviour otherwise unchanged: `_reconnecting` still only suppresses the disconnect callback and is still cleared in a `finally`, the failed-connect path still propagates (the existing regression test for it passes untouched), and `_on_disconnected` stays lock-free — it is a sync bleak callback and takes no part in the lifecycle.

Three new tests: concurrent resets never overlap inside `establish_connection` (tracked via an in-flight counter in the mock), queued duplicate resets for the same address land one `establish_connection` and zero disconnects while still adopting the newer `BLEDevice`, and a reset to a different address still reconnects fully.

Rebased on current `main` (post #547/#549/#551 — this composes with #547's hygiene fixes rather than overlapping them; none of its lines are touched). 758 tests, `ruff check`, `ruff format --check` and `mypy .` clean. Not exercised on hardware: my grill runs the local WiFi transport these days, so the race analysis and the interleaving are established by the code reading in #552 and pinned down deterministically by the in-flight-counter test, not by a live BLE session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)