### PR TITLE
Send PB.SetWiFiUpdateFrequency under the name the firmware registers

### DIFF
--- a/pytboss/api.py
+++ b/pytboss/api.py
@@ -512,10 +512,13 @@ class PitBoss:
     async def set_wifi_update_frequency(self, fast=5, slow=60) -> dict | None:
         """Sets how often (in seconds) the device sends WiFi status updates.
 
+        The method name is `WiFi`, not `Wifi`. RPC names are matched exactly,
+        and every firmware image registers it with the capital F.
+
         :meta private:
         """
         return await self._conn.send_command(
-            "PB.SetWifiUpdateFrequency",
+            "PB.SetWiFiUpdateFrequency",
             await self._authenticate({"slow": slow, "fast": fast}),
         )
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -64,6 +64,7 @@ class FakeTransport(Transport):
     def __init__(self, password: str = ""):
         self.virtual_data: dict = {}
         self.fast_updates_requested = False
+        self.wifi_update_frequency: dict | None = None
         super().__init__()
         self.last_mcu_command: str | None = None
         self.password = password
@@ -93,6 +94,10 @@ class FakeTransport(Transport):
             "PB.GetTime": self._get_time,
             "PB.GetVirtualData": self._get_virtual_data,
             "PB.WiFiAwakeWDT": self._wifi_awake_wdt,
+            # Registered under the name the firmware uses -- `WiFi`, not
+            # `Wifi` -- so a wrong spelling falls through to the unknown
+            # method path rather than being quietly accepted.
+            "PB.SetWiFiUpdateFrequency": self._set_wifi_update_frequency,
             "PB.SetVirtualData": self._set_virtual_data,
             "PB.SetDevicePassword": self._set_password,
             "PB.SendMCUCommand": self._send_mcu_command,
@@ -132,6 +137,11 @@ class FakeTransport(Transport):
         """Password-checked, and ends in `return null` like the firmware."""
         self._check_password(params)
         self.fast_updates_requested = True
+
+    def _set_wifi_update_frequency(self, params: dict) -> None:
+        """Password-checked, and ends in `return null` like the firmware."""
+        self._check_password(params)
+        self.wifi_update_frequency = {k: params[k] for k in ("slow", "fast")}
 
     def _get_virtual_data(self, params: dict) -> dict:
         self._check_password(params)
@@ -605,17 +615,29 @@ async def test_set_mcu_update_timer():
         )
 
 
-async def test_set_wifi_update_frequency():
+async def test_set_wifi_update_frequency(pitboss: api.PitBoss, conn: FakeTransport):
+    """Reaches the grill, rather than merely being sent.
+
+    Driven through the fake's own handler instead of a mocked `send_command`:
+    a mock asserts the name the code happens to send, which is how the
+    `Wifi`/`WiFi` mismatch survived. The fake registers only the name the
+    firmware does, so a wrong spelling fails here as it does on a grill.
+    """
+    assert await pitboss.set_wifi_update_frequency(fast=1, slow=10) is None
+    assert conn.wifi_update_frequency == {"slow": 10, "fast": 1}
+
+
+async def test_set_wifi_update_frequency_uses_the_name_the_firmware_registers():
+    """`Wifi` is answered with "name not found"; the F is capital."""
     conn = FakeTransport()
     pitboss = api.PitBoss(conn, "PBV4PS2")
     await pitboss.start()
     with mock.patch.object(
         conn, "send_command", AsyncMock(return_value=None)
     ) as send_command:
-        assert await pitboss.set_wifi_update_frequency(fast=1, slow=10) is None
-        send_command.assert_awaited_once_with(
-            "PB.SetWifiUpdateFrequency", {"slow": 10, "fast": 1}
-        )
+        await pitboss.set_wifi_update_frequency(fast=1, slow=10)
+        assert send_command.await_args is not None
+        assert send_command.await_args.args[0] == "PB.SetWiFiUpdateFrequency"
 
 
 async def test_set_virtual_data():


### PR DESCRIPTION
`set_wifi_update_frequency()` asks for `PB.SetWifiUpdateFrequency`. Every firmware registers `PB.SetWiFiUpdateFrequency` — capital F. RPC names are matched exactly, so the call has never reached a grill.

## Confirmed on hardware

`RPC.Describe` against a PB1600PS1 on 0.5.7, both spellings:

```
PB.SetWifiUpdateFrequency -> {"code":404,"message":"name not found"}
PB.SetWiFiUpdateFrequency -> {"name":"PB.SetWiFiUpdateFrequency","args_fmt":""}
```

And in the vendor images, the capital F is consistent across the whole mJS line — 0.2.3, 0.4.0, 0.5.0, 0.5.5, 0.5.6, 0.5.7, 0.6.0 all contain `RPC.addHandler("PB.SetWiFiUpdateFrequency", ...)` and nothing else. There is no firmware where the library's spelling works.

The method's own docstring, two hundred lines up in `request_fast_updates()`, already refers to `PB.SetWiFiUpdateFrequency` correctly. The code and its documentation have simply disagreed.

## How it survived

The test asserted the name the code sent:

```python
send_command.assert_awaited_once_with(
    "PB.SetWifiUpdateFrequency", {"slow": 10, "fast": 1}
)
```

which passes for any spelling, including one no grill answers. Same shape of blind spot as #551's `{}`-returning mocks and #546's never-executed docstring.

So the test now drives `FakeTransport`, which registers the handler under the firmware's name and falls through to its unknown-method path otherwise — the fake refuses a wrong spelling the way a grill does. Reverting the one-character fix turns three tests red; with a mocked `send_command` it would still be green.

The second test pins the wire name directly, since that is the actual claim being made.

## Scope

One string in `api.py`. No signature or behaviour change beyond the call now arriving. Nothing downstream calls this method — ha-pitboss does not, and `request_fast_updates()` (#530), which shares the underlying mechanism, uses `PB.WiFiAwakeWDT` and is unaffected.

Worth noting for completeness: the ESP-IDF firmware line does not have this RPC at all, under either spelling — it registers only `PB.SetMCU_UpdateFrequency`. That is a separate matter from the typo.

## Testing

764 pass, `ruff check`, `ruff format --check`, `mypy .` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)