### PR TITLE
Keep the HTTP transport honest when its own deadline fires first

### DIFF
--- a/pytboss/http.py
+++ b/pytboss/http.py
@@ -105,10 +105,24 @@ class HttpConnection(Transport):
         self._connected = True
         try:
             await self.send_command("RPC.Ping", {})
-        except Exception:
+        except BaseException as ex:
+            # `BaseException`, not `Exception`: a caller-imposed cancellation
+            # -- a config flow timing out around `connect()` -- otherwise
+            # skips this rollback entirely, leaving the transport claiming to
+            # be connected and the owned session it just opened leaking, once
+            # per retry.
             self._started = False
             self._connected = False
             await self._close_session()
+            if isinstance(ex, TimeoutError):
+                # At `send_command`'s own default deadline the RPC timeout
+                # fires before aiohttp's, so the unreachable-grill mapping in
+                # `_send_prepared_command` never runs. Map it here too, or
+                # this method answers a silent grill with a bare
+                # `TimeoutError` instead of the error it documents.
+                raise NotConnectedError(
+                    f"Could not reach {self._url}: no answer"
+                ) from ex
             raise
 
     async def disconnect(self) -> None:
@@ -224,6 +238,14 @@ class HttpConnection(Transport):
             # which is not a `ClientError`. Silence is the common case.
             self._connected = False
             raise NotConnectedError(f"Could not reach {self._url}: {ex}") from ex
+        except asyncio.CancelledError:
+            # The caller's RPC deadline (`Transport.send_command`'s
+            # `asyncio.timeout`) fired while the request was in flight. At
+            # the default configuration that deadline beats aiohttp's, so
+            # without this the branch above never runs and `is_connected()`
+            # keeps answering `True` for a grill that stopped answering.
+            self._connected = False
+            raise
         _LOGGER.debug("<-- %s", payload)
         if not isinstance(payload, dict):
             raise RPCError(f"Expected a JSON object, got {type(payload).__name__}")

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -439,3 +439,92 @@ async def test_http_401_arrives_as_unauthorized(host, rpc):
             await conn.send_command("PB.GetState", {})
     finally:
         await conn.disconnect()
+
+
+async def test_is_connected_stops_lying_when_the_grill_goes_silent():
+    """A grill that answered once and then went quiet must read as gone.
+
+    At the default configuration the RPC deadline fires before aiohttp's, so
+    the request is cancelled rather than timing out inside the `except` that
+    clears `_connected` -- and `is_connected()` kept answering `True`,
+    indefinitely, for a grill that stopped answering.
+    """
+    calls = 0
+
+    async def handler(request: web.Request) -> web.Response:
+        nonlocal calls
+        calls += 1
+        cmd = await request.json()
+        if calls == 1:
+            return web.json_response(
+                {"id": cmd["id"], "result": {}}, content_type="text/plain"
+            )
+        await asyncio.sleep(30)
+        raise AssertionError("unreachable")
+
+    app = web.Application()
+    app.router.add_post("/rpc", handler)
+    server = TestServer(app)
+    await server.start_server()
+    try:
+        # aiohttp's deadline is high so the RPC one below beats it, the same
+        # order the defaults produce (30.0 vs 30.0, ceil-rounded up).
+        conn = HttpConnection(f"{server.host}:{server.port}", timeout=5)
+        await conn.connect()
+        assert conn.is_connected()
+
+        with pytest.raises(TimeoutError):
+            await conn.send_command("PB.GetState", {}, timeout=0.1)
+
+        assert not conn.is_connected()
+        await conn.disconnect()
+    finally:
+        await server.close()
+
+
+async def test_a_cancelled_connect_rolls_back():
+    """A config flow timing out around `connect()` cancels it.
+
+    `except Exception` does not catch `CancelledError`, so the rollback was
+    skipped entirely: the transport kept claiming to be connected and the
+    owned session it had just opened leaked, once per retry.
+    """
+
+    async def never_answers(request: web.Request) -> web.Response:
+        await asyncio.sleep(30)
+        raise AssertionError("unreachable")
+
+    app = web.Application()
+    app.router.add_post("/rpc", never_answers)
+    server = TestServer(app)
+    await server.start_server()
+    try:
+        conn = HttpConnection(f"{server.host}:{server.port}")
+        task = asyncio.create_task(conn.connect())
+        await asyncio.sleep(0.2)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        assert not conn.is_connected()
+        assert conn._session is None  # the owned session was closed, not leaked
+    finally:
+        await server.close()
+
+
+async def test_connect_maps_a_bare_timeout_to_the_documented_error(host):
+    """`connect()` promises `NotConnectedError` when nothing answers.
+
+    At `send_command`'s own default deadline the RPC timeout beats aiohttp's,
+    so the unreachable-grill mapping in `_send_prepared_command` never runs
+    and the caller got a bare `TimeoutError` instead.
+    """
+    conn = HttpConnection(host)
+    with (
+        mock.patch.object(
+            conn, "send_command", mock.AsyncMock(side_effect=TimeoutError)
+        ),
+        pytest.raises(NotConnectedError),
+    ):
+        await conn.connect()
+    assert not conn.is_connected()


### PR DESCRIPTION
## What

Two holes in `HttpConnection`'s state-keeping, both only visible at the configuration every real consumer runs — the defaults.

**1. `is_connected()` lies forever once the grill goes silent.** `Transport.send_command` arms `asyncio.timeout(30.0)` and the transport builds `ClientTimeout(total=30.0)` — but aiohttp ceil-rounds its deadline up to the next whole second for timeouts ≥ 5s, so the RPC deadline always fires first. The request is *cancelled* rather than timing out inside the `except (ClientError, TimeoutError)` that clears `_connected`, so that branch is dead code at the defaults. Measured against a grill that answered `RPC.Ping` then went silent:

```
after connect(): is_connected()=True
  raised TimeoutError() after 30.0s
after the grill went silent: is_connected()=True   <- forever
```

A coordinator polling `is_connected()` keeps reporting the grill online after it stopped answering.

**2. A cancelled `connect()` skips the rollback and leaks the session.** `except Exception` does not catch `CancelledError`, so a caller-imposed cancellation — a config flow timing out around `connect()`, exactly what Home Assistant does — leaves `_started=True`, `_connected=True`, `is_connected()=True`, and the just-opened owned `ClientSession` unclosed (aiohttp prints `Unclosed client session`), once per retry.

Related: at those same default deadlines, `connect()` against a silent grill raised a bare `TimeoutError` where its docstring promises `NotConnectedError`.

## Fix

- `_send_prepared_command` gains a `CancelledError` branch that clears `_connected` before re-raising — the cancellation that reaches it is the RPC deadline firing mid-request, which means precisely "the grill did not answer".
- `connect()`'s rollback catches `BaseException`, so cancellation rolls back too, and maps `TimeoutError` to the `NotConnectedError` it documents.

## Tests

All three fail against unpatched `main`, verified:

- `test_is_connected_stops_lying_when_the_grill_goes_silent` — answered once, then quiet; after the RPC deadline fires, `is_connected()` must be `False`.
- `test_a_cancelled_connect_rolls_back` — cancelled mid-ping: not connected, owned session closed.
- `test_connect_maps_a_bare_timeout_to_the_documented_error` — a `TimeoutError` out of the RPC layer surfaces as `NotConnectedError`.

871 pass, `ruff check`, `ruff format --check` and `mypy .` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
