### PR TITLE
Type send_command by what the RPCs actually return

### DIFF
--- a/pytboss/api.py
+++ b/pytboss/api.py
@@ -14,7 +14,7 @@ from .config import Config
 from .exceptions import UnsupportedOperation
 from .fs import FileSystem
 from .grills import Grill, StateDict, get_grill
-from .transport import Transport
+from .transport import RPCResult, Transport, as_dict
 
 _UPTIME_TTL = 60.0
 """Seconds before the cached uptime is re-read rather than extrapolated.
@@ -217,12 +217,12 @@ class PitBoss:
         psw = encode(self._password, key=timed_key(await self.get_uptime())).hex()
         return {**params, "psw": psw}
 
-    async def _send_hex_command(self, cmd: str) -> dict | None:
+    async def _send_hex_command(self, cmd: str) -> RPCResult:
         return await self._conn.send_command(
             "PB.SendMCUCommand", await self._authenticate({"command": cmd})
         )
 
-    async def _send_command(self, slug: str, *args) -> dict | None:
+    async def _send_command(self, slug: str, *args) -> RPCResult:
         cmd = self.spec.control_board.commands[slug]
         return await self._send_hex_command(cmd(*args))
 
@@ -254,7 +254,7 @@ class PitBoss:
         # they floor, so 190F is 87C to the grill rather than 88.
         return [floor((v - 32) / 1.8) for v in increments]
 
-    async def set_grill_temperature(self, temp: int) -> dict | None:
+    async def set_grill_temperature(self, temp: int) -> RPCResult:
         """Sets the target grill temperature.
 
         Snapped to the nearest value the control board accepts, expressed in
@@ -273,7 +273,7 @@ class PitBoss:
         # ignore the extra argument, as do fixed-hex commands.
         return await self._send_command("set-temperature", temp, fahrenheit)
 
-    async def set_probe_temperature(self, temp: int) -> dict | None:
+    async def set_probe_temperature(self, temp: int) -> RPCResult:
         """Sets the target temperature for probe 1.
 
         :param temp: Target probe temperature, in the grill's own unit.
@@ -282,7 +282,7 @@ class PitBoss:
             "set-probe-1-temperature", temp, self._is_fahrenheit()
         )
 
-    async def set_probe_2_temperature(self, temp: int) -> dict | None:
+    async def set_probe_2_temperature(self, temp: int) -> RPCResult:
         """Sets the target temperature for probe 2.
 
         :param temp: Target probe temperature, in the grill's own unit.
@@ -403,7 +403,7 @@ class PitBoss:
         """
         await self._conn.send_command("PB.WiFiAwakeWDT", await self._authenticate({}))
 
-    async def set_temperature_unit(self, fahrenheit: bool) -> dict | None:
+    async def set_temperature_unit(self, fahrenheit: bool) -> RPCResult:
         """Switches the unit the grill itself works in.
 
         This is the grill's own setting -- the one shown on its panel and
@@ -415,19 +415,19 @@ class PitBoss:
             "set-fahrenheit" if fahrenheit else "set-celsius"
         )
 
-    async def turn_light_on(self) -> dict | None:
+    async def turn_light_on(self) -> RPCResult:
         """Turns the light on if the grill has a light."""
         if not self.spec.has_lights:
             return {}
         return await self._send_command("turn-light-on")
 
-    async def turn_light_off(self) -> dict | None:
+    async def turn_light_off(self) -> RPCResult:
         """Turns the light off if the grill has a light."""
         if not self.spec.has_lights:
             return {}
         return await self._send_command("turn-light-off")
 
-    async def turn_grill_on(self) -> dict | None:
+    async def turn_grill_on(self) -> RPCResult:
         """Lights the grill.
 
         **This starts a fire in an appliance nobody may be standing next to.**
@@ -463,15 +463,15 @@ class PitBoss:
         """
         return await self._send_hex_command("FE0101FF")
 
-    async def turn_grill_off(self) -> dict | None:
+    async def turn_grill_off(self) -> RPCResult:
         """Turns the grill off."""
         return await self._send_command("turn-off")
 
-    async def turn_primer_motor_on(self) -> dict | None:
+    async def turn_primer_motor_on(self) -> RPCResult:
         """Turns the primer motor on."""
         return await self._send_command("turn-primer-motor-on")
 
-    async def turn_primer_motor_off(self) -> dict | None:
+    async def turn_primer_motor_off(self) -> RPCResult:
         """Turns the primer motor off."""
         return await self._send_command("turn-primer-motor-off")
 
