### PR TITLE
Strip the password from pushed virtual data too

### DIFF
--- a/pytboss/api.py
+++ b/pytboss/api.py
@@ -210,6 +210,16 @@ class PitBoss:
         # text the firmware printed; `wss` receives it as a member of an
         # already-parsed status frame, so it arrives decoded.
         vdata = json.loads(payload) if isinstance(payload, str) else payload
+        if isinstance(vdata, dict) and "psw" in vdata:
+            # The same strip `get_virtual_data()` applies, for the same
+            # reason: an authenticated write leaves the encoded password in
+            # the firmware's scratchpad, and the firmware pushes that object
+            # back verbatim -- on the BLE debug log and as `data` on the
+            # websocket status frame. Without this, every subscriber is
+            # handed the password, and anything that logs or persists vdata
+            # records it. The encoding is not protection: the key is
+            # `timed_key(uptime)` and this library implements both ends.
+            vdata = {k: v for k, v in vdata.items() if k != "psw"}
         _LOGGER.debug("VData received: %s", vdata)
         async with self._lock:
             callbacks = list(self._vdata_callbacks)
@@ -563,10 +573,11 @@ class PitBoss:
         verbatim, so an authenticated write leaves the encoded password in the
         scratchpad and it would otherwise be handed back as if it were data.
 
-        This is the only thing that removes it, rather than a belt-and-braces
-        measure. Firmware 0.6.0 attempts the same strip and misses -- it
-        clears `vData.pws` while `checkPassword` reads `params.psw` -- and the
-        eight earlier mJS versions do not attempt it at all.
+        Nothing upstream removes it, so this is not a belt-and-braces
+        measure: firmware 0.6.0 attempts the same strip and misses -- it
+        clears `vData.pws` while `checkPassword` reads `params.psw` -- and
+        the eight earlier mJS versions do not attempt it at all.
+        `_on_vdata_received` applies the same strip on the push path.
 
         :meta private:
         """

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1244,3 +1244,24 @@ async def test_scan_wifi_networks_stops_when_the_grill_is_not_scanning():
         assert await pitboss.scan_wifi_networks(poll_interval=0) == []
     # start + a single status poll, rather than polling to the timeout.
     assert idle.await_count == 2
+
+
+async def test_on_vdata_received_strips_the_password():
+    """The push path leaks what `get_virtual_data()` carefully removes.
+
+    An authenticated `PB.SetVirtualData` hands its whole params object to the
+    firmware, which stores it verbatim and pushes it back -- on the BLE debug
+    log and as `data` on the websocket status frame. Every subscriber was
+    handed the encoded password, and the encoding is not protection: the key
+    is `timed_key(uptime)` and this library implements both ends.
+    """
+    conn = FakeTransport()
+    pitboss = api.PitBoss(conn, "PBV4PS2")
+    await pitboss.start()
+    received = []
+    await pitboss.subscribe_vdata(received.append)
+
+    await pitboss._on_vdata_received({"p1T": 165, "psw": "a1b2c3deadbeef"})
+    await pitboss._on_vdata_received('{"p2T": 170, "psw": "a1b2c3deadbeef"}')
+
+    assert received == [{"p1T": 165}, {"p2T": 170}]


### PR DESCRIPTION
## What

`get_virtual_data()` strips `psw` — the firmware stores the params of the last authenticated write verbatim, so the encoded password sits in the vdata scratchpad. But the **push** path doesn't: `_authenticate` injects `psw` into the very params object `PB.SetVirtualData` hands to the firmware (`vData = params` in `init.js`), and the firmware then re-broadcasts that object — `sendBTData` prints it whole to the BLE debug log, `sendWSStatus` attaches it as `data` on the status frame. Both land in `_on_vdata_received`, which passed it to every subscriber unfiltered:

```
subscriber received: {'p1T': 165, 'psw': 'a1b2c3deadbeef'}
```

Concrete path: any consumer that calls `set_probe_target()` on a board without a probe command takes the vdata route, and the grill echoes the encoded password back on the next push. A subscriber that logs or persists vdata records it — and the encoding is not protection, since the key is `timed_key(uptime)` and this library implements both ends.

## Fix

The same strip `get_virtual_data()` applies, applied in `_on_vdata_received` before dispatch (and before the DEBUG log line, which was also printing it). `get_virtual_data()`'s "this is the only thing that removes it" docstring updated to match.

## Test

`test_on_vdata_received_strips_the_password` covers both arrival shapes — the decoded object `wss` hands over and the JSON text `ble` reads off the debug log. Fails against unpatched `main`, verified.

869 pass, `ruff check`, `ruff format --check` and `mypy .` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
