### PR TITLE
Survive replies the grill really sends

### DIFF
--- a/pytboss/api.py
+++ b/pytboss/api.py
@@ -490,8 +490,20 @@ class PitBoss:
         resp = as_dict(
             await self._conn.send_command("PB.GetState", await self._authenticate({}))
         )
-        status = self.spec.control_board.parse_status(resp["sc_11"]) or {}
-        status.update(self.spec.control_board.parse_temperatures(resp["sc_12"]) or {})
+        # Either frame can be absent or empty, so neither is indexed. The
+        # firmware blanks both the moment it forwards a command to the MCU::
+        #
+        #     function sendMCUCommand(pCommand) {
+        #       lastStatus.sc_11 = "";
+        #       lastStatus.sc_12 = "";
+        #
+        # and refills them from the next reply, so a poll landing in that
+        # window is answered with empty strings rather than an error.
+        status = StateDict()
+        if sc_11 := resp.get("sc_11"):
+            status.update(self.spec.control_board.parse_status(sc_11) or {})
+        if sc_12 := resp.get("sc_12"):
+            status.update(self.spec.control_board.parse_temperatures(sc_12) or {})
         if status:
             async with self._lock:
                 self._state.update(status)
@@ -567,7 +579,17 @@ class PitBoss:
         now = monotonic()
         if self._last_uptime is None or now - self._last_uptime_check > _UPTIME_TTL:
             result = as_dict(await self._conn.send_command("PB.GetTime", {}))
-            self._last_uptime = result.get("time", 0.0)
+            uptime = result.get("time")
+            if not isinstance(uptime, (int, float)):
+                # Not cached, because caching it is worse than not having it:
+                # `timed_key` would be built from a wrong uptime for the whole
+                # TTL, so one unreadable reply would cost a minute of rejected
+                # commands on a password-protected grill.
+                _LOGGER.debug("No uptime in the reply: %s", result)
+                if self._last_uptime is None:
+                    return 0.0
+                return self._last_uptime + (now - self._last_uptime_check)
+            self._last_uptime = float(uptime)
             # Deliberately the pre-request timestamp, though the grill
             # computed its uptime later, when the request reached it: every
             # extrapolation therefore runs ahead of the grill by about one

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -949,3 +949,45 @@ async def test_on_vdata_received_accepts_a_decoded_object():
     await pitboss._on_vdata_received('{"p2T": 170}')
 
     assert received == [{"p1T": 165}, {"p2T": 170}]
+
+
+@pytest.mark.parametrize(
+    "reply",
+    [
+        {},
+        {"sc_11": "", "sc_12": ""},
+        {"sc_11": STATE_HEX},
+        {"sc_12": TEMPS_HEX},
+    ],
+    ids=["empty", "blanked", "status_only", "temperatures_only"],
+)
+async def test_get_state_survives_a_partial_reply(reply):
+    """The firmware blanks both frames while a command is in flight.
+
+    `sendMCUCommand` clears `lastStatus.sc_11` and `sc_12` before it writes to
+    the MCU and refills them from the next reply, so a poll landing in that
+    window is answered with empty strings rather than an error.
+    """
+    conn = FakeTransport()
+    pitboss = api.PitBoss(conn, "PBV4PS2")
+    await pitboss.start()
+    with mock.patch.object(conn, "send_command", AsyncMock(return_value=reply)):
+        state = await pitboss.get_state()
+    assert isinstance(state, dict)
+
+
+async def test_get_uptime_does_not_cache_a_reply_it_cannot_read():
+    """Caching it would keep `timed_key` wrong for the whole TTL."""
+    conn = FakeTransport()
+    pitboss = api.PitBoss(conn, "PBV4PS2")
+    await pitboss.start()
+
+    with mock.patch.object(conn, "send_command", AsyncMock(return_value={})):
+        assert await pitboss.get_uptime() == 0.0
+
+    # The next call must go back to the grill rather than extrapolate from a
+    # value it never got.
+    with mock.patch.object(
+        conn, "send_command", AsyncMock(return_value={"time": 500.0})
+    ):
+        assert await pitboss.get_uptime() == 500.0


### PR DESCRIPTION
Two places assume a reply carries a field it may not.

## `get_state()` indexed both frames

```python
status = self.spec.control_board.parse_status(resp["sc_11"]) or {}
status.update(self.spec.control_board.parse_temperatures(resp["sc_12"]) or {})
```

The firmware blanks both the moment it forwards a command to the MCU:

```js
function sendMCUCommand(pCommand) {
  lastStatus.sc_11 = "";
  lastStatus.sc_12 = "";
  uartSend(mcuCommand);
}
```

and refills them from the next reply, so a poll landing in that window is answered with empty strings — which the old code handled, since `parse_status("")` returns `None`. A reply *missing* either key did not:

```
get_state no sc_ keys  -> KeyError: 'sc_11'
get_state only sc_11   -> KeyError: 'sc_12'
get_state None reply   -> KeyError: 'sc_11'
```

Neither frame is indexed now, and either may be absent or empty.

## `get_uptime()` cached a reply it could not read

`result.get("time", 0.0)` turned an unreadable reply into the cache, and with it every `timed_key` for the full 60-second TTL. On a password-protected grill that is a minute of rejected commands from one bad reply, and the next call does not go back to the grill because the cache looks fresh:

```
get_uptime malformed -> 0.0; cached=0.0
next get_uptime      -> 0.00018   (should have re-read 500.0)
```

It now leaves the cache alone and answers from what it already had, so the next call retries.

## Testing

Five tests. **Four fail on the unpatched code** — the fifth is the blanked-frames case, which already worked and is pinned so it keeps working.

785 pass, `ruff check`, `ruff format --check`, `mypy .` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)