@@ -483,9 +483,8 @@ class PitBoss:
         anything relying on it stays correct on a connection that only ever
         polls.
         """
-        resp = (
+        resp = as_dict(
             await self._conn.send_command("PB.GetState", await self._authenticate({}))
-            or {}
         )
         status = self.spec.control_board.parse_status(resp["sc_11"]) or {}
         status.update(self.spec.control_board.parse_temperatures(resp["sc_12"]) or {})
@@ -498,9 +497,9 @@ class PitBoss:
         """Returns the firmware version installed on the grill."""
         # `or {}`: the handler answers with an object in every vendor image,
         # so the empty dict stands in only for a broken exchange.
-        return await self._conn.send_command("PB.GetFirmwareVersion", {}) or {}
+        return as_dict(await self._conn.send_command("PB.GetFirmwareVersion", {}))
 
-    async def set_mcu_update_timer(self, frequency=2) -> dict | None:
+    async def set_mcu_update_timer(self, frequency=2) -> RPCResult:
         """Sets how often (in seconds) the MCU sends status updates.
 
         :meta private:
@@ -509,7 +508,7 @@ class PitBoss:
             "PB.SetMCU_UpdateFrequency", {"frequency": frequency}
         )
 
-    async def set_wifi_update_frequency(self, fast=5, slow=60) -> dict | None:
+    async def set_wifi_update_frequency(self, fast=5, slow=60) -> RPCResult:
         """Sets how often (in seconds) the device sends WiFi status updates.
 
         The method name is `WiFi`, not `Wifi`. RPC names are matched exactly,
@@ -522,7 +521,7 @@ class PitBoss:
             await self._authenticate({"slow": slow, "fast": fast}),
         )
 
-    async def set_virtual_data(self, data: dict) -> dict | None:
+    async def set_virtual_data(self, data: dict) -> RPCResult:
         """Sets arbitrary virtual data on the device.
 
         :meta private:
@@ -563,7 +562,7 @@ class PitBoss:
         """
         now = monotonic()
         if self._last_uptime is None or now - self._last_uptime_check > _UPTIME_TTL:
-            result = await self._conn.send_command("PB.GetTime", {}) or {}
+            result = as_dict(await self._conn.send_command("PB.GetTime", {}))
             self._last_uptime = result.get("time", 0.0)
             # Deliberately the pre-request timestamp, though the grill
             # computed its uptime later, when the request reached it: every
@@ -579,7 +578,7 @@ class PitBoss:
             return self._last_uptime
         return self._last_uptime + (now - self._last_uptime_check)
 
-    async def ping(self, timeout: float | None = None) -> dict | None:
+    async def ping(self, timeout: float | None = None) -> RPCResult:
         """Pings the device.
 
         :param timeout: Time (in seconds) after which to abandon the RPC.

--- a/pytboss/config.py
+++ b/pytboss/config.py
@@ -2,7 +2,7 @@
 
 from typing import Any
 
-from .transport import SendCommandFn, Transport
+from .transport import RPCResult, SendCommandFn, Transport, as_dict
 
 
 class Config:
@@ -20,7 +20,7 @@ class Config:
 
     async def get_info(self) -> dict:
         """Returns system information."""
-        return await self._conn.send_command("Sys.GetInfo", {}) or {}
+        return as_dict(await self._conn.send_command("Sys.GetInfo", {}))
 
     async def get_config(self, key: str | None = None) -> dict:
         """Retrieves device configuration subtree.
@@ -30,7 +30,7 @@ class Config:
         params = {}
         if key:
             params["key"] = key
-        return await self._conn.send_command("Config.Get", params) or {}
+        return as_dict(await self._conn.send_command("Config.Get", params))
 
     async def save_config(self, reboot: bool = True):
         """Writes an existing device configuration on flash.
@@ -42,11 +42,11 @@ class Config:
             fn = self._conn.send_command_without_answer
         await fn("Config.Save", {"reboot": reboot})
 
-    async def set(self, **kwargs) -> dict | None:
+    async def set(self, **kwargs) -> RPCResult:
         """Sets device configuration parameters."""
         return await self._conn.send_command("Config.Set", {"config": kwargs})
 
-    async def set_wifi_credentials(self, ssid: str, password: str) -> dict | None:
+    async def set_wifi_credentials(self, ssid: str, password: str) -> RPCResult:
         """Sets the WiFi credentials on the device.
 
         :param ssid: The SSID to connect to.
@@ -54,14 +54,14 @@ class Config:
         """
         return await self._conn.send_command("Config.Set", _wifi_params(ssid, password))
 
-    async def set_wifi_ssid(self, ssid) -> dict | None:
+    async def set_wifi_ssid(self, ssid) -> RPCResult:
         """Sets the WiFi SSID.
 
         :param ssid: The SSID to connect to.
         """
         return await self._conn.send_command("Config.Set", _wifi_params(ssid=ssid))
 
