### PR TITLE
Bind the BLE client under the lock it is used with

### DIFF
--- a/pytboss/ble.py
+++ b/pytboss/ble.py
@@ -15,6 +15,7 @@ from uuid import UUID
 
 import bleak_retry_connector
 from bleak import BleakClient, BleakGATTCharacteristic, BLEDevice
+from bleak.exc import BleakError
 from bleak_retry_connector import BleakClientWithServiceCache
 
 from .exceptions import NotConnectedError
@@ -218,12 +219,18 @@ class BleConnection(Transport):
             raise NotConnectedError("Not connected")
         payload = json.dumps(cmd)
         async with self._lock:
-            await self._ble_client.write_gatt_char(
-                CHAR_RPC_TX_CTL, _encode_len(len(payload))
-            )
+            # Re-read under the lock: `_on_disconnected` clears `_ble_client`,
+            # so the check above can be stale by the time the writes happen --
+            # every `await` between chunks is a window. Bound once so a drop
+            # mid-payload surfaces as bleak's own error on a dead client
+            # rather than `AttributeError` on `None`.
+            client = self._ble_client
+            if client is None:
+                raise NotConnectedError("Not connected")
+            await client.write_gatt_char(CHAR_RPC_TX_CTL, _encode_len(len(payload)))
             for i in range(0, len(payload), 20):
                 chunk = bytearray(payload[i : i + 20].encode("utf-8"))
