### PR TITLE
Send the OTA method names each firmware line actually serves

### DIFF
--- a/pytboss/ota.py
+++ b/pytboss/ota.py
@@ -1,4 +1,22 @@
-"""Client library for Mongoose OS OTA (Over-The-Air update) RPCs."""
+"""Client library for Mongoose OS OTA (Over-The-Air update) RPCs.
+
+A Mongoose core service rather than anything Dansons wrote, so none of it
+appears in the grill application and every shape here comes from `Mongoose's
+own documentation
+<https://mongoose-os.com/docs/mongoose-os/api/rpc/rpc-service-ota.md>`_,
+corroborated by `RPC.List` and `RPC.Describe` against a PB1600PS1.
+
+**Not the same service on every grill.** The ESP-IDF firmware line --
+versioned `16.x`, on the PBC2, PBD, PBE, PBL2 and PBT boards -- serves
+`OTA.Start` and `OTA.BluetoothStart`, and none of `OTA.Update`, `Begin`,
+`Write`, `End`, `Commit` or `Revert`. Precisely the mirror image of the
+Mongoose set, so `PitBoss.list_rpcs()` is how a caller finds out which one it
+is talking to rather than assuming.
+
+This is the sharpest surface in the library: a bad image is how a grill stops
+working entirely. `commit_timeout` and `commit()` are the pair that keep that
+recoverable -- see `update()`.
+"""
 
 from .transport import RPCResult, Transport, as_dict
 
@@ -16,31 +34,102 @@ class OTA:
         """
         self._conn = conn
 
-    async def start(self, url: str, commit_timeout: int | None = None) -> RPCResult:
-        """Initiates an OTA update.
+    async def update(self, url: str, commit_timeout: int | None = None) -> RPCResult:
+        """Downloads a firmware image and reboots into it.
 
-        Returns whatever the device answers rather than promising a shape:
-        `OTA.*` is a Mongoose core service, so it is not modelled in
-        `fake_firmware/init.js` and nothing here has been seen answering a
-        real grill.
+        Pass `commit_timeout` and the device rolls back to the previous image
+        unless `commit()` is called within that many seconds. That is what
+        stands between a bad image and a grill that needs the panel -- but it
+        is a promise the caller has to keep: set it and fail to commit, and a
+        good update undoes itself.
+
+        Returns whatever the device answers rather than promising a shape;
+        the documentation specifies none, and nothing here has watched a real
+        grill run one.
 
         :param url: URL of the firmware zip file to download.
-        :param commit_timeout: Optional timeout (in seconds) to auto-commit the
-            new firmware. If the device is not committed within this time it
-            rolls back automatically.
+        :param commit_timeout: Seconds to wait for a `commit()` before rolling
+            back. Omitted means no automatic rollback.
+        """
+        params: dict = {"url": url}
+        if commit_timeout is not None:
+            params["commit_timeout"] = commit_timeout
+        return await self._conn.send_command("OTA.Update", params)
+
+    async def start(self, url: str, commit_timeout: int | None = None) -> RPCResult:
+        """Starts an update on an ESP-IDF grill.
+
+        `OTA.Start` is real, but only on the `16.x` firmware line -- the
+        PBC2, PBD, PBE, PBL2 and PBT boards. No Mongoose image serves it, and
+        `RPC.List` on a PB1600PS1 does not list it, so on a `0.x` grill this
+        answers "name not found". `update()` is the Mongoose equivalent.
+
+        Between 2026.8.4 and now this was the only way to start an update and
+        was documented as the Mongoose one, which it never was.
+
+        :param url: URL of the firmware image to download.
+        :param commit_timeout: Seconds to wait for a `commit()` before rolling
+            back.
         """
         params: dict = {"url": url}
         if commit_timeout is not None:
             params["commit_timeout"] = commit_timeout
         return await self._conn.send_command("OTA.Start", params)
 
