### PR TITLE
Log the already-connected connect() no-op at debug level

### DIFF
--- a/pytboss/ble.py
+++ b/pytboss/ble.py
@@ -85,7 +85,11 @@ class BleConnection(Transport):
 
     async def _connect_locked(self) -> None:
         if self._is_connected:
-            _LOGGER.warning("Already connected. Ignoring call to connect().")
+            # Debug, not a warning: this is a documented no-op, and consumers
+            # hit it on a normal path -- Home Assistant connects through
+            # `reset_device` during discovery and then calls `PitBoss.start`,
+            # whose `connect()` lands here at every Bluetooth setup.
+            _LOGGER.debug("Already connected. Ignoring call to connect().")
             return
         if self._ble_device is None:
             return

--- a/pytboss/ble.py
+++ b/pytboss/ble.py
@@ -64,12 +64,26 @@ class BleConnection(Transport):
         self._disconnect_callback = disconnect_callback
         self._is_connected = False
         self._reconnecting = False
+        # Serializes connect/disconnect/reset_device. Establishing a
+        # connection takes seconds, and a consumer driving reconnects from
+        # discovery -- Home Assistant schedules a reset per advertisement
+        # while `is_connected()` is False -- piles several up in exactly that
+        # window. Unserialized, their disconnect/connect steps interleave on
+        # the same object and the losing `establish_connection` leaks a
+        # connected client. Distinct from `self._lock`, which serializes GATT
+        # I/O; holding that one for the length of a connect would stall the
+        # receive path.
+        self._lifecycle_lock = asyncio.Lock()
 
     async def connect(self) -> None:
         """Starts the connection to the device.
 
         Does nothing if already connected or if no BLE device was set.
         """
+        async with self._lifecycle_lock:
+            await self._connect_locked()
+
+    async def _connect_locked(self) -> None:
         if self._is_connected:
             _LOGGER.warning("Already connected. Ignoring call to connect().")
             return
@@ -110,6 +124,10 @@ class BleConnection(Transport):
 
     async def disconnect(self) -> None:
         """Stops the connection to the device."""
+        async with self._lifecycle_lock:
+            await self._disconnect_locked()
+
+    async def _disconnect_locked(self) -> None:
         _LOGGER.debug("Disconnecting from device.")
         if self._ble_client:
             try:
@@ -126,17 +144,32 @@ class BleConnection(Transport):
     async def reset_device(self, ble_device: BLEDevice):
         """Resets the BLE device used for transport.
 
+        A reset that arrives while already connected to the same device --
+        by address -- only adopts the fresher `BLEDevice` and keeps the
+        connection. Discovery-driven consumers queue a reset per
+        advertisement seen while disconnected, and by the time the later
+        ones run, the first has already connected; tearing that connection
+        down to rebuild it against the same grill was pure churn.
+
         :param ble_device: BLE device to use for transport.
         """
-        self._reconnecting = True
-        _LOGGER.debug("Resetting device to: %s", ble_device)
-        try:
-            await self.disconnect()
-            self._is_connected = False
-            self._ble_device = ble_device
-            await self.connect()
-        finally:
-            self._reconnecting = False
+        async with self._lifecycle_lock:
+            if (
+                self._is_connected
+                and self._ble_device is not None
+                and self._ble_device.address == ble_device.address
+            ):
+                _LOGGER.debug("Already connected to %s; keeping it", ble_device)
+                self._ble_device = ble_device
+                return
+            self._reconnecting = True
+            _LOGGER.debug("Resetting device to: %s", ble_device)
+            try:
+                await self._disconnect_locked()
+                self._ble_device = ble_device
+                await self._connect_locked()
+            finally:
+                self._reconnecting = False
 
     def is_connected(self) -> bool:
         """Whether the device is currently connected."""

