### PR TITLE
Gate the local endpoint on firmware family, not just http.enable

### DIFF
--- a/pytboss/http.py
+++ b/pytboss/http.py
@@ -5,17 +5,40 @@ Dansons websocket relays, so the command mappings and status decoders in this
 library work against it unchanged. Talking to the grill directly removes the
 vendor's cloud from the path.
 
-**Not every grill answers.** The endpoint is gated by the firmware's
-`http.enable` setting, and that is per-unit configuration rather than
-something a model or firmware version predicts -- two grills on the same
-board and the same firmware have been observed with opposite values. Nothing
-here turns it on: `connect()` fails against a grill where it is off, and the
-caller is expected to have established that the endpoint exists first, over a
-transport that already works. `Config.Get` over Bluetooth reports it::
+**Not every grill answers**, and whether one does is decided twice over.
 
-    http = await boss.config.get_config("http")
-    if http["enable"]:
+First by firmware family. Dansons ships a second line that is not Mongoose at
+all -- C on ESP-IDF, versioned `16.x` rather than `0.x`, on the PBC2, PBD,
+PBE, PBL2 and PBT boards. Those images link no HTTP server and run their
+websocket as a client only, so they serve nothing on the local network: they
+are reachable over Bluetooth and the vendor's relay, and by nothing else. No
+setting changes that.
+
+Then, within the Mongoose family, by the firmware's `http.enable` setting.
+That part is per-unit configuration rather than something a model or firmware
+version predicts -- two grills on the same board and the same firmware have
+been observed with opposite values.
+
+Nothing here turns it on: `connect()` fails against a grill that does not
+serve the endpoint, whichever of the two reasons applies, and the caller is
+expected to have established that it exists first, over a transport that
+already works. `Config.Get` over Bluetooth reports it::
+
+    try:
+        http = await boss.config.get_config("http")
+    except RPCError:
+        http = {}  # no such section: not a Mongoose grill
+    if http.get("enable"):
         ...  # an HttpConnection will work against this grill
+
+Neither the `try` nor the `.get()` is defensive habit; each covers one of the
+two ways the question can fail to have an answer. The ESP-IDF firmware answers
+`Config.Get` too, but its schema holds only `wifi.sta`, `app` and `version`,
+so there is no `http` section to report on -- and a device that will not
+answer for a key it does not have can either return an error or return
+nothing, which reach a caller as `RPCError` and as `{}` respectively. Since
+this snippet is what decides whether a caller offers the local option at all,
+it needs an answer for every grill rather than a raise for some.
 
 See https://github.com/dknowles2/pytboss/issues/505.
 """

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -7,13 +7,16 @@ and the content type are exercised as the grill would present them.
 
 import asyncio
 from typing import Any
+from unittest import mock
 
 import pytest
 from aiohttp import ClientSession, web
 from aiohttp.test_utils import TestServer
 
+from pytboss.config import Config
 from pytboss.exceptions import NotConnectedError, RPCError, Unauthorized
 from pytboss.http import HttpConnection
+from pytboss.transport import Transport
 
 
 class FakeMongooseRpc:
@@ -259,3 +262,42 @@ async def test_a_silent_grill_is_reported_as_not_connected():
         assert conn.is_connected() is False
     finally:
         await server.close()
+
+
+async def _documented_discovery(config: Config) -> bool:
+    """The snippet from this module's docstring, verbatim.
+
+    Kept executable rather than only rendered: it is what decides whether a
+    caller offers the local option at all, so it has to work against grills
+    that have no `http` section as well as those that do.
+    """
+    try:
+        http = await config.get_config("http")
+    except RPCError:
+        http = {}
+    return bool(http.get("enable"))
+
+
+@pytest.mark.parametrize(
+    "reply,want",
+    [
+        ({"enable": True}, True),
+        ({"enable": False}, False),
+        ({}, False),  # answered with nothing: no such section
+    ],
+)
+async def test_documented_discovery_answers_for_every_grill(reply, want):
+    conn = mock.AsyncMock(spec=Transport)
+    conn.send_command.return_value = reply
+    assert await _documented_discovery(Config(conn)) is want
+
+
+async def test_documented_discovery_survives_a_missing_section():
+    """A grill that errors on an unknown key must not raise past the caller.
+
+    The ESP-IDF firmware answers `Config.Get`, but its schema has no `http`
+    section, so this is the other shape the same question can fail in.
+    """
+    conn = mock.AsyncMock(spec=Transport)
+    conn.send_command.side_effect = RPCError("No such key", -1)
+    assert await _documented_discovery(Config(conn)) is False


### PR DESCRIPTION
Targets `http-transport` rather than `main`, same as #546 — merge it into #543 with one click, take the diff, or ignore it.

Follows the [observation on #543](https://github.com/dknowles2/pytboss/pull/543#issuecomment-5165950688). Docstring and tests only; no behaviour change.

## What the second firmware line changes

Dansons ships a line that is not Mongoose: C on ESP-IDF v4.4.x, versioned `16.x`, on PBC2/PBD/PBE/PBL2/PBT. Reading those images: `esp_http_server` is not linked (the `ESP_ERR_HTTPD_*` strings are `esp_err_to_name` entries, and the component's own source paths are absent where the websocket client's are present), the websocket is client-only, and there is no mDNS, no `bind`/`listen` in application code and no `/rpc` path. Those grills are reachable over Bluetooth and the relay, and by nothing else.

So availability is decided twice: by firmware family first, then by `http.enable` within the Mongoose family. Your per-unit framing was right for the family it describes — @dknowles2's PBV4PS2 and my PB1600PS1 are the same board and firmware with opposite values — it just is not the whole rule.

## Why that lands in the snippet

```python
http = await boss.config.get_config("http")
if http["enable"]:
```

assumes Mongoose's schema. The ESP-IDF firmware answers `Config.Get`, but its schema holds only `wifi.sta`, `app` and `version`, so there is no `http` section to report on. A device that will not answer for a key it does not have can either return an error or return nothing, so the snippet now handles both — `except RPCError` and `.get()` — and says why in a sentence each, since neither is obvious as defensive habit.

## Tests

The snippet is now **executed** rather than only rendered: `_documented_discovery()` in `tests/test_http.py` is the docstring's code verbatim, exercised against a grill that enables the endpoint, one that disables it, one that answers nothing, and one that errors on the key. Same reasoning as last time — documentation that gates a feature is code, and mine was wrong precisely because I never ran it.

## One note on the branch

`http-transport` predates #551, which narrowed `Config.get_config` to return `{}` rather than `None` for a result-less reply. Wrote the snippet against post-merge behaviour, so the empty-reply case is `{}`; if you merge `main` in first, nothing here needs revisiting.

## What is not verified

I do not have an ESP-IDF grill. This is static analysis of stripped release binaries — absence of a linked component is a stronger claim than absence of a string, but it is still not a device saying no. Anyone with a PBD/PBT/PBE/PBC2/PBL2 settles it in one request: if `http://<ip>/rpc` answers, I am wrong.

760 pass, `ruff check`, `ruff format --check` and `mypy .` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)