-    async def set_wifi_password(self, password) -> dict | None:
+    async def set_wifi_password(self, password) -> RPCResult:
         """Sets the WiFi password.
 
         :param password: The password for the WiFi network.

--- a/pytboss/fs.py
+++ b/pytboss/fs.py
@@ -2,7 +2,7 @@
 
 from base64 import b64decode, b64encode
 
-from .transport import Transport
+from .transport import RPCResult, Transport, as_dict
 
 
 class FileSystem:
@@ -18,7 +18,7 @@ class FileSystem:
         """
         self._conn = conn
 
-    async def get_file_list(self) -> dict | None:
+    async def get_file_list(self) -> RPCResult:
         """Lists files present on the device's filesystem."""
         return await self._conn.send_command("FS.List", {})
 
@@ -31,11 +31,10 @@ class FileSystem:
         offset = 0
         content = bytearray()
         while True:
-            resp = (
+            resp = as_dict(
                 await self._conn.send_command(
                     "FS.Get", {"filename": filename, "offset": offset, "len": length}
                 )
-                or {}
             )
             content += b64decode(resp["data"])
             offset += length
@@ -46,7 +45,7 @@ class FileSystem:
 
     async def set_file_content(
         self, filename: str, data: str | bytes, append: bool
-    ) -> dict | None:
+    ) -> RPCResult:
         """Writes content to a file on the device.
 
         `data` is base64-encoded before it is sent, which is what the RPC
@@ -74,7 +73,7 @@ class FileSystem:
             },
         )
 
-    async def rename_file(self, src: str, dst: str) -> dict | None:
+    async def rename_file(self, src: str, dst: str) -> RPCResult:
         """Renames a file on the device.
 
         :param src: Existing filename.
@@ -82,7 +81,7 @@ class FileSystem:
         """
         return await self._conn.send_command("FS.Rename", {"src": src, "dst": dst})
 
-    async def delete_file(self, filename: str) -> dict | None:
+    async def delete_file(self, filename: str) -> RPCResult:
         """Deletes a file from the device.
 
         :param filename: Path of the file to delete.

--- a/pytboss/transport.py
+++ b/pytboss/transport.py
@@ -31,11 +31,29 @@ class RawStateCallback(Protocol):
 RawVDataCallback = Callable[[str], Awaitable[None]]
 """Callback invoked by a `Transport` with a raw, unparsed VData payload."""
 
+RPCResult = dict[Any, Any] | list[Any] | None
+"""The `result` of an RPC reply: an object, an array, or nothing.
+
+Arrays are not hypothetical -- `RPC.List` answers with one. See
+`Transport.send_command` for why all three are needed.
+"""
+
 SendCommandFn = Callable[
     [str, dict[Any, Any], DefaultNamedArg(float | None, "timeout")],
-    Awaitable[dict[Any, Any] | None],
+    Awaitable[RPCResult],
 ]
 """Signature shared by `Transport.send_command` and `send_command_without_answer`."""
+
+
+def as_dict(result: RPCResult) -> dict[Any, Any]:
+    """Narrow an RPC reply to the object a caller expects, or an empty one.
+
+    Written as a type guard rather than `result or {}` because the latter
+    passes a list straight through while telling the checker it is a dict --
+    which is how `RPC.List`'s array went unnoticed when this type was first
+    narrowed.
+    """
+    return result if isinstance(result, dict) else {}
 
 
 UNAUTHORIZED_CODE = 401
