### PR TITLE
Deliver callbacks from their own task, not from the read loop

### DIFF
--- a/pytboss/wss.py
+++ b/pytboss/wss.py
@@ -2,7 +2,7 @@
 
 import asyncio
 import logging
-from asyncio import AbstractEventLoop, Event, Lock, Task
+from asyncio import AbstractEventLoop, Event, Lock, Queue, Task
 from contextlib import suppress
 from typing import Any
 from uuid import uuid4
@@ -58,6 +58,14 @@ class WebSocketConnection(Transport):
         self._url = f"{base_url}/to/{grill_id}"
         self._app_id = app_id or str(uuid4()).split("-")[-1]
         self._subscribe_task: Task | None = None
+        # Callbacks are delivered from their own task, fed by this queue, so
+        # the read loop never awaits user code. A callback that issues an
+        # RPC otherwise waits on a reply only the read loop it is blocking
+        # can deliver -- burning the command's whole timeout -- and every
+        # state update queues behind it. Rebuilt on each connect so a stale
+        # frame from a previous session is never delivered into a new one.
+        self._callback_queue: Queue[tuple[str, Any]] = Queue()
+        self._dispatch_task: Task | None = None
         self._subscribed = Event()
         self._stopping = Event()
         self._keep_running = False
@@ -103,7 +111,9 @@ class WebSocketConnection(Transport):
             self._sock = await self._connect_task
             self._keep_running = True
             self._stopping.clear()
+            self._callback_queue = Queue()
             self._subscribe_task = self._loop.create_task(self._subscribe())
+            self._dispatch_task = self._loop.create_task(self._dispatch_callbacks())
         except BaseException as ex:
             # The rollback `http.connect()` already has: a failed or
             # cancelled connect must not leak the session this call opened.
@@ -132,7 +142,10 @@ class WebSocketConnection(Transport):
         lock awaits the very subscribe task this caller is running on -- a
         deadlock the guard exists to prevent, not cause.
         """
-        if self._subscribe_task is asyncio.current_task():
+        current = asyncio.current_task()
+        if current is not None and (
+            current is self._subscribe_task or current is self._dispatch_task
+        ):
             raise RuntimeError(
                 "Cannot stop this transport from a callback it is dispatching"
             )
@@ -167,6 +180,14 @@ class WebSocketConnection(Transport):
             # The event means "the loop is reading". Left set, the next
             # `connect()` returns before that is true again.
             self._subscribed.clear()
+        if self._dispatch_task is not None:
+            # Cancelled rather than drained: draining means awaiting user
+            # callbacks, and a stuck callback would turn `disconnect()` into
+            # exactly the hang this task exists to prevent.
+            self._dispatch_task.cancel()
+            with suppress(asyncio.CancelledError):
+                await self._dispatch_task
+            self._dispatch_task = None
 
     async def disconnect(self) -> None:
         """Stops the connection to the device.
@@ -296,6 +317,31 @@ class WebSocketConnection(Transport):
             async with asyncio.timeout(backoff):
                 await self._stopping.wait()
 
