### PR TITLE
Bound the BLE RPC response read

### DIFF
--- a/pytboss/ble.py
+++ b/pytboss/ble.py
@@ -40,6 +40,14 @@ CHAR_RPC_RX_CTL = _uuid("_mOS_RPC_rx_ctl_")
 DisconnectCallback = Callable[[BleakClient], None]
 """A callback function called when the BLE connection is disconnected."""
 
+MAX_RPC_RESPONSE_SIZE = 64 * 1024
+"""Largest reply this transport will try to assemble, in bytes.
+
+The length comes off the wire, so a corrupt or desynchronised control
+notification can ask for up to 4 GiB. Nothing the library sends provokes a
+reply anywhere near this bound: the largest are `FS.Get`, capped at 512 bytes
+of content, and `RPC.List`, about 1.4 kB on a grill serving 56 methods."""
+
 
 class BleConnection(Transport):
     """Bluetooth LE protocol transport for Mongoose OS devices."""
@@ -200,10 +208,33 @@ class BleConnection(Transport):
         if self._ble_client is None:
             return
         resp_len = _decode_len(data)
+        if resp_len > MAX_RPC_RESPONSE_SIZE:
+            # The length is whatever the notification said, so a corrupt one
+            # sends this loop after gigabytes that will never arrive. Reading
+            # them would take hours of real GATT round trips, all of it while
+            # holding the lock a send needs, so abandon the reply instead.
+            # The caller times out, which is what already happens whenever a
+            # reply goes missing.
+            _LOGGER.warning(
+                "Ignoring implausible RPC response length: %d bytes", resp_len
+            )
+            return
         resp = bytearray()
         async with self._lock:
             while len(resp) < resp_len:
-                resp += await self._ble_client.read_gatt_char(CHAR_RPC_DATA)
+                chunk = await self._ble_client.read_gatt_char(CHAR_RPC_DATA)
+                if not chunk:
+                    # Nothing left to read, but the announced length says
+                    # otherwise. Without this the loop spins on an empty read
+                    # forever -- and never awaits anything that suspends, so
+                    # no other task on the loop runs again.
+                    _LOGGER.warning(
+                        "Abandoning truncated RPC response: got %d of %d bytes",
+                        len(resp),
+                        resp_len,
+                    )
+                    return
+                resp += chunk
 
         payload = json.loads(resp.decode("utf-8"))
         await self._on_command_response(payload)

--- a/tests/test_ble.py
+++ b/tests/test_ble.py
@@ -650,3 +650,46 @@ async def test_debug_log_checksum_counts_the_whole_payload(
     await conn._on_debug_log_received(None, data)
 
     vdata_cb.assert_awaited_once_with(payload)
+
+
+@mock.patch("bleak_retry_connector.establish_connection")
+@mock.patch("bleak.BleakClient", spec=True)
+@mock.patch("bleak.BLEDevice", spec=True)
+async def test_on_rpc_data_received_gives_up_on_an_empty_read(
+    mock_device, mock_bleak_client, mock_establish_connection
+):
+    """A read that returns nothing cannot make progress.
+
+    Without this the loop spins on the empty read forever, and because
+    nothing in it suspends, no other task on the event loop runs again.
+    """
+    mock_establish_connection.return_value = mock_bleak_client
+    conn = ble.BleConnection(mock_device, loop=asyncio.get_running_loop())
+    await conn.connect()
+    mock_bleak_client.read_gatt_char.side_effect = [
+        bytearray(b"partial"),
+        bytearray(b""),
+        bytearray(b"never reached"),
+    ]
+
+    await asyncio.wait_for(
+        conn._on_rpc_data_received(mock.Mock(), bytearray([0, 0, 0, 64])), timeout=5
+    )
+
+    assert mock_bleak_client.read_gatt_char.await_count == 2
+
+
+@mock.patch("bleak_retry_connector.establish_connection")
+@mock.patch("bleak.BleakClient", spec=True)
+@mock.patch("bleak.BLEDevice", spec=True)
+async def test_on_rpc_data_received_rejects_an_implausible_length(
+    mock_device, mock_bleak_client, mock_establish_connection
+):
+    """The length is whatever the notification claimed, up to 4 GiB."""
+    mock_establish_connection.return_value = mock_bleak_client
+    conn = ble.BleConnection(mock_device, loop=asyncio.get_running_loop())
+    await conn.connect()
+
+    await conn._on_rpc_data_received(mock.Mock(), bytearray([0xFF, 0xFF, 0xFF, 0xFF]))
+
+    mock_bleak_client.read_gatt_char.assert_not_awaited()


### PR DESCRIPTION
`_on_rpc_data_received` takes the reply length from the control notification and reads until it has that many bytes, with no cap, no progress check, and the lock `_send_prepared_command` needs held throughout.

```python
resp_len = _decode_len(data)
resp = bytearray()
async with self._lock:
    while len(resp) < resp_len:
        resp += await self._ble_client.read_gatt_char(CHAR_RPC_DATA)
```

## Two ways out of that loop, and neither is "finish"

**A read that returns nothing.** The loop spins on it, and nothing in that path suspends — `read_gatt_char` returns without yielding once there is nothing to wait for. Driven with a client whose reads go empty:

```
read_gatt_char calls: 200001 in 0.03s
other tasks that got to run meanwhile: 0
```

Zero. On a Home Assistant instance that is not this integration hanging, it is the whole event loop.

**A length that is merely implausible.** `_decode_len` reads four bytes, so a corrupt or desynchronised notification can ask for up to 4 GiB. At ~20 bytes and ~30 ms per GATT read that is hours of real round trips for a reply that will never arrive — all of it holding the lock, so every command sent meanwhile waits out its own 30 s timeout behind it.

## The change

Reject a length past anything a reply can be, and stop when a read stops making progress. Both abandon the reply and log, which leaves the caller to time out exactly as it already does whenever a reply goes missing — no new failure mode, just a bounded one.

The cap is 64 kB. For scale, the largest replies the library can provoke are `FS.Get`, capped at 512 bytes of content, and `RPC.List`, about 1.4 kB on a grill serving 56 methods.

The lock is deliberately kept: it serialises access to the same characteristic `_send_prepared_command` writes to, so the fix is to bound how long it is held rather than to release it.

## Testing

Two tests. The empty-read one **fails on the unpatched code** — the old loop reads straight past the empty chunk and exhausts the fake's replies. The implausible-length one asserts no read is even attempted; on the unpatched code that path is the defect itself, so it is written to assert the absence rather than to wait for a loop that does not end.

778 pass, `ruff check`, `ruff format --check`, `mypy .` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)