### PR TITLE
Deliver the hashability frozen=True advertises

### DIFF
--- a/pytboss/grills.py
+++ b/pytboss/grills.py
@@ -297,8 +297,13 @@ class ControlBoard:
     name: str
     """Name of the control board."""
 
-    commands: dict[str, Command]
-    """Controller commands indexed by their slug."""
+    commands: dict[str, Command] = field(hash=False)
+    """Controller commands indexed by their slug.
+
+    Excluded from the hash (dicts are unhashable), so `frozen=True` delivers
+    the hashability it advertises. Equality still compares every field, and
+    equal boards agree on the hashable subset, so the `a == b` implies
+    `hash(a) == hash(b)` contract holds."""
 
     _status_js_func: str | None
     """JavaScript function body that parses a status reply."""
@@ -413,13 +418,18 @@ class Grill:
     meat_probes: int = 0
     """The number of meat probes available on the grill."""
 
-    temp_increments: list[int] | None = field(default_factory=list)
-    """Supported temperature increments, in Fahrenheit."""
+    temp_increments: list[int] | None = field(default_factory=list, hash=False)
+    """Supported temperature increments, in Fahrenheit.
 
-    json: dict[str, Any] = field(default_factory=dict)
+    This and the two container fields below are excluded from the hash
+    (lists and dicts are unhashable), so `frozen=True` delivers the
+    hashability it advertises -- `set(get_grills())` raised `TypeError`.
+    Equality still compares every field."""
+
+    json: dict[str, Any] = field(default_factory=dict, hash=False)
     """The raw JSON returned by the PitBoss API."""
 
-    celsius_temp_increments: list[int] | None = field(default_factory=list)
+    celsius_temp_increments: list[int] | None = field(default_factory=list, hash=False)
     """Supported temperature increments in Celsius, where the grill declares
     its own list. Most do not; theirs is derived from `temp_increments`.
 

--- a/tests/test_grills.py
+++ b/tests/test_grills.py
@@ -515,3 +515,23 @@ def test_boards_without_the_unit_flag_ignore_it():
     """PBL's routine takes one parameter; the extra flag must be harmless."""
     cmd = grills_lib.get_grill("PB1600PS1").control_board.commands["set-temperature"]
     assert cmd(110, False) == cmd(110)
+
+
+def test_frozen_types_are_hashable():
+    """`frozen=True` advertises hashability; the container fields broke it.
+
+    The generated `__hash__` hashed every field, and `commands`/`json` are
+    dicts, `temp_increments` a list -- so `hash(grill)` raised `TypeError`
+    and deduplicating models via a set, the obvious thing to do with a
+    frozen type, failed at runtime.
+    """
+    grills = list(grills_lib.get_grills())
+    deduped = set(grills)
+    assert len(deduped) == len(grills)  # every model hashes, none collide away
+
+    g1 = grills_lib.get_grill("PB1600PS1")
+    g2 = grills_lib.get_grill("PB1600PS1")
+    assert g1 == g2
+    assert hash(g1) == hash(g2)  # the eq/hash contract
+    assert len({g1, g2}) == 1
+    assert hash(g1.control_board) == hash(g2.control_board)


### PR DESCRIPTION
## What

`Grill` and `ControlBoard` are `frozen=True` dataclasses, which advertises hashability — but the generated `__hash__` hashes every field, and `commands`/`json` are dicts, `temp_increments`/`celsius_temp_increments` lists. So:

```python
>>> hash(get_grill("PB1600PS1"))
TypeError: unhashable type: 'dict'
>>> set(get_grills())
TypeError: cannot use 'pytboss.grills.Grill' as a set element
```

Deduplicating models via a set is the obvious thing a consumer does with a frozen type, and it fails at runtime.

## Fix

The container fields are excluded from the hash with `field(hash=False)`. Equality is untouched — it still compares every field — and since equal objects agree on the hashable subset, the `a == b ⟹ hash(a) == hash(b)` contract holds (objects differing only in a container field hash together and compare unequal, which is an allowed collision, not a violation).

No public signatures change; nothing downstream is affected — this only makes previously-crashing operations work.

## Test

`test_frozen_types_are_hashable` — every catalogue model hashes, none collide away in a set, and two `get_grill()` results for the same model are equal, hash equal, and dedupe to one. Fails against unpatched `main` with the `TypeError` above, verified.

892 pass, `ruff check`, `ruff format --check` and `mypy .` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
