### PR TITLE
Ignore a state frame that arrives before start()

### DIFF
--- a/pytboss/api.py
+++ b/pytboss/api.py
@@ -174,6 +174,15 @@ class PitBoss:
             status_payload,
             temperatures_payload,
         )
+        if not hasattr(self, "spec"):
+            # The callback is registered in `__init__` but the spec only
+            # exists once `start()` has resolved it -- and a transport can
+            # already be connected and receiving before then: Home Assistant
+            # connects through `reset_device` during discovery and calls
+            # `start()` later. A frame in that window has nothing to parse
+            # it; the next push arrives seconds after `start()` completes.
+            _LOGGER.debug("Ignoring state received before start()")
+            return
         state = StateDict()
         if status_payload and (
             new_state := self.spec.control_board.parse_status(status_payload)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1298,3 +1298,25 @@ async def test_board_gated_commands_never_raise_a_bare_keyerror():
                 pass
         checked += 1
     assert checked > 100  # the sweep really covered the catalogue
+
+
+async def test_state_arriving_before_start_is_ignored():
+    """A transport can be connected and receiving before `start()` runs.
+
+    Home Assistant connects through `reset_device` during discovery and
+    calls `start()` later. The state callback is registered in `__init__`,
+    but the spec that parses frames only exists once `start()` resolves it
+    -- a frame in that window raised `AttributeError` inside the
+    transport's dispatch, where no caller sees it.
+    """
+    conn = FakeTransport()
+    pitboss = api.PitBoss(conn, "PBV4PS2")
+    await conn.connect()
+
+    await conn.send_state(STATE_HEX)  # before start(): ignored, not a crash
+
+    await pitboss.start()
+    received = []
+    await pitboss.subscribe_state(received.append)
+    await conn.send_state(STATE_HEX)  # after start(): parsed as ever
+    assert received and received[0]["moduleIsOn"] is True


### PR DESCRIPTION
## What

`PitBoss.__init__` registers `_on_state_received` on the transport immediately, but `self.spec` — the thing that parses frames — only exists once `start()` has resolved it. A transport can already be connected and receiving in that window: Home Assistant connects through `reset_device` during discovery and calls `start()` later (the ordering `ble.py`'s own comments document). A frame arriving then raises:

```
AttributeError: 'PitBoss' object has no attribute 'spec'
```

— inside the transport's dispatch, where no caller sees it. On BLE that's an unhandled task exception in bleak's notification handler; on WSS the read loop's per-payload handler logs it.

## Fix

The pre-`start()` frame is ignored with a DEBUG log. There is nothing useful to do with it — no spec exists to parse it, and the next push arrives seconds after `start()` completes. (Resolving the spec in `__init__` instead would move where `InvalidGrill` raises, which downstream setup code sequences around deliberately, so the guard is the surgical fix.)

## Test

`test_state_arriving_before_start_is_ignored` — a frame before `start()` must not crash, and a frame after `start()` must parse as ever. Fails against unpatched `main` with the `AttributeError` above, verified.

886 pass, `ruff check`, `ruff format --check` and `mypy .` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
