### PR TITLE
Survive the network failures a reconnect actually meets

### DIFF
--- a/pytboss/wss.py
+++ b/pytboss/wss.py
@@ -8,10 +8,10 @@ from typing import Any
 from uuid import uuid4
 
 from aiohttp import (
+    ClientError,
     ClientSession,
     ClientWebSocketResponse,
     WSMsgType,
-    WSServerHandshakeError,
 )
 
 from .exceptions import GrillUnavailable, NotConnectedError
@@ -130,11 +130,19 @@ class WebSocketConnection(Transport):
             self._connect_task.cancel()
         if self._sock is not None and not self._sock.closed:
             await self._sock.close()
-        await self._subscribe_task
-        self._subscribe_task = None
-        # The event means "the loop is reading". Left set, the next
-        # `connect()` returns before that is true again.
-        self._subscribed.clear()
+        try:
+            # A task that died re-raises here. Letting that propagate made
+            # `disconnect()` fail the same way on every call, forever, and
+            # the lines below -- clearing state, and in `disconnect()`'s
+            # case closing an owned session -- never ran.
+            await self._subscribe_task
+        except Exception:
+            _LOGGER.exception("Subscribe task ended with an unhandled error")
+        finally:
+            self._subscribe_task = None
+            # The event means "the loop is reading". Left set, the next
+            # `connect()` returns before that is true again.
+            self._subscribed.clear()
 
     async def disconnect(self) -> None:
         """Stops the connection to the device.
@@ -163,7 +171,13 @@ class WebSocketConnection(Transport):
             raise NotConnectedError("Not connected")
         try:
             return await self._session.ws_connect(self._url)
-        except WSServerHandshakeError as ex:
+        except (ClientError, OSError, TimeoutError) as ex:
+            # Everything the network can do here means the same thing: the
+            # grill cannot be reached right now. Mapping only the handshake
+            # error left `ClientConnectorError` -- what an offline relay or a
+            # dropped network actually raises -- escaping the reconnect
+            # loop's `except GrillUnavailable`, ending the automatic
+            # reconnection this class promises.
             _LOGGER.debug("Failed to connect: %s", ex)
             raise GrillUnavailable(str(ex)) from ex
 

--- a/tests/test_wss.py
+++ b/tests/test_wss.py
@@ -108,7 +108,7 @@ async def conn(
         yield make_conn(fake_server, session)
 
 
-def make_conn(fake_server: BaseTestServer, session: ClientSession):
+def make_conn(fake_server: BaseTestServer, session: ClientSession | None):
     return wss.WebSocketConnection(
         "_grill_id_",
         session=session,
@@ -660,3 +660,73 @@ async def test_a_callback_disconnect_does_not_deadlock_an_outside_one(
     assert len(callback_saw) == 1
     with raises(RuntimeError, match="Cannot stop this transport"):
         raise callback_saw[0]
+
+
+@patch.object(wss.WebSocketConnection, "_backoff_wait")
+async def test_reconnect_survives_the_grill_vanishing_from_the_network(
+    mock_wait: AsyncMock,
+    conn: wss.WebSocketConnection,
+) -> None:
+    """An unreachable relay raises `ClientConnectorError`, not a handshake error.
+
+    Mapping only `WSServerHandshakeError` let the common case -- the network
+    going away entirely -- escape the reconnect loop's
+    `except GrillUnavailable` and end the automatic reconnection this class
+    promises, silently.
+    """
+    await conn.connect()
+    task = conn._subscribe_task
+    assert task is not None
+
+    # The grill drops off the network: the stream ends, and every reconnect
+    # now targets a port nothing is listening on.
+    conn._url = "ws://127.0.0.1:9/to/_grill_id_"
+    assert conn._sock is not None
+    await conn._sock.close()
+
+    for _ in range(100):
+        await sleep(0.05)
+        if mock_wait.await_count >= 2:
+            break
+
+    assert not task.done(), (
+        f"reconnect loop died: {task.exception()!r}"
+        if task.done() and task.exception()
+        else "reconnect loop ended"
+    )
+    assert mock_wait.await_count >= 2  # it is genuinely retrying
+    await conn.disconnect()
+
+
+async def test_a_dead_subscribe_task_does_not_poison_disconnect(
+    fake_server: TestServer,
+) -> None:
+    """`disconnect()` must complete even when the subscribe task has died.
+
+    Re-raising the dead task's error made every later `disconnect()` fail
+    the same way, forever, and the owned session below the await was never
+    closed.
+    """
+    async with fake_server:
+        conn = make_conn(fake_server, session=None)
+        await conn.connect()
+        task = conn._subscribe_task
+        assert task is not None
+        owned_session = conn._session
+        assert owned_session is not None
+
+        # An error the reconnect mapping cannot anticipate kills the task.
+        with patch.object(
+            conn, "_ws_connect", AsyncMock(side_effect=RuntimeError("boom"))
+        ):
+            assert conn._sock is not None
+            await conn._sock.close()
+            async with timeout(5):
+                with raises(RuntimeError):
+                    await task
+
+            await conn.disconnect()
+
+        assert conn._subscribe_task is None
+        assert owned_session.closed
+        await conn.disconnect()  # and a second call stays clean


### PR DESCRIPTION
## What

`WebSocketConnection`'s reconnect loop only survives `GrillUnavailable`, and `_ws_connect` raises that only for `WSServerHandshakeError`. The failures a reconnect actually meets are different ones: an unreachable relay raises `ClientConnectorError`, a dropped network `OSError`, a stalled TCP handshake `TimeoutError`. Each of those escapes the loop's `except GrillUnavailable` and kills the subscribe task — permanently ending the automatic reconnection the class docstring promises, with nothing surfaced to the consumer.

The dead task then poisons `disconnect()`: `_stop_subscribing` awaits it bare, so the task's exception re-raises on **every** later `disconnect()` call, forever. The lines below the await never run, so an internally-created `ClientSession` is never closed. Observed:

```
disconnect() #1: ClientConnectorError: Cannot connect to host ...
disconnect() #2: ClientConnectorError: Cannot connect to host ...
owned session closed: False
```

So a plain Wi-Fi blip leaves the transport dead, un-disconnectable, and leaking.

## Fix

Two halves, same root:

- `_ws_connect` maps `ClientError`, `OSError` and `TimeoutError` to `GrillUnavailable` — everything the network can do there means the same thing: the grill cannot be reached right now. (`WSServerHandshakeError` is a `ClientError`, so the existing case is subsumed.)
- `_stop_subscribing` retrieves a dead task's error defensively (logged, not re-raised) and clears its state in a `finally`, so `disconnect()` always completes and the owned session always closes.

## Tests

Both fail against unpatched `main`, verified:

- `test_reconnect_survives_the_grill_vanishing_from_the_network` — after the stream ends and reconnects target a dead port, the loop must still be retrying; on main it dies with `ClientConnectorError`.
- `test_a_dead_subscribe_task_does_not_poison_disconnect` — a task killed by an unanticipated error must not stop `disconnect()` from completing and closing the owned session; on main the failure even prints aiohttp's "Unclosed client session" warning.

870 pass, `ruff check`, `ruff format --check` and `mypy .` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
