### PR TITLE
Answer "not served" the way the docstrings promise

### DIFF
--- a/pytboss/api.py
+++ b/pytboss/api.py
@@ -11,11 +11,11 @@ from typing import Any
 
 from .codec import WIFI_KEY, encode, timed_key
 from .config import Config
-from .exceptions import UnsupportedOperation
+from .exceptions import RPCError, UnsupportedOperation
 from .fs import FileSystem
 from .grills import Grill, StateDict, get_grill
 from .ota import OTA
-from .transport import RPCResult, Transport, as_dict
+from .transport import METHOD_NOT_FOUND_CODE, RPCResult, Transport, as_dict
 from .wifi import WiFi
 
 _UPTIME_TTL = 60.0
@@ -684,10 +684,17 @@ class PitBoss:
         `get_firmware_version()` reports: a grill on firmware 0.5.7 answers
         `0.2.2` here.
 
-        `None` when the grill does not serve `PBL.GetLoaderVersion`, which
-        `list_rpcs()` reports without a round trip that errors.
+        `None` when the grill does not serve `PBL.GetLoaderVersion`.
         """
-        result = await self._conn.send_command("PBL.GetLoaderVersion", {})
+        try:
+            result = await self._conn.send_command("PBL.GetLoaderVersion", {})
+        except RPCError as ex:
+            if ex.code == METHOD_NOT_FOUND_CODE:
+                # The documented None. Without this, a grill without the
+                # loader RPC raised instead of answering what the docstring
+                # promises.
+                return None
+            raise
         if isinstance(result, dict):
             return result.get("loaderVersion")
         return None
@@ -741,7 +748,15 @@ class PitBoss:
         :param timeout: Seconds to keep polling before giving up.
         :param poll_interval: Seconds between polls.
         """
-        await self.start_wifi_scan()
+        try:
+            await self.start_wifi_scan()
+        except RPCError as ex:
+            if ex.code == METHOD_NOT_FOUND_CODE:
+                # No loader: the documented empty, not an error. Only the
+                # first call needs the guard -- once the start is served,
+                # the status polls are too.
+                return []
+            raise
         deadline = monotonic() + timeout
         while monotonic() < deadline:
             await asyncio.sleep(poll_interval)

--- a/pytboss/transport.py
+++ b/pytboss/transport.py
@@ -59,6 +59,14 @@ def as_dict(result: RPCResult) -> dict[Any, Any]:
 UNAUTHORIZED_CODE = 401
 """The code the firmware answers with when the password is wrong or missing."""
 
+METHOD_NOT_FOUND_CODE = 404
+"""The code mg_rpc answers with for a method the device does not serve.
+
+Verified against a live grill: an unknown method is answered with
+``{"code": 404, "message": "No handler for <name>"}``, while a *failing*
+served method answers with a different code -- so "not served" is
+distinguishable from "went wrong"."""
+
 
 def _rpc_error(error: dict) -> RPCError:
     """Build the exception for an error payload from the device."""

--- a/pytboss/wifi.py
+++ b/pytboss/wifi.py
@@ -1,6 +1,7 @@
 """Client library for Mongoose OS WiFi RPCs."""
 
-from .transport import Transport
+from .exceptions import RPCError
+from .transport import METHOD_NOT_FOUND_CODE, Transport
 
 
 class WiFi:
@@ -36,13 +37,20 @@ class WiFi:
         Mongoose's JS `Wifi.scan()` instead. Same device, same networks, two
         spellings.
 
