### PR TITLE
Answer a board without the command with the documented error

### DIFF
--- a/pytboss/api.py
+++ b/pytboss/api.py
@@ -301,10 +301,15 @@ class PitBoss:
         """Sets the target temperature for probe 1.
 
         :param temp: Target probe temperature, in the grill's own unit.
+        :raise pytboss.exceptions.UnsupportedOperation: When probe 1's
+            target temperature cannot be set. Only 42 of 137 models declare
+            the command; on the rest this raised a bare `KeyError` while its
+            sibling below raised the documented error.
         """
-        return await self._send_command(
-            "set-probe-1-temperature", temp, self._is_fahrenheit()
-        )
+        cmd = "set-probe-1-temperature"
+        if cmd not in self.spec.control_board.commands:
+            raise UnsupportedOperation
+        return await self._send_command(cmd, temp, self._is_fahrenheit())
 
     async def set_probe_2_temperature(self, temp: int) -> RPCResult:
         """Sets the target temperature for probe 2.
@@ -492,12 +497,26 @@ class PitBoss:
         return await self._send_command("turn-off")
 
     async def turn_primer_motor_on(self) -> RPCResult:
-        """Turns the primer motor on."""
-        return await self._send_command("turn-primer-motor-on")
+        """Turns the primer motor on.
+
+        :raise pytboss.exceptions.UnsupportedOperation: When the board has no
+            primer motor command (26 of 137 models).
+        """
+        cmd = "turn-primer-motor-on"
+        if cmd not in self.spec.control_board.commands:
+            raise UnsupportedOperation
+        return await self._send_command(cmd)
 
     async def turn_primer_motor_off(self) -> RPCResult:
-        """Turns the primer motor off."""
-        return await self._send_command("turn-primer-motor-off")
+        """Turns the primer motor off.
+
+        :raise pytboss.exceptions.UnsupportedOperation: When the board has no
+            primer motor command (26 of 137 models).
+        """
+        cmd = "turn-primer-motor-off"
+        if cmd not in self.spec.control_board.commands:
+            raise UnsupportedOperation
+        return await self._send_command(cmd)
 
     async def get_state(self) -> StateDict:
         """Issues a live RPC to fetch and return the current grill state.

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1265,3 +1265,36 @@ async def test_on_vdata_received_strips_the_password():
     await pitboss._on_vdata_received('{"p2T": 170, "psw": "a1b2c3deadbeef"}')
 
     assert received == [{"p1T": 165}, {"p2T": 170}]
+
+
+async def test_board_gated_commands_never_raise_a_bare_keyerror():
+    """A board without the command is an `UnsupportedOperation`, not a crash.
+
+    `set_probe_temperature` sent its slug unguarded while its probe-2 sibling
+    checked membership and raised the documented error -- so the same call
+    crashed with `KeyError('set-probe-1-temperature')` on the 95 of 137
+    models whose board does not declare it. Same hole for the primer motor
+    on 26 models.
+    """
+    checked = 0
+    for grill in grills.get_grills():
+        if grill.name in grills.UNSUPPORTED_MODELS:
+            continue
+        pitboss = api.PitBoss(FakeTransport(), grill.name)
+        await pitboss.start()
+        for op in (
+            pitboss.set_probe_temperature(165),
+            pitboss.turn_primer_motor_on(),
+            pitboss.turn_primer_motor_off(),
+        ):
+            try:
+                await op
+            except UnsupportedOperation:
+                pass  # the documented answer for a board without the command
+            except RPCError:
+                # An artifact of `FakeTransport._send_mcu_command` decoding
+                # the hex as UTF-8, not of the code under test. The command
+                # was rendered and sent, which is all this sweep asks.
+                pass
+        checked += 1
+    assert checked > 100  # the sweep really covered the catalogue


### PR DESCRIPTION
## What

`set_probe_temperature()` sends `set-probe-1-temperature` unguarded, while its sibling `set_probe_2_temperature()` checks membership and raises the documented `UnsupportedOperation`. Only 42 of 137 supported models declare the probe-1 slug, so on the other 95 the call crashes with a bare `KeyError('set-probe-1-temperature')` out of `_send_command`'s dict lookup — verified by sweeping every model in the catalogue:

```
set_probe_temperature    -> KeyError: 'set-probe-1-temperature'   (95 models, e.g. LG1200FL, all 32 PBC models)
set_probe_2_temperature  -> UnsupportedOperation                  (the sibling, same grill)
```

`turn_primer_motor_on()`/`turn_primer_motor_off()` have the same hole on the 26 models whose boards lack the primer slug (PBD, PBE, PBM, PBM2, PBV2, PBVA). For contrast, `turn_light_on()` is guarded via `has_lights` — and I cross-checked that no model with lights sits on a board lacking the slug, so that guard is sound as-is.

## Fix

All three methods now guard the way the probe-2 sibling does: membership check, `UnsupportedOperation` with a `:raise:` line in the docstring. `probe_target_command()` already documents the catalogue counts, so the docstrings carry them too.

## Test

`test_board_gated_commands_never_raise_a_bare_keyerror` sweeps every supported model in the catalogue and accepts only the documented outcomes. Fails against unpatched `main` (KeyError on the first affected model), verified.

869 pass, `ruff check`, `ruff format --check` and `mypy .` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
