### PR TITLE
Route a status push by its frame's prefix, not its position

### DIFF
--- a/pytboss/wss.py
+++ b/pytboss/wss.py
@@ -288,7 +288,24 @@ class WebSocketConnection(Transport):
                 await self._vdata_callback(vdata)
             if not self._state_callback:
                 return
-            await self._state_callback(*payload["status"])
+            frames = payload["status"]
+            if (
+                len(frames) == 1
+                and isinstance(frames[0], str)
+                and (frames[0][:4] == "FE0C")
+            ):
+                # The firmware builds this array conditionally -- a frame is
+                # pushed only if it is non-empty, and `sendMCUCommand` blanks
+                # both frames on every command, refilled one packet at a
+                # time. So a push carrying only the temperatures frame is
+                # producible, right in the window after a user-issued
+                # command, and positional unpacking would hand it over as
+                # the *status* payload -- where every board's status routine
+                # requires an FE0B prefix and returns nothing. Routed by the
+                # frame's own prefix instead, the way `ble` already does.
+                await self._state_callback(None, frames[0])
+                return
+            await self._state_callback(*frames)
             return
 
         if "id" in payload:

--- a/tests/test_wss.py
+++ b/tests/test_wss.py
@@ -730,3 +730,30 @@ async def test_a_dead_subscribe_task_does_not_poison_disconnect(
         assert conn._subscribe_task is None
         assert owned_session.closed
         await conn.disconnect()  # and a second call stays clean
+
+
+async def test_a_temperatures_only_push_reaches_the_callback_as_temperatures(
+    conn: wss.WebSocketConnection, state_payloads: Queue
+) -> None:
+    """The status array is built conditionally; `["FE0C..."]` is producible.
+
+    `sendMCUCommand` blanks both frames on every command and they refill one
+    packet at a time, so a push right after a user-issued command can carry
+    only the temperatures frame. Positional unpacking handed it over as the
+    *status* payload, where every board's status routine requires an FE0B
+    prefix and returns nothing -- the temperatures were silently dropped.
+    """
+    temps_frame = "FE0C0107000105"
+    state_callback = MockCallback(2)
+    conn.set_state_callback(state_callback)
+    async with conn:
+        await state_payloads.put({"status": [temps_frame]})
+        await state_payloads.put({"status": ["FE0B00", temps_frame]})
+        async with timeout(5):
+            await state_callback.wait()
+    state_callback.assert_has_awaits(
+        [
+            call(None, temps_frame),  # routed by its own prefix
+            call("FE0B00", temps_frame),  # the two-frame case is untouched
+        ]
+    )


### PR DESCRIPTION
## What

`_handle_message` unpacks the status push positionally — `await self._state_callback(*payload["status"])` — assuming element 0 is always the FE0B state frame. The firmware builds that array conditionally (`init.js`):

```js
if (lastStatus.sc_11 !== "") wsStatus.push(toHexStr(lastStatus.sc_11));
if (lastStatus.sc_12 !== "") wsStatus.push(toHexStr(lastStatus.sc_12));
if (wsStatus.length < 1) return;
```

so `["FE0C…"]` is a producible frame. And the window is not exotic: `sendMCUCommand` blanks **both** `sc_11` and `sc_12` on every user-issued command, and `handlePacket` refills them one packet at a time — if the push timer fires after the FE0C reply lands but before the FE0B one, the grill sends `{"status": ["FE0C…"]}`. The same applies at boot before the first FE0B arrives.

Positionally unpacked, that frame arrives as the *status* payload; every board's `status_function` requires `startsWith("FE0B")` and returns nothing, so the temperatures are silently dropped and no subscriber is notified — precisely in the moments after the user changed something. Reproduced end-to-end:

```
frames=['FE0C..'] as positional arg 0: subscriber updates = 0
frames=['FE0C..'] routed to arg 1:     subscriber updates = 1, p1Temp=150
```

## Fix

A single-element push whose frame carries the FE0C prefix is routed to the temperatures argument — the same prefix dispatch `ble._on_debug_log_received` already does (`match payload[:4]: case "FE0B" / "FE0C"`). Everything else is unchanged, including the two-frame case and non-hex payloads.

## Test

`test_a_temperatures_only_push_reaches_the_callback_as_temperatures` covers both the temps-only push and the two-frame push through a real websocket round-trip. Fails against unpatched `main`, verified.

869 pass, `ruff check`, `ruff format --check` and `mypy .` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
