### PR TITLE
Base64-encode the data sent to FS.Put

### DIFF
--- a/pytboss/fs.py
+++ b/pytboss/fs.py
@@ -1,6 +1,6 @@
 """Client library for Mongoose OS filesystem RPCs."""
 
-from base64 import b64decode
+from base64 import b64decode, b64encode
 
 from .transport import Transport
 
@@ -45,18 +45,33 @@ class FileSystem:
                 return content.decode("utf-8")
 
     async def set_file_content(
-        self, filename: str, data: str, append: bool
+        self, filename: str, data: str | bytes, append: bool
     ) -> dict | None:
         """Writes content to a file on the device.
 
+        `data` is base64-encoded before it is sent, which is what the RPC
+        expects: the device describes the parameter as `%V` -- Mongoose's
+        format specifier for base64-encoded binary -- rather than the `%Q` it
+        uses for the plain string alongside it::
+
+            FS.Put  {filename: %Q, offset: %ld, data: %V, append: %B}
+
+        which is the same encoding `get_file_content()` decodes on the way
+        back.
+
         :param filename: Path of the file to write.
-        :param data: Content to write.
+        :param data: Content to write. Text is encoded as UTF-8.
         :param append: If True, appends to the existing file instead of
             overwriting it.
         """
+        raw = data.encode("utf-8") if isinstance(data, str) else data
         return await self._conn.send_command(
             "FS.Put",
-            {"filename": filename, "data": data, "append": append},
+            {
+                "filename": filename,
+                "data": b64encode(raw).decode("ascii"),
+                "append": append,
+            },
         )
 
     async def rename_file(self, src: str, dst: str) -> dict | None:

--- a/tests/test_fs.py
+++ b/tests/test_fs.py
@@ -1,4 +1,4 @@
-from base64 import b64encode
+from base64 import b64decode, b64encode
 from unittest import mock
 from unittest.mock import AsyncMock
 
@@ -64,11 +64,38 @@ async def test_get_file_content_multibyte_split_across_chunks(
 
 
 async def test_set_file_content(fs: FileSystem, conn: AsyncMock):
+    """The RPC takes base64: the device declares `data` as `%V`."""
     conn.send_command.return_value = {}
     assert await fs.set_file_content("test.txt", "data", True) == {}
     conn.send_command.assert_awaited_once_with(
-        "FS.Put", {"filename": "test.txt", "data": "data", "append": True}
+        "FS.Put",
+        {
+            "filename": "test.txt",
+            "data": b64encode(b"data").decode(),
+            "append": True,
+        },
     )
+
+
+async def test_set_file_content_round_trips_through_get(
+    fs: FileSystem, conn: AsyncMock
+):
+    """What Put sends must be what Get decodes, or writes land corrupted."""
+    content = "héllo wörld"  # multi-byte, so a raw write would not survive
+    conn.send_command.return_value = {}
+    await fs.set_file_content("test.txt", content, False)
+    sent = conn.send_command.await_args.args[1]["data"]
+
+    conn.send_command.reset_mock()
+    conn.send_command.return_value = {"data": sent, "left": 0}
+    assert await fs.get_file_content("test.txt") == content
+
+
+async def test_set_file_content_accepts_bytes(fs: FileSystem, conn: AsyncMock):
+    conn.send_command.return_value = {}
+    await fs.set_file_content("test.bin", b"\x00\xff", False)
+    sent = conn.send_command.await_args.args[1]["data"]
+    assert b64decode(sent) == b"\x00\xff"
 
 
 async def test_rename_file(fs: FileSystem, conn: AsyncMock):


### PR DESCRIPTION
Fixes #555.

## The evidence

`RPC.Describe` against a PB1600PS1 on 0.5.7:

```
FS.Put: {"name": "FS.Put", "args_fmt": "{filename: %Q, offset: %ld, data: %V, append: %B}"}
```

`%V` is base64-encoded binary; `%Q`, in the same signature, is the plain string. So `data` is base64 and `filename` is not, which is also what the module's own read path assumed — `get_file_content()` has always `b64decode`d what `FS.Get` returns.

The failure is silent rather than loud: the firmware decodes whatever arrives, so writing `"hello"` stored `\x85\xe9e` instead of failing. A file written and then read back did not match.

## The change

Encode in `set_file_content()`, and accept `bytes` as well as `str` — the encoding now happens inside the wrapper, so a caller with binary content previously had no way to express it. Text is UTF-8 encoded first, matching what the read path decodes.

## Testing

Three tests: the request shape, a **round trip** (`set_file_content` → the bytes it sends → `get_file_content`) over multi-byte text that a raw write would corrupt, and a bytes payload. The round trip is the one with teeth — it fails on the old code, since that is precisely the property that was broken.

761 pass, `ruff check`, `ruff format --check`, `mypy .` clean.

## Not verified on hardware

I have a grill that answers `FS.Put`, but I have not written to its filesystem to confirm — that is its running configuration and mJS app, and a botched write is not worth the confirmation. The `%V` declaration comes from the device rather than from the docs, which seems like the stronger evidence anyway. Happy to do a scratch-file round trip against it if you would rather have that too.

No downstream impact: neither ha-pitboss nor any integration I know of calls `set_file_content`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)