### PR TITLE
Raise from a fire-and-forget send the other transports refuse

### DIFF
--- a/pytboss/http.py
+++ b/pytboss/http.py
@@ -175,7 +175,15 @@ class HttpConnection(Transport):
         :param method: The method to call.
         :param params: Parameters to send with the command.
         :param timeout: Ignored. Nothing is awaited, so nothing can elapse.
+        :raise pytboss.exceptions.NotConnectedError: If the transport is not
+            connected. Raised here rather than swallowed in the background
+            task: "the board rebooted before answering" and "nothing was
+            ever sent" are different endings, and the other transports
+            raise for the second one -- a caller's `reboot()` should not
+            report success on a transport that was never connected.
         """
+        if not self._started or self._session is None or self._session.closed:
+            raise NotConnectedError("Not connected")
         cmd = await self._prepare_command(method, params)
         task = self._loop.create_task(self._send_and_forget(cmd))
         # Held so the task is not collected mid-flight, and so `disconnect()`

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -528,3 +528,36 @@ async def test_connect_maps_a_bare_timeout_to_the_documented_error(host):
     ):
         await conn.connect()
     assert not conn.is_connected()
+
+
+async def test_fire_and_forget_on_a_dead_transport_says_so(host):
+    """The three transports must agree on what a doomed send does.
+
+    BLE and WSS raise `NotConnectedError` synchronously from
+    `send_command_without_answer`; here the guard lived inside the
+    background task, where `_send_and_forget` swallowed it -- so
+    `PitBoss.reboot()` over HTTP reported success on a transport that was
+    never connected, or had been disconnected.
+    """
+    conn = HttpConnection(host)
+
+    # Never connected.
+    with pytest.raises(NotConnectedError):
+        await conn.send_command_without_answer("Sys.Reboot", {})
+
+    # Connected, then explicitly disconnected.
+    await conn.connect()
+    await conn.disconnect()
+    with pytest.raises(NotConnectedError):
+        await conn.send_command_without_answer("Sys.Reboot", {})
+
+
+async def test_fire_and_forget_still_swallows_the_expected_silence(rpc, host):
+    """A board that reboots before answering stays a clean ending."""
+    conn = HttpConnection(host)
+    await conn.connect()
+    rpc.status = 500  # the in-flight request fails; nobody is waiting
+    await conn.send_command_without_answer("Sys.Reboot", {})
+    for task in list(conn._pending):
+        await asyncio.gather(task, return_exceptions=True)
+    await conn.disconnect()


### PR DESCRIPTION
## What

`send_command_without_answer` on the HTTP transport spawns `_send_and_forget`, whose `except Exception` deliberately swallows everything — the right call for "the board rebooted before it could answer". But the `NotConnectedError` from `_send_prepared_command`'s own `_started` guard is swallowed by the same net, so:

```python
conn = HttpConnection(host)          # never connected
await PitBoss(conn, model).reboot()  # returns cleanly -- nothing was sent
```

BLE and WSS raise `NotConnectedError` synchronously from the base-class `send_command_without_answer` on the identical call — the three transports disagree on the contract, and the HTTP one reports success for a send that never left.

## Fix

The connected-check runs synchronously in `send_command_without_answer`, before the task is spawned — same predicate `_send_prepared_command` uses. The background swallow keeps covering only what it was written for: in-flight endings from a board that is genuinely gone mid-request.

## Tests

- `test_fire_and_forget_on_a_dead_transport_says_so` — never-connected and connected-then-disconnected both raise. Fails against unpatched `main`, verified.
- `test_fire_and_forget_still_swallows_the_expected_silence` — a failing in-flight request stays a clean ending, pinning that the fix did not over-reach.

887 pass, `ruff check`, `ruff format --check` and `mypy .` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
