### PR TITLE
Deliver virtual data over the WebSocket transport

### DIFF
--- a/pytboss/api.py
+++ b/pytboss/api.py
@@ -194,8 +194,12 @@ class PitBoss:
             for callback in callbacks:
                 await _invoke(callback, self._state)
 
-    async def _on_vdata_received(self, payload: str):
-        vdata = json.loads(payload)
+    async def _on_vdata_received(self, payload: str | dict):
+        # Both, because the transports differ in what they can hand over.
+        # `ble` reads virtual data off the debug log, where it is still the
+        # text the firmware printed; `wss` receives it as a member of an
+        # already-parsed status frame, so it arrives decoded.
+        vdata = json.loads(payload) if isinstance(payload, str) else payload
         _LOGGER.debug("VData received: %s", vdata)
         async with self._lock:
             callbacks = list(self._vdata_callbacks)

--- a/pytboss/transport.py
+++ b/pytboss/transport.py
@@ -28,7 +28,7 @@ class RawStateCallback(Protocol):
     ) -> None: ...
 
 
-RawVDataCallback = Callable[[str], Awaitable[None]]
+RawVDataCallback = Callable[[str | dict], Awaitable[None]]
 """Callback invoked by a `Transport` with a raw, unparsed VData payload."""
 
 RPCResult = dict[Any, Any] | list[Any] | None

--- a/pytboss/wss.py
+++ b/pytboss/wss.py
@@ -196,6 +196,16 @@ class WebSocketConnection(Transport):
             return
 
         if "status" in payload:
+            # Virtual data rides on the status push rather than arriving on a
+            # frame of its own. The firmware builds one object and attaches it
+            # only when there is something to send::
+            #
+            #     let data = {id: -1, src: deviceId, status: wsStatus};
+            #     if (sendVData === true && vData !== null) { data.data = vData; }
+            #
+            # so it has to be picked up here, before returning.
+            if (vdata := payload.get("data")) is not None and self._vdata_callback:
+                await self._vdata_callback(vdata)
             if not self._state_callback:
                 return
             await self._state_callback(*payload["status"])
@@ -203,13 +213,6 @@ class WebSocketConnection(Transport):
 
         if "id" in payload:
             await self._on_command_response(payload)
-            return
-
-        if payload.get("result", None):
-            # TODO: Verify this is actually a vdata response.
-            if not self._vdata_callback:
-                return
-            await self._vdata_callback(payload["result"])
             return
 
     def is_connected(self) -> bool:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -931,3 +931,21 @@ def test_the_turn_on_command_collides_with_nothing():
             except TypeError:
                 continue  # takes arguments; not a fixed command
             assert rendered != "FE0101FF", f"{grill.name} declares it as {slug}"
+
+
+async def test_on_vdata_received_accepts_a_decoded_object():
+    """`wss` hands over an object; `ble` hands over the text it was printed as.
+
+    Virtual data reaches `wss` as a member of an already-parsed status frame,
+    so it arrives decoded, while `ble` reads it off the debug log as text.
+    """
+    conn = FakeTransport()
+    pitboss = api.PitBoss(conn, "PBV4PS2")
+    await pitboss.start()
+    received = []
+    await pitboss.subscribe_vdata(received.append)
+
+    await pitboss._on_vdata_received({"p1T": 165})
+    await pitboss._on_vdata_received('{"p2T": 170}')
+
+    assert received == [{"p1T": 165}, {"p2T": 170}]

--- a/tests/test_wss.py
+++ b/tests/test_wss.py
@@ -327,18 +327,47 @@ async def test_status_no_state_callback(conn: wss.WebSocketConnection) -> None:
     await conn._handle_message({"status": ["state"]})
 
 
