### PR TITLE
Pin the lifecycle lock on disconnect() with an unload-vs-reset race

### DIFF
--- a/tests/test_ble.py
+++ b/tests/test_ble.py
@@ -191,6 +191,55 @@ async def test_connect_racing_a_reset_runs_one_at_a_time(mock_establish_connecti
 
 
 @mock.patch("bleak_retry_connector.establish_connection")
+async def test_disconnect_racing_a_reset_leaves_nothing_behind(
+    mock_establish_connection,
+):
+    """`disconnect()` takes the lifecycle lock in its own right too.
+
+    The reachable interleaving, from review of the lock: discovery connects
+    through `reset_device`; the link drops, so the flag is cleared and the
+    drop queues another reset -- which does the full teardown/reconnect
+    rather than coalescing; the entry then unloads, calling `disconnect()`
+    while that reset is mid-flight. Unserialized, `disconnect()` slots
+    between the reset's teardown and its reconnect: the client the reset
+    establishes afterwards survives the unload -- a live connection nobody
+    disconnected, on a transport reporting connected after an explicit
+    `disconnect()`.
+    """
+    first_seen = mock.create_autospec(bleak.BLEDevice)
+    readvertised = mock.create_autospec(bleak.BLEDevice)
+    first_seen.name = readvertised.name = "GRILL"
+    first_seen.address = readvertised.address = "AA:BB:CC:DD:EE:FF"
+    client_1 = mock.create_autospec(bleak.BleakClient)
+    client_2 = mock.create_autospec(bleak.BleakClient)
+    clients = iter([client_1, client_2])
+
+    async def slow_establish(**kwargs):
+        # Yield so the racing disconnect gets its chance to interleave.
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        return next(clients)
+
+    mock_establish_connection.side_effect = slow_establish
+
+    conn = ble.BleConnection(first_seen)
+    await conn.reset_device(first_seen)
+    assert conn.is_connected()
+
+    # The link drops, which also queues the reset raced below.
+    conn._on_disconnected(client_1)
+
+    await asyncio.gather(conn.reset_device(readvertised), conn.disconnect())
+
+    assert not conn.is_connected()
+    assert conn._ble_client is None
+    # The client the reset established was handed to `disconnect()` rather
+    # than surviving the unload.
+    client_2.disconnect.assert_awaited()
+    assert mock_establish_connection.await_count == 2
+
+
+@mock.patch("bleak_retry_connector.establish_connection")
 async def test_a_queued_duplicate_reset_keeps_the_fresh_connection(
     mock_establish_connection,
 ):


### PR DESCRIPTION
The follow-up from your review of #553: `disconnect()`'s lock acquisition was the last one unpinned, and you supplied the reachable interleaving I had failed to construct — discovery connects through `reset_device`, the link drops (clearing the flag and queueing a reset that now tears down and reconnects rather than coalescing), and the entry unload's `disconnect()` races that reset mid-flight.

Test-only; the scenario is the test, exactly as you laid it out, and as predicted the in-flight counter was not needed. The assertions are the observable outcomes rather than lock mechanics: after the gather, the transport reports disconnected, holds no client, and the client the reset established was handed to `disconnect()` instead of surviving the unload — your `never_disconnected=1` case. `establish_connection` count pins that the reset still did its full reconnect, so the test cannot silently pass by the reset never re-establishing.

Verified by mutation, same method as the `connect()` one: with the lock removed from `disconnect()` alone, this test fails on `is_connected()` reading True after `disconnect()` returned; with it, 760 tests pass. `ruff check`, `ruff format --check` and `mypy .` clean.

With this, all three public lifecycle entry points are individually pinned — `connect()` and `reset_device` from #553, `disconnect()` here — so none of the acquisitions can quietly become "redundant" in a refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)