+    async def commit(self) -> RPCResult:
+        """Keeps the running image, cancelling any pending rollback.
+
+        The other half of `update(commit_timeout=...)`. Without this call the
+        device reverts when that timer expires, so an update that downloaded
+        and booted successfully still undoes itself.
+        """
+        return await self._conn.send_command("OTA.Commit", {})
+
+    async def revert(self) -> RPCResult:
+        """Rolls back to the previous image without waiting for the timeout."""
+        return await self._conn.send_command("OTA.Revert", {})
+
+    async def create_snapshot(
+        self, set_as_revert: bool | None = None, commit_timeout: int | None = None
+    ) -> RPCResult:
+        """Copies the running image into the inactive slot.
+
+        :param set_as_revert: Whether the snapshot becomes what a rollback
+            returns to.
+        :param commit_timeout: Seconds to wait for a `commit()` before rolling
+            back into the snapshot.
+        """
+        params: dict = {}
+        if set_as_revert is not None:
+            params["set_as_revert"] = set_as_revert
+        if commit_timeout is not None:
+            params["commit_timeout"] = commit_timeout
+        return await self._conn.send_command("OTA.CreateSnapshot", params)
+
+    async def get_boot_state(self) -> dict:
+        """Returns which image is running and whether it has been committed.
+
+        Answers `active_slot`, `is_committed`, `revert_slot` and
+        `commit_timeout`. `is_committed` false alongside a non-zero
+        `commit_timeout` means a rollback is pending and `commit()` has not
+        been called yet.
+
+        A cheap unauthenticated read, and the direct way to tell an update
+        landed rather than inferring it from `get_status()`.
+        """
+        return as_dict(await self._conn.send_command("OTA.GetBootState", {}))
+
     async def get_status(self) -> dict:
         """Returns the current OTA update status.
 
-        The returned dict typically contains:
-          - ``state``: current OTA state string (e.g. ``"idle"``, ``"progress"``,
-            ``"error"``)
-          - ``msg``: human-readable message
-          - ``progress``: download progress (0–100) while downloading
+        The reply, as a PB1600PS1 on 0.5.7 sends it::
+
+            {"state": 0, "message": "idle", "is_committed": true,
+             "progress_percent": 0, "commit_timeout": 0, "partition": 0}
+
+        `state` is an int and not a string, the human-readable text is under
+        `message` and not `msg`, and progress is `progress_percent`. This was
+        documented the other way until 2026.8.4, from what the service name
+        suggests rather than from a reply.
         """
         return as_dict(await self._conn.send_command("OTA.Status", {}))

--- a/tests/test_ota.py
+++ b/tests/test_ota.py
@@ -14,31 +14,131 @@ def mock_conn():
     return conn
 
 
-async def test_ota_start(mock_conn):
+async def test_update_sends_the_mongoose_method(mock_conn):
+    """`OTA.Update`, not `OTA.Start` -- no Mongoose image serves the latter."""
     ota = OTA(mock_conn)
-    await ota.start("http://example.com/firmware.zip")
+    await ota.update("http://example.com/firmware.zip")
     mock_conn.send_command.assert_awaited_once_with(
-        "OTA.Start", {"url": "http://example.com/firmware.zip"}
+        "OTA.Update", {"url": "http://example.com/firmware.zip"}
     )
 
 
-async def test_ota_start_with_commit_timeout(mock_conn):
+async def test_update_with_commit_timeout(mock_conn):
     ota = OTA(mock_conn)
-    await ota.start("http://example.com/firmware.zip", commit_timeout=120)
+    await ota.update("http://example.com/firmware.zip", commit_timeout=120)
     mock_conn.send_command.assert_awaited_once_with(
-        "OTA.Start",
+        "OTA.Update",
         {"url": "http://example.com/firmware.zip", "commit_timeout": 120},
     )
 
 