-async def test_vdata_result_payload(conn: wss.WebSocketConnection) -> None:
-    vdata_callback = AsyncMock()
-    conn.set_vdata_callback(vdata_callback)
-    await conn._handle_message({"result": "some-vdata"})
-    vdata_callback.assert_awaited_once_with("some-vdata")
-
-
-async def test_result_payload_no_vdata_callback(
+async def test_vdata_arrives_on_the_status_push(
     conn: wss.WebSocketConnection,
 ) -> None:
-    # No vdata callback registered; the payload should be silently ignored.
-    await conn._handle_message({"result": "some-vdata"})
+    """The shape the firmware actually sends.
+
+    `sendWSStatus` builds one object and attaches virtual data to it, so
+    `data` rides along with `status` rather than arriving on a frame of its
+    own -- and the state callback still has to run for the same payload.
+    """
+    vdata_callback = AsyncMock()
+    state_callback = AsyncMock()
+    conn.set_vdata_callback(vdata_callback)
+    conn.set_state_callback(state_callback)
+
+    await conn._handle_message(
+        {"id": -1, "src": "PBx", "status": ["FE0B00"], "data": {"p1T": 165}}
+    )
+
+    vdata_callback.assert_awaited_once_with({"p1T": 165})
+    state_callback.assert_awaited_once_with("FE0B00")
+
+
+async def test_status_push_without_vdata(conn: wss.WebSocketConnection) -> None:
+    """`data` is attached only when there is something to send."""
+    vdata_callback = AsyncMock()
+    conn.set_vdata_callback(vdata_callback)
+    conn.set_state_callback(AsyncMock())
+
+    await conn._handle_message({"id": -1, "status": ["FE0B00"]})
+
+    vdata_callback.assert_not_awaited()
+
+
+async def test_vdata_with_no_callback_registered(
+    conn: wss.WebSocketConnection,
+) -> None:
+    # No vdata callback; the state half of the payload must still be handled.
+    state_callback = AsyncMock()
+    conn.set_state_callback(state_callback)
+    await conn._handle_message({"status": ["FE0B00"], "data": {"p1T": 165}})
+    state_callback.assert_awaited_once_with("FE0B00")
 
 
 async def test_internal_session_closed():


### PR DESCRIPTION
`subscribe_vdata()` has never fired on a WebSocket connection.

## What the firmware sends

`sendWSStatus` builds one object and attaches virtual data to it, rather than sending a frame of its own:

```js
let data = { id: -1, src: deviceId, status: wsStatus };
if (sendVData === true && vData !== null) { data.data = vData; }
if (pState !== "") { data.pState = pState; }
WS.send(wsConn, JSON.stringify(data));
```

So virtual data arrives as `payload["data"]`, on the same frame as `status`. `_handle_message` matched `"status"` first and returned, dropping it every time.

(That is from the vendor image for 0.5.7 rather than from `fake_firmware/` — same code, and I wanted the shape from the thing that actually ships. It is identical in every mJS version from 0.2.3 to 0.6.0.)

## The branch that was supposed to catch it

```python
if payload.get("result", None):
    # TODO: Verify this is actually a vdata response.
```

Unreachable: every RPC reply carries an `id` and is claimed by the branch above it, and the firmware sends no other frame shaped like that. The TODO asked whether this really is a vdata response — it is not, so the branch is removed rather than repaired. Happy to keep it as a fallback if you would rather; I could not construct a payload that reaches it.

## The type mismatch behind it

`PitBoss._on_vdata_received` does `json.loads(payload)` unconditionally. That is right for `ble`, which reads virtual data off the debug log while it is still the text the firmware printed, and wrong for `wss`, where it is a member of an already-parsed frame. Had the old branch ever fired it would have raised `TypeError: the JSON object must be str, bytes or bytearray, not dict`. Both shapes are now accepted, and `RawVDataCallback` says so.

## Testing

The old tests exercised `{"result": "some-vdata"}` — a shape the firmware never sends — so they passed against a transport that delivered nothing. Replaced with the real frame: virtual data and state both dispatched from one push, a push without `data`, a push whose `data` has no subscriber, and an api-level test that both the decoded and the text form reach subscribers.

778 pass, `ruff check`, `ruff format --check`, `mypy .` clean.

## Not verified on hardware

I have a grill on the local network and over BLE, but not on the Dansons relay — the cloud path has never worked here, which is what #505 is about. The frame shape is read from the firmware that builds it, not observed on the wire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)