-                await self._ble_client.write_gatt_char(CHAR_RPC_DATA, chunk)
+                await client.write_gatt_char(CHAR_RPC_DATA, chunk)
 
     async def _on_rpc_data_received(
         self, unused_char: BleakGATTCharacteristic, data: bytearray
@@ -244,8 +251,30 @@ class BleConnection(Transport):
             return
         resp = bytearray()
         async with self._lock:
+            # Re-read under the lock, as in `_send_prepared_command`: a
+            # disconnect between chunks clears `_ble_client`, and this
+            # callback runs inside bleak's notification dispatch, where an
+            # `AttributeError` surfaces as an unhandled-task traceback
+            # rather than reaching any caller. A `return` matches the
+            # truncated-response handling below; `_on_disconnected`
+            # separately fails the commands in flight.
+            client = self._ble_client
+            if client is None:
+                return
             while len(resp) < resp_len:
-                chunk = await self._ble_client.read_gatt_char(CHAR_RPC_DATA)
+                try:
+                    chunk = await client.read_gatt_char(CHAR_RPC_DATA)
+                except BleakError:
+                    # The connection dropped mid-reply. Abandoning it matches
+                    # the truncated-response handling below; the caller's
+                    # command is failed by `_on_disconnected`.
+                    _LOGGER.warning(
+                        "Abandoning RPC response after a disconnect: "
+                        "got %d of %d bytes",
+                        len(resp),
+                        resp_len,
+                    )
+                    return
                 if not chunk:
                     # Nothing left to read, but the announced length says
                     # otherwise. Without this the loop spins on an empty read

--- a/tests/test_ble.py
+++ b/tests/test_ble.py
@@ -764,3 +764,83 @@ async def test_a_failed_start_notify_releases_the_connection(
     mock_bleak_client.disconnect.assert_awaited_once()
     assert conn._ble_client is None
     assert conn.is_connected() is False
+
+
+async def test_a_drop_mid_send_raises_the_contract_error():
+    """`_ble_client` is checked outside the lock and was used inside it.
+
+    `_on_disconnected` clears it, and every await between chunks is a
+    window -- a drop after the length header raised `AttributeError` on
+    `None` instead of the `NotConnectedError` the transport contract
+    promises.
+    """
+    conn = ble.BleConnection.__new__(ble.BleConnection)
+    conn._lock = asyncio.Lock()
+    client = mock.AsyncMock()
+
+    # Cleared before the send starts: the documented error.
+    conn._ble_client = None
+    with raises(NotConnectedError):
+        await conn._send_prepared_command({"id": 1, "method": "M", "params": {}})
+
+    # The window itself: the disconnect callback fires after the length
+    # header goes out. The client bound under the lock finishes the send it
+    # started instead of dereferencing `None` on the next chunk.
+    conn._ble_client = client
+
+    async def write_and_drop(*args, **kwargs):
+        conn._ble_client = None
+
+    client.write_gatt_char = mock.AsyncMock(side_effect=write_and_drop)
+    await conn._send_prepared_command({"id": 1, "method": "M", "params": {}})
+    assert client.write_gatt_char.await_count > 1  # header plus payload chunks
+
+    # A drop the backend notices surfaces as bleak's own error on a dead
+    # client -- part of the send contract -- never as `AttributeError`.
+    conn._ble_client = client
+    client.write_gatt_char = mock.AsyncMock(
+        side_effect=[None, bleak.exc.BleakError("disconnected")]
+    )
+    with raises(bleak.exc.BleakError):
+        await conn._send_prepared_command({"id": 1, "method": "M", "params": {}})
+
+
+async def test_a_drop_mid_reply_abandons_the_read_cleanly():
+    """The receive path runs inside bleak's notification dispatch.
+
+    An exception there surfaces as an unhandled-task traceback rather than
+    reaching any caller -- a drop between chunks raised `AttributeError` on
+    `None`. Now the read is abandoned the way a truncated response already
+    is; `_on_disconnected` separately fails the command in flight.
+    """
+    conn = ble.BleConnection.__new__(ble.BleConnection)
+    conn._lock = asyncio.Lock()
+    client = mock.AsyncMock()
+
+    # The stale-check window: cleared after the notification arrived but
+    # before the lock was taken. Nothing to read from; return, not raise.
+    conn._ble_client = None
+    await conn._on_rpc_data_received(None, bytearray(b"\x00\x00\x00\x05"))
+
+    # A drop that surfaces as bleak's error mid-read is abandoned the way a
+    # truncated response already is.
+    conn._ble_client = client
+    client.read_gatt_char = mock.AsyncMock(
+        side_effect=[b"x", bleak.exc.BleakError("disconnected")]
+    )
+    await conn._on_rpc_data_received(None, bytearray(b"\x00\x00\x00\x05"))
+
+    # The window itself: `_on_disconnected` clears `_ble_client` between
+    # chunks. The client bound under the lock finishes the read it started
+    # instead of dereferencing `None` on the next chunk.
+    conn._rpc_futures = {}
+    conn._ble_client = client
+    reply = b'{"id": 9}'
+    chunks = iter([reply[:4], reply[4:]])
+
+    async def clear_mid_read(*args, **kwargs):
+        conn._ble_client = None
+        return next(chunks)
+
+    client.read_gatt_char = mock.AsyncMock(side_effect=clear_mid_read)
+    await conn._on_rpc_data_received(None, bytearray(len(reply).to_bytes(4, "big")))


### PR DESCRIPTION
## What

Both GATT paths in `BleConnection` check `self._ble_client` outside the lock and dereference it inside — and `_on_disconnected` sets it to `None`, so every `await` between chunks is a window. Reproduced both:

- **Send** (`_send_prepared_command`): a drop after the length header is written but before the payload chunks raises `AttributeError: 'NoneType' object has no attribute 'write_gatt_char'` instead of the `NotConnectedError` the transport contract promises — and that this method's own comment insists on.
- **Receive** (`_on_rpc_data_received`): a drop between chunks of a multi-chunk reply raises `AttributeError: 'NoneType' object has no attribute 'read_gatt_char'` inside bleak's notification dispatch, where it surfaces as an unhandled-task traceback rather than reaching any caller.

This is precisely the bug the websocket transport was already fixed for — `wss._send_prepared_command` re-reads `_sock` under the lock with the comment "a check made before acquiring the lock can be stale by the time the send happens." BLE never got the same treatment.

## Fix

Mirror the wss fix on both paths: re-read under the lock, bind once, and finish the exchange on the bound client. On send, a `None` re-read raises `NotConnectedError`; a drop the backend notices mid-payload surfaces as bleak's own error on a dead client, never `AttributeError`. On receive, a `None` re-read returns, and a `BleakError` mid-read abandons the reply the way a truncated response already is — `_on_disconnected` separately fails the command in flight.

## Tests

Both fail against unpatched `main` (with the two `AttributeError`s above), verified:

- `test_a_drop_mid_send_raises_the_contract_error`
- `test_a_drop_mid_reply_abandons_the_read_cleanly`

870 pass, `ruff check`, `ruff format --check` and `mypy .` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