-async def test_ota_get_status(mock_conn):
+async def test_update_omits_commit_timeout_rather_than_sending_null(mock_conn):
+    """No timeout means no automatic rollback, not a rollback after `None`."""
+    ota = OTA(mock_conn)
+    await ota.update("http://example.com/firmware.zip")
+    _, params = mock_conn.send_command.await_args.args
+    assert "commit_timeout" not in params
+
+
+async def test_start_is_the_esp_idf_method(mock_conn):
+    """Kept because `OTA.Start` is correct on the `16.x` line, and only there."""
+    ota = OTA(mock_conn)
+    await ota.start("http://example.com/firmware.bin", commit_timeout=60)
+    mock_conn.send_command.assert_awaited_once_with(
+        "OTA.Start",
+        {"url": "http://example.com/firmware.bin", "commit_timeout": 60},
+    )
+
+
+async def test_commit(mock_conn):
+    ota = OTA(mock_conn)
+    await ota.commit()
+    mock_conn.send_command.assert_awaited_once_with("OTA.Commit", {})
+
+
+async def test_revert(mock_conn):
+    ota = OTA(mock_conn)
+    await ota.revert()
+    mock_conn.send_command.assert_awaited_once_with("OTA.Revert", {})
+
+
+async def test_create_snapshot_defaults_to_no_parameters(mock_conn):
+    ota = OTA(mock_conn)
+    await ota.create_snapshot()
+    mock_conn.send_command.assert_awaited_once_with("OTA.CreateSnapshot", {})
+
+
+async def test_create_snapshot_with_parameters(mock_conn):
+    ota = OTA(mock_conn)
+    await ota.create_snapshot(set_as_revert=True, commit_timeout=90)
+    mock_conn.send_command.assert_awaited_once_with(
+        "OTA.CreateSnapshot", {"set_as_revert": True, "commit_timeout": 90}
+    )
+
+
+async def test_create_snapshot_sends_set_as_revert_false(mock_conn):
+    """`False` is a value the caller chose; only `None` means "unset"."""
+    ota = OTA(mock_conn)
+    await ota.create_snapshot(set_as_revert=False)
+    mock_conn.send_command.assert_awaited_once_with(
+        "OTA.CreateSnapshot", {"set_as_revert": False}
+    )
+
+
+async def test_get_boot_state(mock_conn):
+    """The shape Mongoose documents, and the one a real grill answered."""
     mock_conn.send_command.return_value = {
-        "state": "progress",
-        "msg": "Downloading...",
-        "progress": 42,
+        "active_slot": 0,
+        "is_committed": True,
+        "revert_slot": 0,
+        "commit_timeout": 0,
+    }
+    ota = OTA(mock_conn)
+    result = await ota.get_boot_state()
+    mock_conn.send_command.assert_awaited_once_with("OTA.GetBootState", {})
+    assert result["is_committed"] is True
+
+
+async def test_get_boot_state_when_a_rollback_is_pending(mock_conn):
+    mock_conn.send_command.return_value = {
+        "active_slot": 1,
+        "is_committed": False,
+        "revert_slot": 0,
+        "commit_timeout": 300,
+    }
+    ota = OTA(mock_conn)
+    result = await ota.get_boot_state()
+    assert result["is_committed"] is False
+    assert result["commit_timeout"] == 300
+
+
+async def test_get_status_is_the_shape_a_grill_sends(mock_conn):
+    """A PB1600PS1 on 0.5.7, verbatim.
+
+    `state` is an int, the text is under `message`, and progress is
+    `progress_percent`. The previous test here asserted `state="progress"`,
+    `msg` and `progress` -- a shape invented from the method name, which is
+    how the wrong docstring survived review.
+    """
+    mock_conn.send_command.return_value = {
+        "state": 0,
+        "message": "idle",
+        "is_committed": True,
+        "progress_percent": 0,
+        "commit_timeout": 0,
+        "partition": 0,
     }
     ota = OTA(mock_conn)
     result = await ota.get_status()
     mock_conn.send_command.assert_awaited_once_with("OTA.Status", {})