-        Empty when the device does not serve it. `PitBoss.list_rpcs()` reports
-        whether it does without a round trip that errors -- worth checking
-        first, since an empty list otherwise reads the same as seeing no
-        networks.
+        Empty when the device does not serve it -- an empty list reads the
+        same as seeing no networks, so `PitBoss.list_rpcs()` is the way to
+        tell those apart when it matters.
 
         Unauthenticated, and a read: it changes nothing about the device's own
         connection.
         """
-        result = await self._conn.send_command("Wifi.Scan", {})
+        try:
+            result = await self._conn.send_command("Wifi.Scan", {})
+        except RPCError as ex:
+            if ex.code == METHOD_NOT_FOUND_CODE:
+                # The documented empty. Without this, "the device does not
+                # serve it" raised instead of answering what the docstring
+                # promises.
+                return []
+            raise
         return result if isinstance(result, list) else []

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -118,10 +118,20 @@ class FakeTransport(Transport):
             "PBL.GetWifiScanStatus": self._get_wifi_scan_status,
         }
         resp = {"id": cmd["id"]}
+        handler = dispatch.get(cmd["method"])
+        if handler is None:
+            # The frame a live grill answers for a method it does not
+            # serve; distinct from a served handler failing, below.
+            resp["error"] = {
+                "code": 404,
+                "message": f"No handler for {cmd['method']}",
+            }
+            await self._on_command_response(resp)
+            return
         try:
             # Like the firmware: handlers that return null produce a reply
             # without a `result` key.
-            result = dispatch[cmd["method"]](cmd["params"])
+            result = handler(cmd["params"])
             if result is not None:
                 resp["result"] = result
         except Unauthorized:
@@ -793,11 +803,43 @@ async def test_get_loader_version(pitboss: api.PitBoss):
 
 
 async def test_get_loader_version_when_the_grill_has_no_loader():
+    """The real unserved-method answer is mg_rpc's 404 error frame.
+
+    The old test mocked `send_command` returning `None` -- a reply the "does
+    not serve it" case cannot produce -- so it certified the docstring
+    without testing it: the real path raised `RPCError`.
+    """
     conn = FakeTransport()
     pitboss = api.PitBoss(conn, "PBV4PS2")
     await pitboss.start()
-    with mock.patch.object(conn, "send_command", AsyncMock(return_value=None)):
+    with mock.patch.object(
+        conn,
+        "send_command",
+        AsyncMock(side_effect=RPCError("No handler for PBL.GetLoaderVersion", 404)),
+    ):
         assert await pitboss.get_loader_version() is None
+
+    # A loader that exists but *fails* is not silently read as absent.
+    with (
+        mock.patch.object(
+            conn, "send_command", AsyncMock(side_effect=RPCError("boom", -1))
+        ),
+        pytest.raises(RPCError),
+    ):
+        await pitboss.get_loader_version()
+
+
+async def test_scan_wifi_networks_when_the_grill_has_no_loader():
+    """`[]`, as documented -- not the `RPCError` the 404 frame arrives as."""
+    conn = FakeTransport()
+    pitboss = api.PitBoss(conn, "PBV4PS2")
+    await pitboss.start()
+    with mock.patch.object(
+        conn,
+        "send_command",
+        AsyncMock(side_effect=RPCError("No handler for PBL.StartWifiScan", 404)),
+    ):
+        assert await pitboss.scan_wifi_networks(timeout=0.2, poll_interval=0.01) == []
 
 
 async def test_get_state_updates_the_cached_state(conn: FakeTransport, password: str):
@@ -839,9 +881,15 @@ async def test_other_rpc_errors_keep_their_code():
     pitboss = api.PitBoss(conn, "PBV4PS2")
     await pitboss.start()
 
+    # An unknown method answers mg_rpc's 404, as a live grill does.
     with pytest.raises(RPCError) as caught:
         await pitboss._conn.send_command("No.SuchMethod", {})
     assert not isinstance(caught.value, Unauthorized)
+    assert caught.value.code == 404
+
+    # A served handler that fails keeps its own, different code.
+    with pytest.raises(RPCError) as caught:
+        await pitboss._conn.send_command("PB.SendMCUCommand", {})
     assert caught.value.code == -1
 
 

--- a/tests/test_wifi.py
+++ b/tests/test_wifi.py
@@ -3,7 +3,9 @@
 from unittest import mock
 
 import pytest
+from pytest import raises
 
+from pytboss.exceptions import RPCError
 from pytboss.wifi import WiFi
 
 NETWORK = {
@@ -31,10 +33,29 @@ async def test_scan_returns_the_array_as_sent(mock_conn):
 
 
 async def test_scan_when_the_device_does_not_serve_it(mock_conn):
+    """The real unserved-method answer is mg_rpc's 404 error frame.
+
+    The old version mocked a `None` reply -- a shape the "does not serve
+    it" case cannot produce -- so the docstring's "empty" was certified
+    while the real path raised `RPCError`.
+    """
+    mock_conn.send_command.side_effect = RPCError("No handler for Wifi.Scan", 404)
+    wifi = WiFi(mock_conn)
+    assert await wifi.scan() == []
+
+
+async def test_scan_when_the_device_answers_null(mock_conn):
     """Must not hand back a non-list, the same trap `RPC.List` had."""
     mock_conn.send_command.return_value = None
     wifi = WiFi(mock_conn)
     assert await wifi.scan() == []
+
+
+async def test_a_failing_scan_is_not_read_as_absent(mock_conn):
+    mock_conn.send_command.side_effect = RPCError("boom", -1)
+    wifi = WiFi(mock_conn)
+    with raises(RPCError):
+        await wifi.scan()
 
 
 async def test_scan_when_the_device_answers_an_object(mock_conn):


### PR DESCRIPTION
## What

Three wrappers document a graceful answer for a device that does not serve their RPC:

- `WiFi.scan()` — "Empty when the device does not serve it"
- `PitBoss.get_loader_version()` — "`None` when the grill does not serve `PBL.GetLoaderVersion`"
- `PitBoss.scan_wifi_networks()` — "Empty if … the grill serves no loader"

None of that was true. An unserved method is answered with an error frame, which `send_command` raises as `RPCError` — the `isinstance` guards only cover a *successful* reply of the wrong shape. The tests certified the docstrings by mocking replies the "does not serve it" case cannot produce (`send_command` returning `None`).

## Why the fix is a fix and not a doc change

Verified against a live grill: an unknown method answers

```json
{"code": 404, "message": "No handler for Totally.Bogus"}
```

while a **failing served** method answers a different code (e.g. `400` for a bad `FS.Get`). So "not served" is genuinely distinguishable from "went wrong", and the documented graceful answers can be real: the three wrappers catch `RPCError` with the new `METHOD_NOT_FOUND_CODE = 404` (documented next to `UNAUTHORIZED_CODE`, with the live-grill evidence) and return their documented empty/`None`. **Any other code keeps raising** — a loader that exists but fails is not silently read as absent, pinned by tests.

`FakeTransport` now models the 404 frame the way the firmware sends it (unknown method → 404, failing handler → its own code), so the fixture can no longer mask this class of bug.

## Tests

The three rewritten "does not serve it" tests drive the real error path and fail against unpatched `main` (verified); new failure-path tests pin that other codes still raise; `test_other_rpc_errors_keep_their_code` now distinguishes the unknown-method 404 from a served handler's own code.

894 pass, `ruff check`, `ruff format --check` and `mypy .` clean. No public signatures changed; ha-pitboss uses none of these three wrappers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