+    async def _dispatch_callbacks(self) -> None:
+        """Deliver state and vdata payloads from the read loop's queue.
+
+        On its own task so the read loop never awaits user code. A callback
+        that issues an RPC otherwise waits on a reply that only the read
+        loop it is blocking can deliver -- the command burns its whole
+        timeout with the answer sitting unread in the socket, and every
+        state update queues behind it. A single consumer keeps delivery in
+        arrival order. Cancelled by the wind-down; one failing callback is
+        logged and must not starve the rest.
+        """
+        while True:
+            kind, payload = await self._callback_queue.get()
+            try:
+                if kind == "status":
+                    if self._state_callback:
+                        await self._state_callback(*payload)
+                elif self._vdata_callback:
+                    await self._vdata_callback(payload)
+            except Exception:
+                _LOGGER.exception("Error in %s callback for: %s", kind, payload)
+            finally:
+                # So `join()` can observe delivery, not just consumption.
+                self._callback_queue.task_done()
+
     async def _handle_message(self, payload: dict[str, Any]) -> None:
         if "app_id" in payload and payload["app_id"] != self._app_id:
             _LOGGER.debug(
@@ -315,7 +361,7 @@ class WebSocketConnection(Transport):
             #
             # so it has to be picked up here, before returning.
             if (vdata := payload.get("data")) is not None and self._vdata_callback:
-                await self._vdata_callback(vdata)
+                self._callback_queue.put_nowait(("vdata", vdata))
             if not self._state_callback:
                 return
             frames = payload["status"]
@@ -333,9 +379,9 @@ class WebSocketConnection(Transport):
                 # the *status* payload -- where every board's status routine
                 # requires an FE0B prefix and returns nothing. Routed by the
                 # frame's own prefix instead, the way `ble` already does.
-                await self._state_callback(None, frames[0])
+                self._callback_queue.put_nowait(("status", (None, frames[0])))
                 return
-            await self._state_callback(*frames)
+            self._callback_queue.put_nowait(("status", tuple(frames)))
             return
 
         if "id" in payload:

--- a/tests/test_wss.py
+++ b/tests/test_wss.py
@@ -263,9 +263,9 @@ async def test_state_callback_may_send_commands(
 ) -> None:
     """The receive loop must not hold the send lock while dispatching.
 
-    Awaiting the *response* inside a callback can never complete -- the
-    response is read by the very loop the callback is blocking -- but the
-    send itself must go through rather than deadlock the stream forever.
+    The send must go through rather than deadlock the stream. (Awaiting a
+    full round trip from a callback works too, now that callbacks run on
+    their own task -- pinned separately below.)
     """
     done = Event()
 
@@ -334,6 +334,21 @@ async def test_status_no_state_callback(conn: wss.WebSocketConnection) -> None:
     await conn._handle_message({"status": ["state"]})
 
 
+async def deliver_queued_callbacks(conn: wss.WebSocketConnection) -> None:
+    """Run the dispatcher over whatever `_handle_message` queued.
+
+    Direct `_handle_message` tests have no running dispatch task; callbacks
+    are delivered from one, not from the read loop.
+    """
+    task = create_task(conn._dispatch_callbacks())
+    try:
+        async with timeout(2):
+            await conn._callback_queue.join()
+    finally:
+        task.cancel()
+        await asyncio.gather(task, return_exceptions=True)
+
+
 async def test_vdata_arrives_on_the_status_push(
     conn: wss.WebSocketConnection,
 ) -> None:
@@ -351,6 +366,7 @@ async def test_vdata_arrives_on_the_status_push(
     await conn._handle_message(
         {"id": -1, "src": "PBx", "status": ["FE0B00"], "data": {"p1T": 165}}
     )
+    await deliver_queued_callbacks(conn)
 
     vdata_callback.assert_awaited_once_with({"p1T": 165})
     state_callback.assert_awaited_once_with("FE0B00")
@@ -374,6 +390,7 @@ async def test_vdata_with_no_callback_registered(
     state_callback = AsyncMock()
     conn.set_state_callback(state_callback)
     await conn._handle_message({"status": ["FE0B00"], "data": {"p1T": 165}})
+    await deliver_queued_callbacks(conn)
     state_callback.assert_awaited_once_with("FE0B00")
 
 
@@ -618,30 +635,23 @@ async def test_a_cancellation_we_did_not_ask_for_is_not_swallowed(
         await task
 
 
-async def test_a_callback_disconnect_does_not_deadlock_an_outside_one(
+async def test_an_outside_disconnect_is_not_blocked_by_a_parked_callback(
     conn: wss.WebSocketConnection,
     state_payloads: Queue,
 ) -> None:
-    """The reentrancy guard has to run before the lifecycle lock is taken.
+    """A slow subscriber must not hold up `disconnect()`.
 
-    Past the lock, a subscriber calling `disconnect()` waits on the lock
-    while the lock's holder awaits the very subscribe task that is
-    dispatching that subscriber. Neither side can proceed, and unlike the
-    self-await this guard replaced, nothing raises: the hang is permanent.
+    Callbacks run on the dispatch task, not the read loop, so the wind-down
+    no longer waits behind user code: the subscribe task ends promptly and
+    the parked callback is cancelled with the dispatch task.
     """
     in_callback = Event()
-    release = Event()
-    callback_saw: list[BaseException] = []
 
     async def on_state(
         status_payload: str | None, temperatures_payload: str | None = None
     ) -> None:
         in_callback.set()
-        await release.wait()
-        try:
-            await conn.disconnect()
-        except RuntimeError as ex:
-            callback_saw.append(ex)
+        await sleep(3600)  # a subscriber that never comes back
 
     conn.set_state_callback(on_state)
     await conn.connect()
@@ -649,17 +659,44 @@ async def test_a_callback_disconnect_does_not_deadlock_an_outside_one(
     async with timeout(3):
         await in_callback.wait()
 
-    # An outside disconnect() -- a config entry unloading -- takes the lock
-    # and awaits the subscribe task, which is parked in the callback above.
-    outside = create_task(conn.disconnect())
-    await sleep(0.1)
-    release.set()
-
     async with timeout(3):
-        await outside
+        await conn.disconnect()
+
+
+async def test_a_callback_calling_disconnect_is_told_no(
+    conn: wss.WebSocketConnection,
+    state_payloads: Queue,
+) -> None:
+    """The reentrancy guard covers the dispatch task too.
+
+    `disconnect()` cancels the dispatch task during wind-down; from inside a
+    callback that is a lifecycle call cancelling its own caller, so it is
+    refused the same way it is from the read loop.
+    """
+    callback_saw: list[BaseException] = []
+    done = Event()
+
+    async def on_state(
+        status_payload: str | None, temperatures_payload: str | None = None
+    ) -> None:
+        if done.is_set():
+            return
+        try:
+            await conn.disconnect()
+        except RuntimeError as ex:
+            callback_saw.append(ex)
+        done.set()
+
+    conn.set_state_callback(on_state)
+    await conn.connect()
+    await state_payloads.put({"status": ["FE0B00"]})
+    async with timeout(3):
+        await done.wait()
+
     assert len(callback_saw) == 1
     with raises(RuntimeError, match="Cannot stop this transport"):
         raise callback_saw[0]
+    await conn.disconnect()  # from outside, it works as ever
 
 
 @patch.object(wss.WebSocketConnection, "_backoff_wait")
@@ -798,3 +835,41 @@ async def test_disconnect_interrupts_a_connect_stuck_in_its_handshake() -> None:
             async with timeout(3):
                 await connect_task
     hang.set()
+
+
+async def test_a_callback_can_await_a_full_round_trip(
+    conn: wss.WebSocketConnection,
+    state_payloads: Queue,
+    command_payloads: Queue,
+) -> None:
+    """An RPC issued from a state callback must complete, promptly.
+
+    Callbacks used to be awaited by the read loop itself, so a callback
+    awaiting a command waited on a reply that only the loop it was blocking
+    could deliver: the command burned its whole timeout with the answer
+    sitting unread in the socket, and every state update queued behind it.
+    """
+    import time
+
+    outcome: dict = {}
+    done = Event()
+
+    async def on_state(
+        status_payload: str | None, temperatures_payload: str | None = None
+    ) -> None:
+        if done.is_set():
+            return
+        start = time.monotonic()
+        outcome["result"] = await conn.send_command("RPC.Ping", {}, timeout=5)
+        outcome["elapsed"] = time.monotonic() - start
+        done.set()
+
+    conn.set_state_callback(on_state)
+    async with conn:
+        await command_payloads.put({"app_id": "_app_id_", "id": 1, "result": "pong"})
+        await state_payloads.put({"status": ["FE0B00"]})
+        async with timeout(4):
+            await done.wait()
+
+    assert outcome["result"] == "pong"
+    assert outcome["elapsed"] < 2  # answered, not waited out


### PR DESCRIPTION
> **Stacked on #584** (same file, same lifecycle machinery) — the first commit here is that PR; this one is `deliver callbacks from their own task, not from the read loop`. Merging #584 first collapses this to a one-commit diff.

## What

The websocket read loop awaits `_handle_message` — and with it every subscriber callback — inline. A subscriber that issues an RPC from its callback therefore waits on a reply that only the read loop it is blocking can deliver. Measured: a `ping()` that completes in 0.000s outside a callback times out at exactly its full deadline inside one, with the answer sitting unread in the socket the whole time — and every state update queues behind it (a frame sent at t=0.2s was delivered at t=2.0s). At the default timeout that is a 30s stall of all state updates per callback-issued RPC. A slow callback also holds up `disconnect()`, which awaits the subscribe task.

The API layer explicitly blesses subscriber callbacks; its own `_callback_lock` comment documents dispatching outside the lock precisely so subscribers can call back into the API — which then doesn't work on this transport for any command that expects an answer.

## Fix

Callbacks flow through a queue consumed by a dedicated dispatch task:

- the read loop only enqueues (`put_nowait`) — it never awaits user code again, so replies are processed the moment they arrive;
- a **single** consumer preserves delivery order (arrival order), which per-frame `create_task` would not guarantee;
- the queue is rebuilt on each `connect()` so a stale frame from a previous session is never delivered into a new one;
- wind-down cancels the dispatcher rather than draining it — draining means awaiting the very user code this task exists to keep out of the way;
- the reentrancy guard covers the dispatch task too: a callback calling `disconnect()` would be a lifecycle call cancelling its own caller, so it is refused with the same error as from the read loop.

`test_state_callback_may_send_commands`' docstring — which documented "awaiting the response inside a callback can never complete" — is updated: it now can.

## Tests

- `test_a_callback_can_await_a_full_round_trip` — RPC from a state callback completes with the real result in <2s. Fails against the base branch (times out), verified.
- `test_an_outside_disconnect_is_not_blocked_by_a_parked_callback` — a subscriber sleeping forever no longer holds up `disconnect()`. Fails against the base branch, verified.
- `test_a_callback_calling_disconnect_is_told_no` — the reentrancy contract, now exercised through the dispatch task.
- The two direct `_handle_message` vdata tests drive the dispatcher explicitly via a small delivery helper (`task_done`/`join`, deterministic).

889 pass, `ruff check`, `ruff format --check` and `mypy .` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