@@ -98,13 +116,25 @@ class Transport(ABC):
 
     async def send_command(
         self, method: str, params: dict, *, timeout: float | None = DEFAULT_TIMEOUT
-    ) -> dict[Any, Any] | None:
+    ) -> RPCResult:
         """Sends a comand to the device.
 
-        Returns the reply's `result`, which is `None` for the handlers that
-        return nothing: every vendor firmware image resolves the setter RPCs
-        (`PB.SendMCUCommand`, `PB.SetVirtualData`, ...) with `null`, and only
-        the getters answer with an object.
+        Returns the reply's `result`, whatever JSON value that is:
+
+        * `None` for handlers that return nothing. Every vendor firmware
+          image resolves the setter RPCs (`PB.SendMCUCommand`,
+          `PB.SetVirtualData`, ...) with `null`.
+        * an object for the `PB.*` getters the grill's own app registers.
+        * an **array** for some of Mongoose's core RPCs -- `RPC.List` answers
+          with a bare list of method names, confirmed on a PB1600PS1, and
+          `FS.List` is documented to answer with one too.
+
+        That last case is why this is not simply `dict | None`. The `PB.*`
+        handlers are modelled in `fake_firmware/init.js` and were audited when
+        this type was first narrowed; Mongoose's own services are not modelled
+        there, so they were not. Narrow with `as_dict()` rather than `or {}`:
+        the first is a type guard the checker can see, the second silently
+        passes a list through.
 
         :param method: The method to call.
         :param params: Parameters to send with the command.

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -3,7 +3,7 @@ import asyncio
 import pytest
 
 from pytboss.exceptions import GrillUnavailable, NotConnectedError
-from pytboss.transport import Transport
+from pytboss.transport import Transport, as_dict
 
 
 class FakeTransport(Transport):
@@ -88,3 +88,38 @@ async def test_fail_pending_commands_with_nothing_in_flight():
     conn = FakeTransport()
     await conn._fail_pending_commands()
     assert conn._rpc_futures == {}
+
+
+async def test_a_reply_can_be_an_array():
+    """`RPC.List` answers with a bare list, not an object.
+
+    This is why `send_command` is not typed `dict | None`. The `PB.*`
+    handlers the grill's own app registers all answer with objects, and those
+    are the ones modelled in `fake_firmware/init.js` -- so when the type was
+    first narrowed, Mongoose's own services were not in the audit.
+    """
+    conn = FakeTransport()
+    task = asyncio.create_task(conn.send_command("RPC.List", {}, timeout=None))
+    await asyncio.sleep(0)
+    cmd_id = next(iter(conn._rpc_futures))
+
+    await conn._on_command_response({"id": cmd_id, "result": ["RPC.List", "RPC.Ping"]})
+
+    assert await task == ["RPC.List", "RPC.Ping"]
+
+
+@pytest.mark.parametrize(
+    "result,want",
+    [
+        ({"a": 1}, {"a": 1}),
+        (None, {}),
+        (["RPC.List"], {}),  # an array is not the object a getter asked for
+    ],
+)
+def test_as_dict_narrows_every_reply_shape(result, want):
+    """A type guard rather than `result or {}`.
+
+    `or {}` passes an array straight through while telling the checker it is
+    a dict, which is exactly how the array case went unnoticed.
+    """
+    assert as_dict(result) == want


### PR DESCRIPTION
Follows the observation on #561. `send_command` is annotated `dict[Any, Any] | None`, but **`RPC.List` answers with a bare array** — confirmed on a PB1600PS1 in that PR, and its `isinstance(result, list)` guard is what makes `list_rpcs()` work.

## Why #551's audit missed it

That PR narrowed the type on a firmware audit establishing "every setter returns `null`, every getter answers with an object". The audit was right about what it covered: the `PB.*` handlers the grill's own app registers, which are the ones `fake_firmware/init.js` models.

**Mongoose's own services are not modelled there.** `RPC.*`, `FS.*`, `OTA.*` and `Sys.*` are core RPCs the app never registers, so they were not in the audit — the same blind spot that left `Sys.Reboot` unverifiable in #458 and `FS.Put`'s `%V` encoding undiscovered until #556.

`FS.List` is the other one: `FileSystem.get_file_list()` is annotated `dict | None` and Mongoose documents that RPC as answering with an array. **Unverified** — I have no grill and the existing test only asserts the call, not the reply shape. Its annotation widens here rather than being changed to `list`, because guessing would be the same mistake in the other direction.

## What this does

* `RPCResult = dict[Any, Any] | list[Any] | None` — the honest union, named so it documents itself.
* `as_dict()` for the getters that want an object.
* Setter wrappers widen from `dict | None` to `RPCResult`. Strictly more honest, and a caller can still test for `None`.

**`as_dict()` is a type guard rather than `result or {}`, and that is the point of the change.** `or {}` passes an array straight through while telling the checker it is a dict — so `get_state()` would have handed a list to `resp["sc_11"]` with mypy seeing nothing wrong. Every `or {}` on an RPC reply is now a guard the checker can actually see.

The same weakness is what made #561's guard invisible: with `dict | None` declared, mypy accepted `isinstance(result, list)` only because it believed the branch unreachable. Deleting the guard entirely still passed.

## Runtime behaviour

Unchanged for every reply any grill has been observed to send. `as_dict()` and `or {}` agree on objects and on `None`. They differ only for an array reaching a getter, which used to be passed through as if it were a dict and is now an empty one — a case that has never happened, because the getters this touches are all `PB.*`.

## Testing

- An array round-trips through `send_command` — the shape `RPC.List` actually returns.
- `as_dict()` across all three reply shapes.

Verified the guard has teeth: reverting `as_dict()` to `result or {}` fails the array case and nothing else.

776 tests, `ruff check`, `ruff format --check` and `mypy .` clean.

Closes the loop on #542, which I filed and #551 fixed for the part of the surface that was audited.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
