### PR TITLE
Give the tests that assert nothing something to fail on

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -10,7 +10,7 @@ import pytest
 from freezegun import freeze_time
 
 from pytboss import api, grills
-from pytboss.codec import WIFI_KEY, decode, encode, timed_key
+from pytboss.codec import WIFI_KEY, decode, timed_key
 from pytboss.exceptions import (
     InvalidGrill,
     RPCError,
@@ -1188,16 +1188,6 @@ async def test_set_wifi_credentials_does_not_send_the_password_in_the_clear(
     with mock.patch.object(conn, "_send_prepared_command", capture):
         await pitboss.set_wifi_credentials("Kitchen", "hunter2")
     assert "hunter2" not in json.dumps(sent)
-
-
-async def test_set_wifi_credentials_is_not_the_config_service_key(
-    pitboss: api.PitBoss, conn: FakeTransport
-):
-    """Encoding under the grill password key must not decode as the WiFi one."""
-    await pitboss.set_wifi_credentials("Kitchen", "hunter2")
-    assert conn.wifi_credentials is not None
-    wrong = decode(bytes.fromhex(encode(b"hunter2").hex()), key=WIFI_KEY)
-    assert wrong != b"hunter2"
 
 
 async def test_debug_pstate(pitboss: api.PitBoss, conn: FakeTransport):

--- a/tests/test_grills.py
+++ b/tests/test_grills.py
@@ -57,11 +57,13 @@ class TestCommand:
 
 
 class TestController:
-    def parse_status(self):
+    # `test_` prefixes, or pytest collects nothing from this class: both
+    # bodies passed for as long as they existed, but neither ever ran.
+    def test_parse_status(self):
         ctrl = grills_lib.ControlBoard("PBx", {}, "return {'foo': message}", None)
         assert ctrl.parse_status("bar") == {"foo": "bar"}
 
-    def parse_temperatures(self):
+    def test_parse_temperatures(self):
         ctrl = grills_lib.ControlBoard("PBx", {}, "", "return {'foo': message}")
         assert ctrl.parse_temperatures("bar") == {"foo": "bar"}
 

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -392,14 +392,47 @@ async def test_send_command_without_answer_does_not_wait(host, rpc):
         await server.close()
 
 
-async def test_disconnect_stops_a_request_still_in_flight(host, rpc):
-    conn = HttpConnection(host)
-    await conn.connect()
-    await conn.send_command_without_answer("Sys.Reboot", {})
-    assert conn._pending
+async def test_disconnect_stops_a_request_still_in_flight():
+    """The request must actually be stopped, not just forgotten.
 
-    await conn.disconnect()
-    assert conn._pending == set()
+    The old version asserted `_pending == set()` -- satisfied by
+    `disconnect()`'s own `clear()` whether or not anything was cancelled.
+    Proved by mutation: removing the `task.cancel()` entirely still passed.
+    Now the request is genuinely parked server-side and the task's ending
+    is observed.
+    """
+    in_flight = asyncio.Event()
+
+    async def handler(request: web.Request) -> web.Response:
+        cmd = await request.json()
+        if cmd["method"] == "RPC.Ping":
+            return web.json_response(
+                {"id": cmd["id"], "result": {}}, content_type="text/plain"
+            )
+        in_flight.set()
+        await asyncio.sleep(30)
+        raise AssertionError("unreachable")
+
+    app = web.Application()
+    app.router.add_post("/rpc", handler)
+    server = TestServer(app)
+    await server.start_server()
+    try:
+        conn = HttpConnection(f"{server.host}:{server.port}")
+        await conn.connect()
+        await conn.send_command_without_answer("Sys.Reboot", {})
+        async with asyncio.timeout(3):
+            await in_flight.wait()  # genuinely on the wire
+        task = next(iter(conn._pending))
+
+        await conn.disconnect()
+
+        async with asyncio.timeout(3):
+            await asyncio.gather(task, return_exceptions=True)
+        assert task.cancelled()
+        assert conn._pending == set()
+    finally:
+        await server.close()
 
 
 async def test_a_non_json_body_is_reported_as_an_rpc_error():

--- a/tests/test_ota.py
+++ b/tests/test_ota.py
@@ -5,11 +5,12 @@ from unittest import mock
 import pytest
 
 from pytboss.ota import OTA
+from pytboss.transport import Transport
 
 
 @pytest.fixture
 def mock_conn():
-    conn = mock.AsyncMock()
+    conn = mock.AsyncMock(spec=Transport)
     conn.send_command = mock.AsyncMock(return_value={})
     return conn
 

--- a/tests/test_wifi.py
+++ b/tests/test_wifi.py
@@ -6,6 +6,7 @@ import pytest
 from pytest import raises
 
 from pytboss.exceptions import RPCError
+from pytboss.transport import Transport
 from pytboss.wifi import WiFi
 
 NETWORK = {
@@ -21,7 +22,7 @@ NETWORK = {
 
 @pytest.fixture
 def mock_conn():
-    conn = mock.AsyncMock()
+    conn = mock.AsyncMock(spec=Transport)
     conn.send_command = mock.AsyncMock(return_value=[NETWORK])
     return conn
 

--- a/tests/test_wss.py
+++ b/tests/test_wss.py
@@ -873,3 +873,31 @@ async def test_a_callback_can_await_a_full_round_trip(
 
     assert outcome["result"] == "pong"
     assert outcome["elapsed"] < 2  # answered, not waited out
+
+
+async def test_a_cancel_that_never_landed_does_not_mark_the_next_one(
+    conn: wss.WebSocketConnection,
+) -> None:
+    """The reconnect loop's `finally` must clear `_handshake_cancelled`.
+
+    The flag means "the cancellation about to arrive is ours". A cancel
+    that loses its race -- the handshake finishing first -- leaves no
+    cancellation to consume it; left set, the *next*, caller-owned
+    cancellation would read as ours and be swallowed, losing a shutdown.
+    Found as a mutation survivor: removing the reset passed the suite.
+    """
+    await conn.connect()
+
+    # A cancel that never landed.
+    conn._handshake_cancelled = True
+
+    # The stream ends; the loop reconnects, and the handshake it runs on
+    # the way back up must reset the flag in its finally.
+    assert conn._sock is not None
+    await conn._sock.close()
+    async with timeout(5):
+        while conn._sock is None or conn._sock.closed:
+            await sleep(0.01)
+
+    assert conn._handshake_cancelled is False
+    await conn.disconnect()


### PR DESCRIPTION
## What

Five test-hygiene fixes, all found by collection sweep and mutation testing. None change library code — this PR makes existing coverage honest.

**1. Two tests that never ran.** `TestController.parse_status`/`parse_temperatures` lack the `test_` prefix, so pytest collects nothing from that class — verified with `--collect-only`. They are the only direct unit tests of the `ControlBoard` parsers, and they have passed-if-run for as long as they've existed. Renamed; the suite gains two genuinely running tests.

**2. A test that asserts nothing about the code under test.** `test_set_wifi_credentials_is_not_the_config_service_key`'s load-bearing assertion exercises `codec.py` alone — the API call above it never feeds it. Proved by mutation: switching `set_wifi_credentials` to encode under the *grill* key still passed one parametrized variant. The sibling `test_set_wifi_credentials_obfuscates_the_password` already pins the key end-to-end (its docstring even explains why the round trip is the right assertion), so the inert test is deleted as false coverage rather than duplicated.

**3. A test satisfied by the code it was meant to check.** `test_disconnect_stops_a_request_still_in_flight` asserted `_pending == set()` — which `disconnect()`'s own `clear()` satisfies whether or not anything was cancelled. Proved by mutation: removing the `task.cancel()` entirely still passed. The request is now genuinely parked server-side (an event confirms it is on the wire) and the task's cancellation is observed directly. The mutation now fails it.

**4. A mutation survivor in the reconnect loop.** The `finally` clearing `_handshake_cancelled` had no test: removing it survived the whole wss suite. Its scenario — a cancel that never landed (the handshake finished first) must not make the *next*, caller-owned cancellation look like ours and be swallowed — is now pinned; the mutation fails on the intended assert.

**5. Unspecced mocks.** The ota/wifi fixtures used bare `AsyncMock()` while the fs/config siblings use `AsyncMock(spec=Transport)` — a call to a nonexistent transport method was silently absorbed. Specced to match.

892 pass (890 previously + the two recovered, − the one deleted), `ruff check`, `ruff format --check` and `mypy .` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
