### PR TITLE
Make disconnect() final for the HTTP transport

### DIFF
--- a/pytboss/http.py
+++ b/pytboss/http.py
@@ -98,6 +98,10 @@ class HttpConnection(Transport):
         # ours to close, and it is rebuilt by `connect()` so this transport is
         # reusable after `disconnect()`.
         self._session_owned = session is None
+        # Two different questions. `_started` is whether this transport has
+        # been connected and not since disconnected; `_connected` is whether
+        # the grill answered the last time we spoke to it.
+        self._started = False
         self._connected = False
 
     async def connect(self) -> None:
@@ -115,17 +119,25 @@ class HttpConnection(Transport):
                 raise NotConnectedError("The session given to this transport is closed")
             self._session = ClientSession(loop=self._loop)
         # Set before the ping so `_send_prepared_command` will proceed; a
-        # failure below clears it again.
+        # failure below clears them again.
+        self._started = True
         self._connected = True
         try:
             await self.send_command("RPC.Ping", {})
         except Exception:
+            self._started = False
             self._connected = False
             await self._close_session()
             raise
 
     async def disconnect(self) -> None:
-        """Releases the session, if this transport owns one."""
+        """Stops using the grill, and releases the session if this owns one.
+
+        Final until `connect()` is called again. A caller's session stays
+        open, since it is theirs, so nothing else here would stop a command
+        from going out on it.
+        """
+        self._started = False
         self._connected = False
         await self._close_session()
 
@@ -143,11 +155,18 @@ class HttpConnection(Transport):
         `connect()` until a request fails to reach the grill.
         """
         return (
-            self._connected and self._session is not None and not self._session.closed
+            self._started
+            and self._connected
+            and self._session is not None
+            and not self._session.closed
         )
 
     async def _send_prepared_command(self, cmd: dict) -> None:
-        if self._session is None or self._session.closed:
+        # `_started` rather than `_connected`: a request that failed leaves
+        # the latter false, and this transport is meant to recover from that
+        # by itself on the next call. An explicit `disconnect()` is the one
+        # that has to stick.
+        if not self._started or self._session is None or self._session.closed:
             raise NotConnectedError("Not connected")
         _LOGGER.debug("--> %s", cmd)
         try:

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -301,3 +301,55 @@ async def test_documented_discovery_survives_a_missing_section():
     conn = mock.AsyncMock(spec=Transport)
     conn.send_command.side_effect = RPCError("No such key", -1)
     assert await _documented_discovery(Config(conn)) is False
+
+
+async def test_a_command_after_disconnect_is_refused(host, rpc):
+    """A caller's session stays open, so nothing else stops the request.
+
+    Home Assistant always supplies one, so this is the ordinary case: a
+    refresh still in flight when the entry unloads would otherwise keep
+    polling the grill successfully.
+    """
+    async with ClientSession() as session:
+        conn = HttpConnection(host, session=session)
+        await conn.connect()
+        sent = len(rpc.requests)
+        await conn.disconnect()
+
+        with pytest.raises(NotConnectedError):
+            await conn.send_command("PB.GetState", {})
+
+        assert len(rpc.requests) == sent
+        assert conn.is_connected() is False
+
+
+async def test_a_command_before_connect_is_refused(host, rpc):
+    """`connect()` is what checks the grill is there at all."""
+    async with ClientSession() as session:
+        conn = HttpConnection(host, session=session)
+        with pytest.raises(NotConnectedError):
+            await conn.send_command("PB.GetState", {})
+        assert rpc.requests == []
+
+
+async def test_a_failed_request_does_not_end_the_transport(host, rpc):
+    """Unlike a disconnect, a grill that goes away is expected to come back.
+
+    The class promises exactly this: no reconnect loop, because each call is
+    independent and one that fails does not stop the next from working.
+    """
+    conn = HttpConnection(host)
+    await conn.connect()
+    try:
+        rpc.status = 503
+        with pytest.raises(RPCError):
+            await conn.send_command("PB.GetState", {})
+
+        rpc.status = 200
+        assert await conn.send_command("PB.GetState", {}) == {
+            "sc_11": "FE0B",
+            "sc_12": "FE0C",
+        }
+        assert conn.is_connected() is True
+    finally:
+        await conn.disconnect()


### PR DESCRIPTION
Targets `http-transport`, same as #546 and #558 — merge it into #543 with one click, take the diff, or ignore it.

**One of three**, from reviewing this PR's code. Suggested order: this one, then the fire-and-forget fix, then the contract items. They touch the same small file, so whichever lands first will leave the others needing a rebase — say the word and I will do it as they go.

## The defect

`_send_prepared_command` decides whether it can send from the session alone:

```python
if self._session is None or self._session.closed:
    raise NotConnectedError("Not connected")
```

and a caller's session is not this transport's to close — `_close_session()` says so itself. So after `disconnect()` the session is still open, commands still go out and succeed, and line 178's `self._connected = True` puts the transport back to reporting itself connected after it was told to stop.

Home Assistant always supplies a shared session (`async_get_clientsession`), so this is the ordinary case rather than an exotic one: a coordinator refresh still in flight when the entry unloads keeps polling the grill, and `is_connected()` flips back to `True` behind it. The same path lets a command go out before `connect()` has ever run, which is the thing that checks the grill is there at all.

## Why a separate flag rather than gating on `_connected`

Because the two answer different questions, and this class deliberately recovers from the second. A request that fails leaves `_connected` false, and the next call is still expected to work — the class docstring is explicit that there is no reconnect loop because *"a grill that goes away surfaces as `NotConnectedError` on the next call and starts working again by itself"*. Gating sends on `_connected` would turn one failed request into a permanently dead transport.

`_started` is therefore only about `connect()`/`disconnect()`, and `_connected` keeps meaning what its docstring says.

## Consistency

`wss.py` re-reads `_sock` under the lock and raises `NotConnectedError`; `ble.py` releases `_ble_client` so the same check refuses (#565). This was the third transport and the only one that did not.

## Testing

Three tests. Two **fail on this PR as it stands** — a command after `disconnect()` and a command before `connect()` both reach the grill. The third pins the recovery behaviour so the fix cannot quietly take it away: a failed request followed by a good one still works.

785 pass, `ruff check`, `ruff format --check`, `mypy .` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
