### PR TITLE
Read a file by what the device sends, not by what was asked for

### DIFF
--- a/pytboss/fs.py
+++ b/pytboss/fs.py
@@ -36,12 +36,23 @@ class FileSystem:
                     "FS.Get", {"filename": filename, "offset": offset, "len": length}
                 )
             )
-            content += b64decode(resp["data"])
-            offset += length
-            if resp["left"] == 0:
-                # Decoded once, whole: a multi-byte character split across
-                # the chunk boundary is not valid UTF-8 on its own.
-                return content.decode("utf-8")
+            chunk = b64decode(resp.get("data", ""))
+            if not chunk:
+                # Nothing came back, so nothing more will: reading on would
+                # ask for the same offset forever when `left` disagrees.
+                break
+            content += chunk
+            # Advanced by what arrived rather than by what was asked for. A
+            # device answering with less -- the reply is bounded by the RPC
+            # frame size, which is configurable and smaller than this on some
+            # units -- would otherwise leave a hole in the middle of the file
+            # and the read would report success.
+            offset += len(chunk)
+            if resp.get("left") == 0:
+                break
+        # Decoded once, whole: a multi-byte character split across a chunk
+        # boundary is not valid UTF-8 on its own.
+        return content.decode("utf-8")
 
     async def set_file_content(
         self, filename: str, data: str | bytes, append: bool

--- a/tests/test_fs.py
+++ b/tests/test_fs.py
@@ -110,3 +110,44 @@ async def test_delete_file(fs: FileSystem, conn: AsyncMock):
     conn.send_command.return_value = {}
     assert await fs.delete_file("test.txt") == {}
     conn.send_command.assert_awaited_once_with("FS.Remove", {"filename": "test.txt"})
+
+
+async def test_get_file_content_follows_what_the_device_actually_sent(
+    fs: FileSystem, conn: AsyncMock
+):
+    """The reply is bounded by the RPC frame size, not by what we asked for.
+
+    Advancing the offset by the requested length instead leaves a hole in the
+    middle of the file, and the read reports success.
+    """
+    raw = "".join(f"line{i:04d}\n" for i in range(140)).encode()
+
+    async def short_chunks(method, params, *, timeout=None):
+        offset = params["offset"]
+        chunk = raw[offset : offset + 200]
+        return {
+            "data": b64encode(chunk).decode(),
+            "left": max(0, len(raw) - offset - len(chunk)),
+        }
+
+    conn.send_command = short_chunks
+    assert await fs.get_file_content("test.txt") == raw.decode()
+
+
+async def test_get_file_content_stops_when_the_device_sends_nothing(
+    fs: FileSystem, conn: AsyncMock
+):
+    """`left` can disagree with what is actually there.
+
+    Without this the same offset is requested forever.
+    """
+    conn.send_command.return_value = {"data": "", "left": 999}
+    assert await fs.get_file_content("test.txt") == ""
+    assert conn.send_command.await_count == 1
+
+
+async def test_get_file_content_tolerates_a_reply_without_data(
+    fs: FileSystem, conn: AsyncMock
+):
+    conn.send_command.return_value = {}
+    assert await fs.get_file_content("test.txt") == ""


### PR DESCRIPTION
`get_file_content` advances the offset by the 512 bytes it asked for, however many actually came back, and indexes `resp["data"]` and `resp["left"]` without checking either is there.

```python
content += b64decode(resp["data"])
offset += length
if resp["left"] == 0:
```

## Three ways that goes wrong

**A device that answers with less than was asked for leaves a hole, and the read reports success.** The reply is bounded by the RPC frame size, which is configurable — `Config.Get {key: "rpc"}` reports `max_frame_size: 4096` on the grill I have, and a smaller one is a supported setting. Reading a 1260-byte file in 200-byte answers:

```
asked for 1260 bytes, got back 600
identical to the file: False
```

No exception. The caller gets a file with the middle missing and no way to know.

**A `left` that never reaches zero asks for the same offset forever.** I stopped the probe at 300 round trips; nothing in the loop would have ended it.

**A reply without `data` raised `KeyError: 'data'`** — the same shape #566 has just been through elsewhere in the library.

## The change

The offset follows what arrived, and the loop stops when nothing does. That last part ends the runaway case as well, since reading past the end of a file returns nothing whatever `left` claims.

## Testing

Three tests. Two **fail on the unpatched code**; the third — the device that stops sending — is the runaway, so on the old code it does not fail, it hangs. I checked that separately rather than leaving it in a suite run.

791 pass, `ruff check`, `ruff format --check`, `mypy .` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