-    assert result["state"] == "progress"
-    assert result["progress"] == 42
+    assert result["state"] == 0
+    assert result["message"] == "idle"
+    assert result["progress_percent"] == 0
+
+
+async def test_getters_narrow_a_result_less_reply(mock_conn):
+    """`send_command` can answer `None`; a getter must still hand back a dict."""
+    mock_conn.send_command.return_value = None
+    ota = OTA(mock_conn)
+    assert await ota.get_status() == {}
+    assert await ota.get_boot_state() == {}


### PR DESCRIPTION
Fixes a bug released in **2026.8.4**. Reported by @trailro on #458 before it merged; I merged it anyway without re-reading the discussion, which is on me.

## `OTA.Start` is not a Mongoose method

`RPC.List` on a PB1600PS1 returns `OTA.Begin`, `OTA.Write`, `OTA.End`, `OTA.Update`, `OTA.Commit`, `OTA.Revert`, `OTA.CreateSnapshot`, `OTA.GetBootState`, `OTA.SetBootState` and `OTA.Status` — **no `OTA.Start`**. [Mongoose's `rpc-service-ota` docs](https://mongoose-os.com/docs/mongoose-os/api/rpc/rpc-service-ota.md) list the same set, with `url` and `commit_timeout` under `OTA.Update` exactly as we were already sending them.

So every Mongoose grill answers `ota.start()` with "name not found". The parameters were right; the method name never was.

## `start()` is kept rather than removed, because it is right elsewhere

`OTA.Start` is the **ESP-IDF** line's own name — `16.x`, on the PBC2, PBD, PBE, PBL2 and PBT boards — which serves it alongside `OTA.BluetoothStart` and none of `Update`/`Begin`/`Write`/`End`/`Commit`/`Revert`. The mirror image of the Mongoose set, the same family split `http.py` documents.

So this is not a rename. `update()` is the Mongoose method, `start()` is the ESP-IDF one, both are real, and `PitBoss.list_rpcs()` tells a caller which grill it has. Nothing that calls `start()` today breaks; it simply now says which firmware it is for.

## `commit()` was the missing half of the safety net

The 2026.8.4 surface was `start()` and `get_status()` only. With no way to commit, **`commit_timeout` was a guaranteed rollback rather than protection** — an update that downloaded and rebooted successfully would still undo itself when the timer expired, and the caller had no call to stop it.

Added with its companions: `revert()`, `create_snapshot()`, and `get_boot_state()`, which is the cheap unauthenticated read that answers "did it land" directly instead of inferring it from `get_status()`.

## `get_status()`'s documented shape was invented

Documented as `state` (string `"idle"`/`"progress"`/`"error"`), `msg`, `progress`. A real grill answers:

```json
{"state": 0, "message": "idle", "is_committed": true,
 "progress_percent": 0, "commit_timeout": 0, "partition": 0}
```

`state` is an int, the text is under `message`, progress is `progress_percent`, and three documented-nowhere fields come with it.

**The old test asserted the invented shape**, which is how the wrong docstring survived review — a mock returning fiction agreeing with a docstring describing fiction. It now asserts the reply verbatim.

## Verified

**829 tests**, `ruff check`, `ruff format --check`, `mypy .` clean.

Mutated each mechanism, including putting the original bug back:

```
update() -> OTA.Start (the released bug) -> test_update_sends_the_mongoose_method       FAILS
start()  -> OTA.Update                   -> test_start_is_the_esp_idf_method            FAILS
commit() -> wrong method                 -> test_commit                                 FAILS
snapshot: treat set_as_revert=False as unset -> test_create_snapshot_sends_..._false    FAILS
get_boot_state(): drop as_dict           -> test_getters_narrow_a_result_less_reply     FAILS
get_status():     drop as_dict           -> test_getters_narrow_a_result_less_reply     FAILS
```

**Nothing here has run an update on a grill, and I would not ask anyone to.** Every name and shape comes from Mongoose's documentation and from @trailro's read-only `RPC.List`/`RPC.Describe`. A bad image is how a grill stops working entirely — which is precisely why `commit()` needed to exist before anyone used `commit_timeout`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)