### PR TITLE
Make connect()'s own handshake cancellable, and roll back on failure

### DIFF
--- a/pytboss/wss.py
+++ b/pytboss/wss.py
@@ -93,10 +93,34 @@ class WebSocketConnection(Transport):
             if not self._session_owned:
                 raise NotConnectedError("The session given to this transport is closed")
             self._session = ClientSession(loop=self._loop)
-        self._sock = await self._ws_connect()
-        self._keep_running = True
-        self._stopping.clear()
-        self._subscribe_task = self._loop.create_task(self._subscribe())
+        # Run as a task for the same reason the reconnect loop runs its own:
+        # no flag reaches a handshake in flight. `disconnect()` cancels
+        # `_connect_task` *before* taking the lifecycle lock -- the lock this
+        # call is holding -- so a caller is not parked behind a stalled
+        # handshake for aiohttp's full session timeout.
+        self._connect_task = self._loop.create_task(self._ws_connect())
+        try:
+            self._sock = await self._connect_task
+            self._keep_running = True
+            self._stopping.clear()
+            self._subscribe_task = self._loop.create_task(self._subscribe())
+        except BaseException as ex:
+            # The rollback `http.connect()` already has: a failed or
+            # cancelled connect must not leak the session this call opened.
+            # A config flow constructing a fresh transport per attempt
+            # otherwise leaks one per retry.
+            if self._session_owned and self._session is not None:
+                if not self._session.closed:
+                    await self._session.close()
+                self._session = None
+            if isinstance(ex, asyncio.CancelledError) and self._handshake_cancelled:
+                raise NotConnectedError(
+                    "disconnect() was called while connecting"
+                ) from ex
+            raise
+        finally:
+            self._connect_task = None
+            self._handshake_cancelled = False
         await self._subscribed.wait()
 
     def _check_not_reentrant(self) -> None:
@@ -152,6 +176,12 @@ class WebSocketConnection(Transport):
         for the background reconnect/subscribe task to finish.
         """
         self._check_not_reentrant()
+        # Cancelled before taking the lock: a `connect()` parked in its
+        # handshake is HOLDING the lock, so waiting for it first means
+        # waiting out aiohttp's session timeout before this could act.
+        if (handshake := self._connect_task) is not None:
+            self._handshake_cancelled = True
+            handshake.cancel()
         async with self._lifecycle_lock:
             await self._disconnect_locked()
 

--- a/tests/test_wss.py
+++ b/tests/test_wss.py
@@ -757,3 +757,44 @@ async def test_a_temperatures_only_push_reaches_the_callback_as_temperatures(
             call("FE0B00", temps_frame),  # the two-frame case is untouched
         ]
     )
+
+
+async def test_a_failed_connect_does_not_leak_the_owned_session() -> None:
+    """`http.connect()` rolls back on failure; this one left its session open.
+
+    A config flow constructing a fresh transport per attempt leaked one
+    `ClientSession` per retry, each printing aiohttp's "Unclosed client
+    session" when abandoned.
+    """
+    conn = wss.WebSocketConnection("_grill_id_", base_url="ws://127.0.0.1:9")
+    with raises(GrillUnavailable):
+        await conn.connect()
+    assert conn._session is None  # closed and released, not leaked
+
+
+async def test_disconnect_interrupts_a_connect_stuck_in_its_handshake() -> None:
+    """`connect()` holds the lifecycle lock across its handshake.
+
+    The reconnect loop's handshake was made cancellable, but `connect()`'s
+    own was not -- and `disconnect()` blocks on the lock `connect()` is
+    holding, so it waited out aiohttp's session timeout (minutes) behind a
+    handshake to a host that never answers.
+    """
+    conn = wss.WebSocketConnection("_grill_id_", base_url="ws://127.0.0.1:9")
+    hang = Event()
+
+    async def hung_handshake():
+        await hang.wait()
+        raise AssertionError("unreachable")
+
+    with patch.object(conn, "_ws_connect", hung_handshake):
+        connect_task = create_task(conn.connect())
+        await sleep(0.1)  # let it take the lock and park in the handshake
+
+        async with timeout(3):
+            await conn.disconnect()
+
+        with raises(NotConnectedError, match="disconnect"):
+            async with timeout(3):
+                await connect_task
+    hang.set()


### PR DESCRIPTION
## What

Two holes in `_connect_locked`, both proved by running code:

**1. A failed `connect()` leaks the owned session.** `_connect_locked` creates its `ClientSession`, then `_ws_connect` raises `GrillUnavailable` — nothing closes what was just opened. A caller that abandons the transport (a config flow constructing a fresh one per attempt) leaks one session per retry, each printing aiohttp's `Unclosed client session`. `http.connect()` has exactly the rollback this path lacked.

**2. `connect()`'s own handshake is the one the lifecycle work never covered.** #572 made the *reconnect loop's* handshake cancellable via `_connect_task`, but `connect()`'s own remained a bare `await self._ws_connect()` — executed while holding `_lifecycle_lock`. `disconnect()` blocks on that same lock, so against a host that accepts nothing, `disconnect()` queues behind the stalled handshake for aiohttp's session timeout (5 minutes by default). Measured: with `connect()` parked in the handshake, `disconnect()` had not returned after 0.5s and could only be freed by externally cancelling the connect task.

## Fix

- The handshake runs as `_connect_task`, exactly as the reconnect loop's does, reusing the `_handshake_cancelled` disambiguation #572 introduced.
- `disconnect()` cancels `_connect_task` *before* taking the lifecycle lock — the lock `connect()` is holding is precisely why waiting first cannot work.
- The cancelled `connect()` rolls back and raises `NotConnectedError("disconnect() was called while connecting")`; any other failure (including `GrillUnavailable`) rolls back — owned session closed and released — and re-raises. `_connect_task`/`_handshake_cancelled` are cleared in a `finally`, same discipline as the reconnect path.

## Tests

Both fail against unpatched `main`, verified:

- `test_a_failed_connect_does_not_leak_the_owned_session` — the failing run even prints the "Unclosed client session" warning this removes.
- `test_disconnect_interrupts_a_connect_stuck_in_its_handshake` — `disconnect()` completes within its 3s bound and `connect()` surfaces the documented error; on main the disconnect times out behind the lock.

887 pass, `ruff check`, `ruff format --check` and `mypy .` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
