### PR TITLE
Wrap RPC.List and PBL.GetLoaderVersion

### DIFF
--- a/pytboss/api.py
+++ b/pytboss/api.py
@@ -585,3 +585,35 @@ class PitBoss:
         :param timeout: Time (in seconds) after which to abandon the RPC.
         """
         return await self._conn.send_command("RPC.Ping", {}, timeout=timeout)
+
+    async def list_rpcs(self) -> list[str]:
+        """Returns the RPC methods this grill serves.
+
+        What a grill answers is not uniform, so this is how a caller finds
+        out rather than inferring it from a model or firmware version. A
+        PB1600PS1 on 0.5.7 lists 56 methods; the same list is where
+        `PBL.GetLoaderVersion` and the `Wifi.*` calls do or do not appear.
+
+        Not universal itself: the ESP-IDF firmware line -- versioned `16.x`,
+        on the PBC2, PBD, PBE, PBL2 and PBT boards -- names this one
+        `RPC.ListEx` and does not serve `RPC.List` at all, so a caller
+        covering both has to ask for each.
+        """
+        result = await self._conn.send_command("RPC.List", {})
+        return result if isinstance(result, list) else []
+
+    async def get_loader_version(self) -> str | None:
+        """Returns the version of the loader application, if it has one.
+
+        This is the `PitBoss Loader` that carries the grill's own
+        application, and is versioned independently of the firmware
+        `get_firmware_version()` reports: a grill on firmware 0.5.7 answers
+        `0.2.2` here.
+
+        `None` when the grill does not serve `PBL.GetLoaderVersion`, which
+        `list_rpcs()` reports without a round trip that errors.
+        """
+        result = await self._conn.send_command("PBL.GetLoaderVersion", {})
+        if isinstance(result, dict):
+            return result.get("loaderVersion")
+        return None

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -102,6 +102,8 @@ class FakeTransport(Transport):
             "PB.SetDevicePassword": self._set_password,
             "PB.SendMCUCommand": self._send_mcu_command,
             "PB.GetState": self._get_state,
+            "RPC.List": self._list_rpcs,
+            "PBL.GetLoaderVersion": self._get_loader_version,
         }
         resp = {"id": cmd["id"]}
         try:
@@ -169,6 +171,13 @@ class FakeTransport(Transport):
         if not command:
             raise ValueError("Empty command")
         self.last_mcu_command = bytes.fromhex(params["command"]).decode()
+
+    def _list_rpcs(self, params: dict) -> list:
+        """Answers with a bare list, as the firmware does."""
+        return ["RPC.List", "RPC.Ping", "PB.GetState", "PBL.GetLoaderVersion"]
+
+    def _get_loader_version(self, params: dict) -> dict:
+        return {"loaderVersion": "0.2.2"}
 
     def _get_state(self, params: dict) -> dict:
         self._check_password(params)
@@ -660,6 +669,37 @@ async def test_ping():
     ) as send_command:
         assert await pitboss.ping(timeout=5.0) == {}
         send_command.assert_awaited_once_with("RPC.Ping", {}, timeout=5.0)
+
+
+async def test_list_rpcs(pitboss: api.PitBoss):
+    """The reply is a bare list rather than an object."""
+    assert await pitboss.list_rpcs() == [
+        "RPC.List",
+        "RPC.Ping",
+        "PB.GetState",
+        "PBL.GetLoaderVersion",
+    ]
+
+
+async def test_list_rpcs_when_the_grill_answers_with_nothing():
+    """A grill that does not serve it must not hand back a non-list."""
+    conn = FakeTransport()
+    pitboss = api.PitBoss(conn, "PBV4PS2")
+    await pitboss.start()
+    with mock.patch.object(conn, "send_command", AsyncMock(return_value=None)):
+        assert await pitboss.list_rpcs() == []
+
+
+async def test_get_loader_version(pitboss: api.PitBoss):
+    assert await pitboss.get_loader_version() == "0.2.2"
+
+
+async def test_get_loader_version_when_the_grill_has_no_loader():
+    conn = FakeTransport()
+    pitboss = api.PitBoss(conn, "PBV4PS2")
+    await pitboss.start()
+    with mock.patch.object(conn, "send_command", AsyncMock(return_value=None)):
+        assert await pitboss.get_loader_version() is None
 
 
 async def test_get_state_updates_the_cached_state(conn: FakeTransport, password: str):


### PR DESCRIPTION
Two of the calls from #167, picked because they are reads that take no arguments, need no password, and cannot change anything. Rationale for the other thirteen is [in the issue](https://github.com/dknowles2/pytboss/issues/167).

## `list_rpcs()`

What a grill answers is not uniform, and the library has had no way to ask. Both #543 and #458 currently turn on that question — which grills serve a local endpoint, which serve which `OTA.*` method — and the answer has been reached by inference rather than by asking. This is the call that asks.

A PB1600PS1 on 0.5.7 lists 56 methods, and that list is where `PBL.GetLoaderVersion`, the `Wifi.*` calls, and the `OTA.*` set do or do not appear.

Not universal itself, and the docstring says so: the ESP-IDF line names it `RPC.ListEx` and does not serve `RPC.List`. I did not add a fallback between them — which to call is a question about the grill, and inventing a two-call retry here would bury that rather than answer it.

## `get_loader_version()`

The loader application carries the grill's own application and is versioned separately: the same grill that reports firmware `0.5.7` reports loader `0.2.2`. Present on both firmware lines.

## Verified

Both against a PB1600PS1 on 0.5.7, read-only:

```
GET /rpc/PBL.GetLoaderVersion  -> {"loaderVersion":"0.2.2"}
GET /rpc/RPC.List              -> ["PBL.GetWifiScanStatus","PBL.StartWifiScan", ... ]  (56)
RPC.Describe both              -> args_fmt ""   (no parameters)
```

The fake transport answers with those shapes — a bare **list** rather than an object for `RPC.List`, which is why `list_rpcs()` returns `list[str]` and guards the type rather than assuming a dict.

## Testing

770 pass, `ruff check`, `ruff format --check`, `mypy .` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)