### PR TITLE
Send login credentials in the request body

### DIFF
--- a/pytboss/auth.py
+++ b/pytboss/auth.py
@@ -1,6 +1,6 @@
 """Authentication routines."""
 
-from aiohttp import ClientSession
+from aiohttp import ClientSession, ContentTypeError
 
 from .exceptions import Unauthorized
 
@@ -17,12 +17,17 @@ async def async_login(
     :param password: The PitBoss account password.
     :raise pytboss.exceptions.Unauthorized: If the credentials are rejected.
     """
-    params = {"email": email, "password": password}
-    async with session.post(f"{API_URL}/login/app", params=params) as response:
-        response_json = await response.json()
-        if response_json["status"] == "error":
-            raise Unauthorized(response_json["error"]["message"])
-        token = (await response.json())["data"]["token"]
+    payload = {"email": email, "password": password}
+    async with session.post(f"{API_URL}/login/app", json=payload) as response:
+        try:
+            response_json = await response.json()
+        except ContentTypeError:
+            response.raise_for_status()
+            raise Unauthorized("Unexpected non-JSON response from login endpoint")
+        if response_json.get("status") != "success":
+            errors = response_json.get("errors") or {}
+            raise Unauthorized(errors.get("message", "Login failed"))
+        token = response_json["data"]["token"]
         return {
             "Accept": "application/json",
             "Content-Type": "application/json",

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,14 +1,15 @@
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from aiohttp import ClientResponseError, ContentTypeError
 
 from pytboss.auth import API_URL, async_login
 from pytboss.exceptions import Unauthorized
 
 
-def make_session(response_json: dict) -> MagicMock:
-    response = AsyncMock()
-    response.json.return_value = response_json
+def make_session(response_json: dict | None = None, json_side_effect=None) -> MagicMock:
+    response = MagicMock()
+    response.json = AsyncMock(return_value=response_json, side_effect=json_side_effect)
     cm = MagicMock()
     cm.__aenter__ = AsyncMock(return_value=response)
     cm.__aexit__ = AsyncMock(return_value=None)
@@ -18,7 +19,14 @@ def make_session(response_json: dict) -> MagicMock:
 
 
 async def test_async_login_success():
-    session = make_session({"status": "success", "data": {"token": "abc123"}})
+    session = make_session(
+        {
+            "status": "success",
+            "message": None,
+            "data": {"token": "abc123", "token_expiration": "2026-01-01T00:00:00Z"},
+            "errors": None,
+        }
+    )
     headers = await async_login(session, "me@example.com", "hunter2")
     assert headers == {
         "Accept": "application/json",
@@ -27,13 +35,44 @@ async def test_async_login_success():
     }
     session.post.assert_called_once_with(
         f"{API_URL}/login/app",
-        params={"email": "me@example.com", "password": "hunter2"},
+        json={"email": "me@example.com", "password": "hunter2"},
     )
 
 
-async def test_async_login_error():
+async def test_async_login_bad_credentials():
+    # Live API shape: HTTP 404 with an "errors" (plural) object.
     session = make_session(
-        {"status": "error", "error": {"message": "Invalid credentials"}}
+        {
+            "status": "error",
+            "error_code": "UNIDENTIFIED_CUSTOMER",
+            "message": "Error",
+            "errors": {
+                "message": (
+                    "Customer not found or password entered incorrectly. "
+                    "Please try again."
+                )
+            },
+        }
     )
-    with pytest.raises(Unauthorized, match="Invalid credentials"):
+    with pytest.raises(Unauthorized, match="Customer not found"):
         await async_login(session, "me@example.com", "wrong")
+
+
+async def test_async_login_non_json_response():
+    session = make_session(
+        json_side_effect=ContentTypeError(request_info=None, history=())
+    )
+    with pytest.raises(Unauthorized, match="non-JSON"):
+        await async_login(session, "me@example.com", "hunter2")
+
+
+async def test_async_login_non_json_http_error():
+    session = make_session(
+        json_side_effect=ContentTypeError(request_info=None, history=())
+    )
+    response = session.post.return_value.__aenter__.return_value
+    response.raise_for_status.side_effect = ClientResponseError(
+        request_info=None, history=(), status=502
+    )
+    with pytest.raises(ClientResponseError):
+        await async_login(session, "me@example.com", "hunter2")


### PR DESCRIPTION
Fixes #539.

`async_login()` sent the account email and password as URL query parameters, where they routinely end up in server/proxy access logs. As verified live in the issue discussion, the endpoint accepts the credentials as a JSON body with an identical success response (and the body takes precedence when both are present), so this moves them to `json=`.

While in there, this also fixes the error handling, which was dead code against the live API:

- Wrong credentials return HTTP 404 with `{"status": "error", ..., "errors": {"message": ...}}` — `errors` plural — so the old `response_json["error"]["message"]` raised `KeyError: 'error'` instead of `Unauthorized`. The function now parses `errors.message` and raises `Unauthorized` for any non-success status.
- Non-JSON responses (e.g. the bare-POST 302 to an HTML page) now surface via `raise_for_status()` or a clear `Unauthorized`, instead of an opaque `ContentTypeError`.
- Removed the redundant second `await response.json()`.

Tests now mock the live response shapes — the old error test mocked a singular-`error` shape, which is why the `KeyError` was never caught in CI.

Verified live against a real account: login via JSON body succeeds and returns the same token payload, and a wrong password now raises `Unauthorized("Customer not found or password entered incorrectly. Please try again.")`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
