### PR TITLE
Reject a truncated frame instead of parsing it into a falsy state

### DIFF
--- a/pytboss/grills.py
+++ b/pytboss/grills.py
@@ -290,6 +290,35 @@ def _live_code(js: str | None) -> str:
     return re.sub(r"//.*", "", re.sub(r"/\*.*?\*/", "", js, flags=re.DOTALL))
 
 
+def _min_frame_bytes(js: str | None) -> int | None:
+    """The byte count the routine's own guard requires, or None if it has no guard.
+
+    Every routine opens with `if (parts < N) return null` intending to reject
+    a frame too short to read -- but `parts` is the Array, and `Array < N`
+    coerces to `NaN < N`, always false, so the guard never fires. A truncated
+    frame then indexes past the end (every `parts[i]` is `undefined`), and the
+    routine returns a fully-populated, entirely-falsy state rather than
+    nothing. `parts` is the hex split into byte pairs, so the intended
+    threshold is `N` bytes; recovered here and enforced in `parse_*`, since
+    `grills.json` is generated and must not be hand-edited (REVIEW.md)."""
+    m = re.search(r"\bparts(?:\.length)?\s*<\s*(\d+)", _live_code(js))
+    return int(m.group(1)) if m else None
+
+
+def _is_truncated(message: str, js: str | None) -> bool:
+    """Whether `message` is shorter than the routine needs to read.
+
+    The vendor's dead `parts < N` guard, made to work: the routine splits the
+    hex into byte pairs, so a message carrying fewer than `N` bytes has it
+    reading past the end. A frame at or above the threshold is left alone.
+    """
+    min_bytes = _min_frame_bytes(js)
+    if min_bytes is None:
+        return False
+    # `parseHexMessage` steps by two chars, so the byte count is `ceil(len/2)`.
+    return (len(message) + 1) // 2 < min_bytes
+
+
 @dataclass(frozen=True)
 class ControlBoard:
     """Specifications for a control board connected via UART."""
@@ -367,6 +396,8 @@ class ControlBoard:
         """
         if not self._status_js_func:
             raise NotImplementedError
+        if _is_truncated(message, self._status_js_func):
+            return None
         return _drop_fields(
             self._evaljs(self._status_js_func, message),
             DROPPED_STATUS_FIELDS.get(self.name, frozenset()),
@@ -381,6 +412,8 @@ class ControlBoard:
         """
         if not self._temperatures_js_func:
             raise NotImplementedError
+        if _is_truncated(message, self._temperatures_js_func):
+            return None
         return _drop_fields(
             self._evaljs(self._temperatures_js_func, message),
             DROPPED_TEMPERATURE_FIELDS.get(self.name, frozenset()),

--- a/tests/test_grills.py
+++ b/tests/test_grills.py
@@ -537,3 +537,34 @@ def test_frozen_types_are_hashable():
     assert hash(g1) == hash(g2)  # the eq/hash contract
     assert len({g1, g2}) == 1
     assert hash(g1.control_board) == hash(g2.control_board)
+
+
+def test_a_truncated_frame_is_rejected_not_parsed_into_a_falsy_state():
+    """The vendor's `parts < N` guard is dead; a short frame must still be dropped.
+
+    On the 14 boards whose guard compares the Array object to a number
+    (always false), a truncated frame indexed past its end and returned a
+    fully-populated, entirely-falsy status -- which merged into the cache and
+    flipped `moduleIsOn` and every error flag to False. It must parse to None.
+    """
+    cb = grills_lib.get_grill("PB1600PS1").control_board  # PBL: dead guard
+    # A full frame parses; a header-only fragment of the same prefix does not.
+    full = cb.parse_status(
+        "FE0B01060501090101090209060009060002020002020501010000000000000000000101010001"
+        "01040C3B1F"
+    )
+    assert full is not None and full["moduleIsOn"] is True
+    assert cb.parse_status("FE0B00000000") is None  # 6 bytes, needs 44
+    assert cb.parse_temperatures("FE0C0000") is None  # 4 bytes, needs 27
+
+
+def test_every_board_accepts_a_frame_at_its_length_threshold():
+    """The guard must reject only what is genuinely too short -- no false drops."""
+    for grill in grills_lib.get_grills():
+        cb = grill.control_board
+        for js in (cb._status_js_func, cb._temperatures_js_func):
+            n = grills_lib._min_frame_bytes(js)
+            if n is None:
+                continue
+            assert not grills_lib._is_truncated("f" * (2 * n), js)  # at threshold: ok
+            assert grills_lib._is_truncated("f" * (2 * n - 2), js)  # one byte short


### PR DESCRIPTION
## What

Every board's `status_function`/`temperature_function` opens with `if (parts < N) return null` — meant to drop a frame too short to read. But `parts` is the Array returned by `parseHexMessage`, and `Array < Number` coerces via the array's string form to `NaN < N`, which is **always false**. On **14 of 20 boards** the guard never fires (only PBA, PBB, PBD, PBE, PBT, PBX1 write `parts.length < N`).

With the guard dead, a truncated frame indexes past its end — every `parts[i]` is `undefined`, so every `=== 1` is false and every `convertTemperature` is null — and the routine returns a **fully-populated, entirely-falsy** status dict. `_on_state_received` sees that as truthy, merges it into the cache (flipping `moduleIsOn` and every error flag — `noPellets`, `highTempErr`, `motorErr` — to False), and pushes it to subscribers. Reproduced end-to-end on PBL: a 6-byte `FE0B00000000` fragment yielded `moduleIsOn: False` and clobbered a cached `True`.

**Reachability:** BLE. `_on_debug_log_received` processes one notification at a time with no reassembly, and only validates the firmware's `[len]` checksum when the payload ends in `]` — a headed fragment split across notifications lacks the trailing `]`, so the one integrity check is bypassed exactly on truncation. HTTP/WSS deliver fully-reassembled frames, so they are not affected (confirmed against a live grill — its frames arrive complete).

## Fix

`grills.json` is generated from the vendor API and must never be hand-edited (REVIEW.md), so the routine's own intended threshold `N` is recovered from its `parts < N` text and enforced in Python: `parse_status`/`parse_temperatures` return `None` for a message carrying fewer than `N` byte-pairs, before running the JS. It reconstructs exactly the guard the vendor wrote and failed to make effective. Boards whose guard already works are unaffected — a valid frame clears the same threshold.

## Tests

- `test_a_truncated_frame_is_rejected_not_parsed_into_a_falsy_state` — a header-only fragment on a dead-guard board parses to `None`, a full frame still parses.
- `test_every_board_accepts_a_frame_at_its_length_threshold` — no false drops: every board accepts a frame at its threshold and rejects one byte short.

Both fail against unpatched `main`, verified.

900 pass, `ruff check`, `ruff format --check` and `mypy .` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
