### PR TITLE
Survive a subscribe task cancelled from outside

### DIFF
--- a/pytboss/wss.py
+++ b/pytboss/wss.py
@@ -173,6 +173,18 @@ class WebSocketConnection(Transport):
             # the lines below -- clearing state, and in `disconnect()`'s
             # case closing an owned session -- never ran.
             await self._subscribe_task
+        except asyncio.CancelledError:
+            # The subscribe task ended *cancelled* -- an outside cancellation
+            # (a shutdown sweep, a test harness reaping tasks), not our own
+            # caller being cancelled. `except Exception` does not catch this,
+            # so it used to escape `disconnect()` into a caller that never
+            # asked to be cancelled, and skipped the dispatch cancel and the
+            # owned-session close below. Distinguished from a cancellation
+            # aimed at *this* task, which must still be honoured.
+            task = asyncio.current_task()
+            if task is not None and task.cancelling() > 0:
+                raise
+            _LOGGER.debug("Subscribe task was cancelled")
         except Exception:
             _LOGGER.exception("Subscribe task ended with an unhandled error")
         finally:

--- a/tests/test_wss.py
+++ b/tests/test_wss.py
@@ -901,3 +901,69 @@ async def test_a_cancel_that_never_landed_does_not_mark_the_next_one(
 
     assert conn._handshake_cancelled is False
     await conn.disconnect()
+
+
+async def test_disconnect_survives_an_externally_cancelled_subscribe_task(
+    fake_server: TestServer,
+) -> None:
+    """An outside cancellation of the subscribe task must not break disconnect().
+
+    A shutdown sweep or a test harness can cancel the subscribe task from
+    outside. Awaiting a cancelled task re-raises `CancelledError`, which
+    `except Exception` does not catch -- so it escaped `disconnect()` into a
+    caller that never asked to be cancelled, left the owned session open,
+    and orphaned the dispatch task.
+    """
+    async with fake_server:
+        conn = make_conn(fake_server, session=None)  # owned session
+        await conn.connect()
+        owned = conn._session
+        assert owned is not None
+        sub, disp = conn._subscribe_task, conn._dispatch_task
+        assert sub is not None and disp is not None
+
+        sub.cancel()
+        with raises(asyncio.CancelledError):
+            await sub
+
+        # A normal disconnect from a caller that is NOT being cancelled.
+        async with timeout(3):
+            await conn.disconnect()
+
+        assert owned.closed  # not leaked
+        assert disp.done()  # not orphaned
+        assert conn._subscribe_task is None
+
+
+async def test_a_cancellation_aimed_at_the_caller_is_still_honoured(
+    fake_server: TestServer,
+) -> None:
+    """The dead-task catch must not swallow a cancellation of our own task.
+
+    If the task running `disconnect()` is itself cancelled while awaiting the
+    wind-down, that cancellation has to propagate -- only the subscribe
+    task's *own* cancellation is absorbed.
+    """
+    async with fake_server:
+        conn = make_conn(fake_server, session=None)
+        await conn.connect()
+
+        # A subscribe task that never returns from the await, so the
+        # disconnect parks on it and we can cancel the disconnect itself.
+        never = asyncio.Event()
+
+        async def hang() -> None:
+            await never.wait()
+
+        hang_task = asyncio.get_running_loop().create_task(hang())
+        conn._subscribe_task = hang_task
+
+        stopper = asyncio.create_task(conn.disconnect())
+        await sleep(0.1)  # let it reach `await self._subscribe_task`
+        stopper.cancel()
+        with raises(asyncio.CancelledError):
+            await stopper  # the caller's cancellation propagated, not swallowed
+
+        never.set()
+        hang_task.cancel()
+        await asyncio.gather(hang_task, return_exceptions=True)


### PR DESCRIPTION
## What

`_stop_subscribing`'s `await self._subscribe_task` re-raises whatever the task ended with. The `except Exception` there (from the dead-task-poisoning fix) catches a task that *died* — but not one that ended **cancelled**: `CancelledError` is a `BaseException`. An outside cancellation of the subscribe task (a shutdown sweep, a test harness reaping lingering tasks) therefore:

1. escaped `disconnect()` into a caller that never asked to be cancelled (`current_task().cancelling() == 0`);
2. skipped the dispatch-task cancel below it — orphaning the dispatcher;
3. skipped the owned-session close in `_disconnect_locked` — leaking the `ClientSession`.

Reproduced end-to-end against a real aiohttp ws server: `disconnect()` raised `CancelledError`, owned session left open, dispatch task not done.

## Fix

A `CancelledError` from awaiting the dead subscribe task is absorbed (logged at DEBUG) so the wind-down completes — session closed, dispatcher cancelled, state cleared — **except** when this task is itself being cancelled (`asyncio.current_task().cancelling() > 0`), which must still propagate so a genuine cancellation of the caller is honoured. This is the one distinction that separates "the task I was waiting on ended cancelled" from "someone is cancelling me."

## Tests

- `test_disconnect_survives_an_externally_cancelled_subscribe_task` — owned session closed, dispatch task done, no `CancelledError` escapes. Fails against unpatched `main` (the reproduction), verified.
- `test_a_cancellation_aimed_at_the_caller_is_still_honoured` — a cancellation targeting the task running `disconnect()` still propagates; guards the fix against over-swallowing.

900 pass, `ruff check`, `ruff format --check` and `mypy .` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
