### PR TITLE
Isolate state and vdata subscribers from each other

### DIFF
--- a/pytboss/api.py
+++ b/pytboss/api.py
@@ -211,7 +211,15 @@ class PitBoss:
             # TODO: Run callbacks concurrently
             # TODO: Send copies of state so subscribers can't modify it
             for callback in callbacks:
-                await _invoke(callback, self._state)
+                try:
+                    await _invoke(callback, self._state)
+                except Exception:
+                    # Isolated per subscriber: without this the first one to
+                    # raise skips every subscriber registered after it for
+                    # that update, and the exception escapes into the
+                    # transport's dispatch -- on BLE, an unhandled task
+                    # traceback in bleak's notification handler.
+                    _LOGGER.exception("Error in state subscriber")
 
     async def _on_vdata_received(self, payload: str | dict):
         # Both, because the transports differ in what they can hand over.
@@ -236,7 +244,11 @@ class PitBoss:
             # TODO: Run callbacks concurrently
             # TODO: Send copies of state so subscribers can't modify it
             for callback in callbacks:
-                await _invoke(callback, vdata)
+                try:
+                    await _invoke(callback, vdata)
+                except Exception:
+                    # Isolated per subscriber, as in `_on_state_received`.
+                    _LOGGER.exception("Error in vdata subscriber")
 
     async def _authenticate(self, params: dict) -> dict:
         """Return `params` with the encoded password added.

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1358,3 +1358,48 @@ async def test_state_arriving_before_start_is_ignored():
     await pitboss.subscribe_state(received.append)
     await conn.send_state(STATE_HEX)  # after start(): parsed as ever
     assert received and received[0]["moduleIsOn"] is True
+
+
+async def test_one_raising_state_subscriber_does_not_starve_the_rest():
+    """A subscriber that raises must not skip the ones registered after it.
+
+    The fan-out had no per-callback isolation, so the first to raise skipped
+    every later subscriber for that update and the exception escaped into
+    the transport's dispatch.
+    """
+    conn = FakeTransport()
+    pitboss = api.PitBoss(conn, "PBV4PS2")
+    await pitboss.start()
+    seen = []
+
+    async def bad(state):
+        seen.append("bad")
+        raise RuntimeError("subscriber blew up")
+
+    async def good(state):
+        seen.append("good")
+
+    await pitboss.subscribe_state(bad)
+    await pitboss.subscribe_state(good)
+
+    await conn.send_state(STATE_HEX)  # must not raise out
+
+    assert seen == ["bad", "good"]  # the raiser did not starve the rest
+
+
+async def test_one_raising_vdata_subscriber_does_not_starve_the_rest():
+    conn = FakeTransport()
+    pitboss = api.PitBoss(conn, "PBV4PS2")
+    await pitboss.start()
+    seen = []
+
+    async def bad(vdata):
+        seen.append("bad")
+        raise RuntimeError("boom")
+
+    await pitboss.subscribe_vdata(bad)
+    await pitboss.subscribe_vdata(lambda v: seen.append("good"))
+
+    await pitboss._on_vdata_received({"p1T": 165})
+
+    assert seen == ["bad", "good"]


### PR DESCRIPTION
## What

`PitBoss._on_state_received` and `_on_vdata_received` fan out to subscribers with a bare `for cb in callbacks: await _invoke(...)` and no per-callback isolation. So the first subscriber to raise:

1. skips every subscriber registered after it for that update, and
2. lets the exception escape out of the receive path — on BLE that surfaces as an unhandled-task traceback inside bleak's notification dispatch.

Reproduced (two state subscribers, first raises): only the raiser ran; the second never saw the update, and `RuntimeError` propagated out of `_on_state_received`.

The transport layer's own `wss._dispatch_callbacks` already wraps its single callback in `except Exception` — but the multi-subscriber loop lives one layer up, in `PitBoss`, where it had no such guard.

## Fix

Each callback invocation is wrapped in `try/except Exception` with `_LOGGER.exception`, matching the dispatcher's discipline. One raising subscriber no longer starves the rest or escapes the receive path. (The cache is advanced before dispatch, as before, so there's no state corruption — the bug was purely a fan-out isolation gap.)

## Tests

`test_one_raising_state_subscriber_does_not_starve_the_rest` and the vdata sibling — a raising subscriber must not skip the later ones or raise out. Both fail against unpatched `main`, verified.

900 pass, `ruff check`, `ruff format --check` and `mypy .` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
