### PR TITLE
Send a no-answer command without waiting for one

### DIFF
--- a/pytboss/http.py
+++ b/pytboss/http.py
@@ -43,6 +43,7 @@ it needs an answer for every grill rather than a raise for some.
 See https://github.com/dknowles2/pytboss/issues/505.
 """
 
+import asyncio
 import logging
 from asyncio import AbstractEventLoop
 from typing import Any
@@ -103,6 +104,7 @@ class HttpConnection(Transport):
         # the grill answered the last time we spoke to it.
         self._started = False
         self._connected = False
+        self._pending: set[asyncio.Task] = set()
 
     async def connect(self) -> None:
         """Verifies the grill answers RPC at this address.
@@ -139,6 +141,9 @@ class HttpConnection(Transport):
         """
         self._started = False
         self._connected = False
+        for task in list(self._pending):
+            task.cancel()
+        self._pending.clear()
         await self._close_session()
 
     async def _close_session(self) -> None:
@@ -160,6 +165,38 @@ class HttpConnection(Transport):
             and self._session is not None
             and not self._session.closed
         )
+
+    async def send_command_without_answer(
+        self, method: str, params: dict, *, timeout: float | None = None
+    ) -> None:
+        """Sends a command without waiting for the reply.
+
+        Issued in the background, unlike the other transports, where writing
+        to the socket is the whole of it. Here a request is only finished
+        when its response has been read, and the callers that choose this
+        method choose it for commands the board cannot answer: `Sys.Reboot`
+        is gone before it could, so awaiting the exchange means waiting out
+        the full timeout and then raising `NotConnectedError` at a caller
+        that is not expecting one.
+
+        :param method: The method to call.
+        :param params: Parameters to send with the command.
+        :param timeout: Ignored. Nothing is awaited, so nothing can elapse.
+        """
+        cmd = await self._prepare_command(method, params)
+        task = self._loop.create_task(self._send_and_forget(cmd))
+        # Held so the task is not collected mid-flight, and so `disconnect()`
+        # can stop one that is still going.
+        self._pending.add(task)
+        task.add_done_callback(self._pending.discard)
+
+    async def _send_and_forget(self, cmd: dict) -> None:
+        try:
+            await self._send_prepared_command(cmd)
+        except Exception as ex:  # noqa: BLE001
+            # Nobody is waiting to be told, and for a command the board was
+            # never going to answer this is the expected ending.
+            _LOGGER.debug("No answer to %s, as expected: %s", cmd["method"], ex)
 
     async def _send_prepared_command(self, cmd: dict) -> None:
         # `_started` rather than `_connected`: a request that failed leaves

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -353,3 +353,50 @@ async def test_a_failed_request_does_not_end_the_transport(host, rpc):
         assert conn.is_connected() is True
     finally:
         await conn.disconnect()
+
+
+async def test_send_command_without_answer_does_not_wait(host, rpc):
+    """`reboot()` picks this method because the board cannot answer.
+
+    A request is only finished here when its response has been read, so
+    awaiting the exchange means waiting out the whole timeout and then
+    raising at a caller that is not expecting an exception.
+    """
+    hung = asyncio.Event()
+
+    async def never_answers(request: web.Request) -> web.Response:
+        hung.set()
+        await asyncio.sleep(30)
+        raise AssertionError("unreachable")
+
+    app = web.Application()
+    app.router.add_post("/rpc", never_answers)
+    server = TestServer(app)
+    await server.start_server()
+    try:
+        conn = HttpConnection(f"{server.host}:{server.port}", timeout=5)
+        # Connected by hand: `connect()` pings, and this server never
+        # answers anything, which is the whole point of it.
+        conn._session = ClientSession()
+        conn._started = True
+        try:
+            async with asyncio.timeout(2):
+                await conn.send_command_without_answer("Sys.Reboot", {})
+            # The request is on its way even though we did not wait for it.
+            async with asyncio.timeout(2):
+                await hung.wait()
+        finally:
+            # Owns the session it was given here, so this closes it too.
+            await conn.disconnect()
+    finally:
+        await server.close()
+
+
+async def test_disconnect_stops_a_request_still_in_flight(host, rpc):
+    conn = HttpConnection(host)
+    await conn.connect()
+    await conn.send_command_without_answer("Sys.Reboot", {})
+    assert conn._pending
+
+    await conn.disconnect()
+    assert conn._pending == set()


### PR DESCRIPTION
Targets `http-transport`, same as #546, #558 and #569.

**Two of three**, from reviewing this PR's code. It sits after #569 in the order I would merge them; both touch `disconnect()`, so whichever lands first leaves the other needing a rebase — happy to do it as they go.

## The defect

`send_command_without_answer` is inherited, and the base implementation awaits `_send_prepared_command`. On the other transports that is the whole of the send — `ble.py` writes to the characteristic, `wss.py` sends on the socket, both return immediately. Over HTTP a request is not finished until its response has been read.

So the one method whose entire purpose is "do not wait for a reply" waits for one. Its callers pick it for commands the board cannot answer:

```python
async def reboot(self) -> None:
    """...No response is expected, since the board reboots before it can answer."""
    await self._conn.send_command_without_answer("Sys.Reboot", {})
```

Over this transport `reboot()` and `Config.save_config(reboot=True)` block for the constructor timeout — 30 seconds by default — and then raise `NotConnectedError` at a caller with no reason to catch anything. Measured with a 1-second timeout to keep it short:

```
PROBE reboot: raised NotConnectedError after 1.00s
```

## The change

The request is issued in the background. The task is held in a set so it is not collected mid-flight, discarded on completion, and cancelled by `disconnect()` if one is still going.

`timeout` becomes meaningless on this path and the docstring says so, rather than accepting it and quietly ignoring it.

I considered keeping it awaited with a short timeout and swallowing the expiry, but that trades a 30-second block for a shorter one and still guesses how long a board takes to stop answering. Say the word if you would rather have that shape.

## Testing

Two tests, both **failing on this PR as it stands**: the call returns promptly against a server that never answers (while the request does reach it), and `disconnect()` clears a request still in flight.

784 pass, `ruff check`, `ruff format --check`, `mypy .` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
