### PR TITLE
Report HTTP failures as the exceptions the contract names

### DIFF
--- a/pytboss/http.py
+++ b/pytboss/http.py
@@ -51,7 +51,7 @@ from typing import Any
 from aiohttp import ClientError, ClientSession, ClientTimeout
 
 from .exceptions import NotConnectedError, RPCError
-from .transport import DEFAULT_TIMEOUT, Transport
+from .transport import DEFAULT_TIMEOUT, Transport, _rpc_error
 
 _LOGGER = logging.getLogger("pytboss")
 
@@ -211,11 +211,28 @@ class HttpConnection(Transport):
                 self._url, json=cmd, timeout=self._timeout
             ) as resp:
                 if resp.status != 200:
-                    raise RPCError(
-                        f"{self._url} answered HTTP {resp.status}", resp.status
+                    # Built through `_rpc_error` so a 401 arrives as
+                    # `Unauthorized`, which is what a caller re-prompting for
+                    # a password catches and what a Mongoose build with
+                    # `rpc.auth_file` set answers with.
+                    raise _rpc_error(
+                        {
+                            "code": resp.status,
+                            "message": f"{self._url} answered HTTP {resp.status}",
+                        }
                     )
                 # Mongoose does not always set a JSON content type.
-                payload: Any = await resp.json(content_type=None)
+                try:
+                    payload: Any = await resp.json(content_type=None)
+                except ValueError as ex:
+                    # A 200 carrying something that is not JSON is not this
+                    # protocol at all -- a mistyped address landing on a
+                    # router's admin page answers exactly like that. Left
+                    # alone it escapes as `JSONDecodeError`, which is neither
+                    # documented here nor caught by callers.
+                    raise RPCError(
+                        f"{self._url} answered with something that is not JSON"
+                    ) from ex
         except (ClientError, TimeoutError) as ex:
             # The grill is unreachable rather than refusing the call. Reported
             # as a lost connection so callers treat it the way they treat a

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -400,3 +400,42 @@ async def test_disconnect_stops_a_request_still_in_flight(host, rpc):
 
     await conn.disconnect()
     assert conn._pending == set()
+
+
+async def test_a_non_json_body_is_reported_as_an_rpc_error():
+    """A mistyped address reaching something else answers like this.
+
+    `JSONDecodeError` is a `ValueError`, so the `except (ClientError,
+    TimeoutError)` in the transport does not see it and it escapes
+    undocumented.
+    """
+
+    async def html(request: web.Request) -> web.Response:
+        return web.Response(text="<html>router admin</html>", content_type="text/html")
+
+    app = web.Application()
+    app.router.add_post("/rpc", html)
+    server = TestServer(app)
+    await server.start_server()
+    try:
+        conn = HttpConnection(f"{server.host}:{server.port}")
+        with pytest.raises(RPCError):
+            await conn.connect()
+    finally:
+        await server.close()
+
+
+async def test_http_401_arrives_as_unauthorized(host, rpc):
+    """A build with `rpc.auth_file` set refuses at the HTTP layer.
+
+    Callers catch `Unauthorized` to re-prompt for a password; a bare
+    `RPCError` reads as a generic failure instead.
+    """
+    conn = HttpConnection(host)
+    await conn.connect()
+    try:
+        rpc.status = 401
+        with pytest.raises(Unauthorized):
+            await conn.send_command("PB.GetState", {})
+    finally:
+        await conn.disconnect()


### PR DESCRIPTION
Targets `http-transport`, same as #546, #558, #569 and #570.

**Three of three**, from reviewing this PR's code. Last in the order I would merge them; it touches `_send_prepared_command`, as #569 does, so one of the two will need a rebase — happy to do it.

## Two outcomes that arrive as the wrong thing

**A 200 whose body is not JSON escapes as `JSONDecodeError`.** It is a `ValueError`, so the `except (ClientError, TimeoutError)` a few lines below does not catch it, and it reaches a caller with no reason to expect it. This is the ordinary wrong-address mistake rather than an exotic one: a mistyped IP landing on a router's admin page answers `200 text/html`. `connect()` promises `NotConnectedError` when nothing answers; a config flow catching that and `RPCError` gets a traceback instead.

The `isinstance(payload, dict)` guard just below shows the intent already — it normalises replies that parse but are not objects. This covers the ones that do not parse.

**An HTTP 401 becomes a bare `RPCError`.** It is constructed directly rather than through `transport._rpc_error`, which is what maps code 401 to `Unauthorized`. A caller catching `Unauthorized` to re-prompt for a password — which ha-pitboss does — sees a generic failure. A Mongoose build with `rpc.auth_file` set refuses at the HTTP layer rather than in a JSON-RPC error frame.

## Left alone deliberately

The per-call `timeout=` is also not honoured: `ClientTimeout` is fixed at construction, so a longer per-call value is capped and `None` does not mean forever, and aiohttp's expiry is swallowed into `NotConnectedError` rather than the documented `TimeoutError`.

I did not fix it here because a correct fix has to decide how the constructor's default composes with `Transport.send_command`'s own `asyncio.timeout`, and `_send_prepared_command` cannot see the per-call value at all — the base does not pass it down. That is an API shape question rather than a bug to patch quietly. Happy to write it whichever way you want it.

## Testing

Two tests, both **failing on this PR as it stands**: a router-style HTML answer surfaces as `RPCError`, and a 401 as `Unauthorized`.

784 pass, `ruff check`, `ruff format --check`, `mypy .` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