--- a/tests/test_ble.py
+++ b/tests/test_ble.py
@@ -118,6 +118,91 @@ async def test_reset_device_connect_failure_resets_reconnecting_flag(
 
 
 @mock.patch("bleak_retry_connector.establish_connection")
+async def test_concurrent_resets_run_one_at_a_time(mock_establish_connection):
+    """Two resets racing must not interleave their disconnect/connect steps.
+
+    Establishing a connection takes seconds, and a consumer driving resets
+    from discovery schedules one per advertisement seen while disconnected --
+    so several are queued in exactly that window. Unserialized, the losing
+    `establish_connection` leaked a connected client.
+    """
+    device_a = mock.create_autospec(bleak.BLEDevice)
+    device_b = mock.create_autospec(bleak.BLEDevice)
+    device_a.name = device_b.name = "GRILL"
+
+    in_flight = 0
+    max_in_flight = 0
+
+    async def slow_establish(**kwargs):
+        nonlocal in_flight, max_in_flight
+        in_flight += 1
+        max_in_flight = max(max_in_flight, in_flight)
+        # Yield so the racing reset gets its chance to interleave.
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        in_flight -= 1
+        return mock.create_autospec(bleak.BleakClient)
+
+    mock_establish_connection.side_effect = slow_establish
+
+    conn = ble.BleConnection(device_a)
+    await asyncio.gather(conn.reset_device(device_a), conn.reset_device(device_b))
+
+    assert max_in_flight == 1
+    assert conn.is_connected()
+
+
+@mock.patch("bleak_retry_connector.establish_connection")
+async def test_a_queued_duplicate_reset_keeps_the_fresh_connection(
+    mock_establish_connection,
+):
+    """Resets queued for the same grill coalesce instead of churning.
+
+    By the time the later ones run, the first has already connected; tearing
+    that connection down to rebuild it against the same address was pure
+    churn. The fresher `BLEDevice` is still adopted.
+    """
+    first_seen = mock.create_autospec(bleak.BLEDevice)
+    readvertised = mock.create_autospec(bleak.BLEDevice)
+    first_seen.name = readvertised.name = "GRILL"
+    first_seen.address = readvertised.address = "AA:BB:CC:DD:EE:FF"
+    mock_bleak_client = mock.create_autospec(bleak.BleakClient)
+    mock_establish_connection.return_value = mock_bleak_client
+
+    conn = ble.BleConnection(first_seen)
+    await asyncio.gather(conn.reset_device(first_seen), conn.reset_device(readvertised))
+
+    assert conn.is_connected()
+    mock_establish_connection.assert_awaited_once()
+    mock_bleak_client.disconnect.assert_not_awaited()
+    assert conn._ble_device is readvertised
+
+
+@mock.patch("bleak_retry_connector.establish_connection")
+async def test_reset_to_a_different_address_still_reconnects(
+    mock_establish_connection,
+):
+    """Coalescing is by address; a different device still gets a full reset."""
+    device_a = mock.create_autospec(bleak.BLEDevice)
+    device_b = mock.create_autospec(bleak.BLEDevice)
+    device_a.name = device_b.name = "GRILL"
+    device_a.address = "AA:BB:CC:DD:EE:FF"
+    device_b.address = "11:22:33:44:55:66"
+    client_a = mock.create_autospec(bleak.BleakClient)
+    client_b = mock.create_autospec(bleak.BleakClient)
+    mock_establish_connection.side_effect = [client_a, client_b]
+
+    conn = ble.BleConnection(device_a)
+    await conn.connect()
+    await conn.reset_device(device_b)
+
+    assert conn.is_connected()
+    client_a.disconnect.assert_awaited_once()
+    assert conn._ble_device is device_b
+    assert mock_establish_connection.await_count == 2
+
+
+@mock.patch("bleak_retry_connector.establish_connection")
 @mock.patch("bleak.BleakClient", spec=True)
 @mock.patch("bleak.BLEDevice", spec=True)
 async def test_subscribe_debug_logs(

--- a/tests/test_ble.py
+++ b/tests/test_ble.py
@@ -398,7 +398,7 @@ async def test_connect_when_already_connected(
     await conn.connect()
     assert conn.is_connected()
 
-    # Connecting again should be a no-op (with a warning logged).
+    # Connecting again should be a no-op (logged at debug level).
     await conn.connect()
     mock_establish_connection.assert_awaited_once()
 

--- a/tests/test_ble.py
+++ b/tests/test_ble.py
@@ -153,6 +153,44 @@ async def test_concurrent_resets_run_one_at_a_time(mock_establish_connection):
 
 
 @mock.patch("bleak_retry_connector.establish_connection")
+async def test_connect_racing_a_reset_runs_one_at_a_time(mock_establish_connection):
+    """`connect()` takes the lifecycle lock in its own right, not via reset.
+
+    The reachable interleaving: a consumer connects through `reset_device`
+    (discovery), the link drops before its follow-up `connect()` call runs,
+    and the drop queues another reset -- so `connect()` and `reset_device`
+    race on a disconnected transport. Without the lock on `connect()`, both
+    run `establish_connection` concurrently and the loser leaks.
+    """
+    device_a = mock.create_autospec(bleak.BLEDevice)
+    device_b = mock.create_autospec(bleak.BLEDevice)
+    device_a.name = device_b.name = "GRILL"
+    device_a.address = "AA:BB:CC:DD:EE:FF"
+    device_b.address = "AA:BB:CC:DD:EE:FF"
+
+    in_flight = 0
+    max_in_flight = 0
+
+    async def slow_establish(**kwargs):
+        nonlocal in_flight, max_in_flight
+        in_flight += 1
+        max_in_flight = max(max_in_flight, in_flight)
+        # Yield so the racing call gets its chance to interleave.
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        in_flight -= 1
+        return mock.create_autospec(bleak.BleakClient)
+
+    mock_establish_connection.side_effect = slow_establish
+
+    conn = ble.BleConnection(device_a)
+    await asyncio.gather(conn.connect(), conn.reset_device(device_b))
+
+    assert max_in_flight == 1
+    assert conn.is_connected()
+
+
+@mock.patch("bleak_retry_connector.establish_connection")
 async def test_a_queued_duplicate_reset_keeps_the_fresh_connection(
     mock_establish_connection,
 ):


### PR DESCRIPTION
One line (plus its rationale as a comment): the "Already connected. Ignoring call to connect()." log drops from warning to debug.

It fires on a healthy, documented path. ha-pitboss establishes the Bluetooth connection through `reset_device` during discovery and then calls `PitBoss.start()`, whose `connect()` lands on this guard — so every successful Bluetooth setup emits a warning about behaviour that is working as designed. A warning that always fires teaches people to ignore warnings; the guard itself is correct and stays.

Stacked on #553 (`serialize-ble-lifecycle`), where the guard now lives in `_connect_locked` — the diff includes that PR until it lands and reduces to this one line after. Happy to rebase either way once #553 settles.

759 tests, `ruff check`, `ruff format --check`, `mypy .` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)