### PR TITLE
Release the BLE client when the link goes, or never opens

### DIFF
--- a/pytboss/ble.py
+++ b/pytboss/ble.py
@@ -110,14 +110,37 @@ class BleConnection(Transport):
         # Only once the notifications are registered: until they are there is
         # no receive path, so a command would be sent and never answered while
         # `is_connected()` claimed otherwise.
-        await self._ble_client.start_notify(CHAR_RPC_RX_CTL, self._on_rpc_data_received)
-        await self._ble_client.start_notify(CHAR_DEBUG_LOG, self._on_debug_log_received)
+        try:
+            await self._ble_client.start_notify(
+                CHAR_RPC_RX_CTL, self._on_rpc_data_received
+            )
+            await self._ble_client.start_notify(
+                CHAR_DEBUG_LOG, self._on_debug_log_received
+            )
+        except Exception:
+            # The connection itself succeeded, so leaving it behind holds a
+            # slot on an adapter that has few, and the next `connect()` would
+            # overwrite the only reference to it.
+            client, self._ble_client = self._ble_client, None
+            try:
+                await client.disconnect()
+            except Exception as ex:  # noqa: BLE001
+                _LOGGER.debug("Failed to release the client: %s", ex)
+            raise
         self._is_connected = True
 
     def _on_disconnected(self, client: BleakClient) -> None:
         """Called when our Bluetooth client is disconnected."""
         _LOGGER.debug("Bluetooth disconnected.")
         self._is_connected = False
+        # Released here as well as in `_disconnect_locked`, which drops it for
+        # the same reason: `_send_prepared_command` decides whether it can
+        # send from this reference alone, so a client left behind turns an
+        # unsolicited drop into `BleakError` where an explicit disconnect
+        # gives `NotConnectedError`. Guarded on identity because a reconnect
+        # may already have put a live client here.
+        if self._ble_client is client:
+            self._ble_client = None
         # Bleak calls this synchronously, so the cleanup has to be scheduled.
         # Guarded because this also fires while the loop is shutting down,
         # where scheduling raises inside bleak's own callback.

--- a/tests/test_ble.py
+++ b/tests/test_ble.py
@@ -4,6 +4,7 @@ from itertools import zip_longest
 from unittest import mock
 
 import bleak
+import pytest
 from bleak_retry_connector import BleakClientWithServiceCache
 from pytest import raises
 
@@ -693,3 +694,73 @@ async def test_on_rpc_data_received_rejects_an_implausible_length(
     await conn._on_rpc_data_received(mock.Mock(), bytearray([0xFF, 0xFF, 0xFF, 0xFF]))
 
     mock_bleak_client.read_gatt_char.assert_not_awaited()
+
+
+@mock.patch("bleak_retry_connector.establish_connection")
+@mock.patch("bleak.BleakClient", spec=True)
+@mock.patch("bleak.BLEDevice", spec=True)
+async def test_an_unsolicited_disconnect_releases_the_client(
+    mock_device, mock_bleak_client, mock_establish_connection
+):
+    """A dropped link has to look like a disconnect to the send path.
+
+    `_send_prepared_command` decides from `_ble_client` alone, so a client
+    left behind raises `BleakError` where an explicit `disconnect()` gives
+    `NotConnectedError`.
+    """
+    mock_establish_connection.return_value = mock_bleak_client
+    conn = ble.BleConnection(mock_device, loop=asyncio.get_running_loop())
+    await conn.connect()
+
+    # Bleak calls this itself when the grill goes away.
+    conn._on_disconnected(mock_bleak_client)
+    # Let the cleanup it schedules finish, so what follows is a fresh command
+    # rather than one caught by `_fail_pending_commands`.
+    await asyncio.sleep(0)
+    # A real client refuses once the link is gone.
+    mock_bleak_client.write_gatt_char.side_effect = bleak.exc.BleakError(
+        "Not connected"
+    )
+
+    assert conn.is_connected() is False
+    with pytest.raises(NotConnectedError):
+        await conn.send_command("PB.GetState", {}, timeout=1)
+
+
+@mock.patch("bleak_retry_connector.establish_connection")
+@mock.patch("bleak.BleakClient", spec=True)
+@mock.patch("bleak.BLEDevice", spec=True)
+async def test_a_disconnect_for_a_replaced_client_is_ignored(
+    mock_device, mock_bleak_client, mock_establish_connection
+):
+    """A late callback for the previous client must not drop the live one."""
+    mock_establish_connection.return_value = mock_bleak_client
+    conn = ble.BleConnection(mock_device, loop=asyncio.get_running_loop())
+    await conn.connect()
+
+    conn._on_disconnected(mock.Mock())  # some earlier client
+
+    assert conn._ble_client is mock_bleak_client
+
+
+@mock.patch("bleak_retry_connector.establish_connection")
+@mock.patch("bleak.BleakClient", spec=True)
+@mock.patch("bleak.BLEDevice", spec=True)
+async def test_a_failed_start_notify_releases_the_connection(
+    mock_device, mock_bleak_client, mock_establish_connection
+):
+    """The connection succeeded, so nothing else will release it.
+
+    Each retry would otherwise burn a slot on an adapter that has few, and
+    the next `connect()` overwrites the only reference to it.
+    """
+    mock_establish_connection.return_value = mock_bleak_client
+    mock_bleak_client.start_notify.side_effect = bleak.exc.BleakError("no notify")
+    conn = ble.BleConnection(mock_device, loop=asyncio.get_running_loop())
+
+    with pytest.raises(bleak.exc.BleakError):
+        await conn.connect()
+
+    mock_bleak_client.disconnect.assert_awaited_once()
+    assert conn._ble_client is None
+    assert conn.is_connected() is False


### PR DESCRIPTION
Two places keep a `BleakClient` that nothing else will clean up.

## An unsolicited disconnect

`_on_disconnected` marks the transport disconnected but keeps the reference, and `_send_prepared_command` decides whether it can send from that reference alone. So a grill switched off or carried out of range turns the next command into a raw `BleakError`, where an explicit `disconnect()` gives `NotConnectedError` — `_disconnect_locked` already clears it, with a comment saying why.

```
OLD: _ble_client still set? True
OLD raised: BleakError: Not connected
```

Worth noting how that probe has to be written, because it fooled me first time round: `_on_disconnected` schedules `_fail_pending_commands()`, and if the next command is issued before that task runs, its future is resolved by the cleanup and the call *does* raise `NotConnectedError` — for an unrelated reason. Letting the loop settle first is what shows the real behaviour, and the test does that.

The clear is guarded on identity: a reconnect may already have put a live client there, and a late callback for the previous one must not drop it.

## A connection that never finishes opening

`_connect_locked` left a **connected** client behind if `start_notify` raised. The connection itself had succeeded, so nothing disconnected it, and the next `connect()` overwrote the only reference to it. Each retry burned a slot on an adapter that has very few.

```
after failed connect, _ble_client is c1 -> True | c1.disconnect called -> False
after retry,          _ble_client is c2 -> True | c1 ever disconnected -> False
```

The existing test asserts `is_connected()` is False afterwards, which was already true; it never checked that the client was released.

## Testing

Three tests, two of them **verified to fail on the unpatched code** (restored `ble.py` from `main`, kept the tests). The third — a disconnect callback for a client that has since been replaced — guards the identity check rather than a defect.

783 pass, `ruff check`, `ruff format --check`, `mypy .` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)