### PR TITLE
Fail in-flight commands on an explicit BLE disconnect

### DIFF
--- a/pytboss/ble.py
+++ b/pytboss/ble.py
@@ -176,6 +176,12 @@ class BleConnection(Transport):
             # `NotConnectedError` every other transport raises.
             self._ble_client = None
         self._is_connected = False
+        # Not left to bleak's disconnected callback: when `disconnect()`
+        # itself raised above, or on a backend that does not fire the
+        # callback for a locally-initiated disconnect, nothing else fails
+        # the commands in flight and their callers wait out the full
+        # timeout. Idempotent with the callback path.
+        await self._fail_pending_commands()
 
     async def reset_device(self, ble_device: BLEDevice):
         """Resets the BLE device used for transport.

--- a/tests/test_ble.py
+++ b/tests/test_ble.py
@@ -844,3 +844,38 @@ async def test_a_drop_mid_reply_abandons_the_read_cleanly():
 
     client.read_gatt_char = mock.AsyncMock(side_effect=clear_mid_read)
     await conn._on_rpc_data_received(None, bytearray(len(reply).to_bytes(4, "big")))
+
+
+async def test_disconnect_fails_the_commands_in_flight():
+    """`disconnect()` must not leave callers waiting out their timeout.
+
+    Failing the in-flight commands was left entirely to bleak's
+    disconnected callback -- but when `client.disconnect()` itself raises
+    (caught and logged above), or on a backend that does not fire the
+    callback for a locally-initiated disconnect, nothing else fails them
+    and every caller waits the full 30s to learn nothing.
+    """
+    conn = ble.BleConnection.__new__(ble.BleConnection)
+    conn._lock = asyncio.Lock()
+    conn._lifecycle_lock = asyncio.Lock()
+    conn._rpc_futures = {}
+    conn._last_command_id = 0
+    conn._loop = asyncio.get_running_loop()
+    conn._is_connected = True
+    conn._reconnecting = False
+    client = mock.AsyncMock()
+    # The nastier half: even the disconnect itself fails, so the
+    # disconnected callback certainly never fires.
+    client.disconnect = mock.AsyncMock(
+        side_effect=bleak.exc.BleakError("backend refused")
+    )
+    conn._ble_client = client
+
+    cmd = asyncio.create_task(conn.send_command("PB.GetState", {}, timeout=30))
+    await asyncio.sleep(0.05)  # let it reach the wire and register its future
+
+    await conn.disconnect()
+
+    async with asyncio.timeout(3):
+        with raises(NotConnectedError):
+            await cmd


### PR DESCRIPTION
## What

`BleConnection._disconnect_locked` never fails the commands in flight — that is left entirely to bleak invoking the disconnected callback. Two real paths skip it:

- `client.disconnect()` itself raises (caught and logged with "Bluetooth is awful" — accurate), so the backend may never deliver the callback;
- a backend that does not fire `disconnected_callback` for a locally-initiated disconnect.

Either way, an in-flight `send_command` waits out its full 30s timeout to learn what `disconnect()` already knew. Reproduced: command in flight, `disconnect()` with a client whose `disconnect` raises `BleakError` — the command was still pending after `disconnect()` returned.

The websocket transport already fails its own in-flight commands on wind-down; BLE now matches.

## Fix

One call at the end of `_disconnect_locked`: `await self._fail_pending_commands()`. Idempotent with the callback path — `_fail_pending_commands` snapshots-and-clears under the lock and skips already-done futures, so the callback arriving as well is harmless.

## Test

`test_disconnect_fails_the_commands_in_flight` — in-flight command, disconnect whose `client.disconnect()` raises; the caller must get `NotConnectedError` promptly. Fails against unpatched `main` (times out with the command still pending), verified.

886 pass, `ruff check`, `ruff format --check` and `mypy .` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
