### PR TITLE
Read a disconnected probe as None, not -18 C

### DIFF
--- a/pytboss/grills.py
+++ b/pytboss/grills.py
@@ -137,11 +137,23 @@ parse(dukpy['message']);
 
 _FN_RE = re.compile(r"(.+ ?= ?)(\(.[^\)]+\))( ?=>)?(.+)")
 
+# The converting boards' `ftoc` helper short-circuits the disconnected-probe
+# sentinel with `typeof temp === "undefined" || temp === 960`, returning the
+# value unchanged -- but `convertTemperature` (in the template) has already
+# mapped 960 to `null`, and the guard does not cover `null`. So `ftoc(null)`
+# falls through to `Math.floor((null - 32) / 1.8)`, and JS coerces `null` to
+# 0: a disconnected probe reads -18 (degrees C) instead of None. Every
+# `=== 960` in the shipped routines is that guard (nothing else compares to
+# the sentinel), so extending it to `null` restores the intended None without
+# touching `grills.json`, which is generated (REVIEW.md).
+_FTOC_SENTINEL_RE = re.compile(r"(\w+)\s*===\s*960\b")
+
 
 def _scrub_js(s: str | None) -> str | None:
     if s is None:
         return s
     s = _FN_RE.sub(r"\1 function \2\4", s)
+    s = _FTOC_SENTINEL_RE.sub(r"\1 === 960 || \1 === null", s)
     s = s.replace("let ", "var ")
     s = s.replace("const ", "var ")
     return s

--- a/tests/test_grills.py
+++ b/tests/test_grills.py
@@ -568,3 +568,40 @@ def test_every_board_accepts_a_frame_at_its_length_threshold():
                 continue
             assert not grills_lib._is_truncated("f" * (2 * n), js)  # at threshold: ok
             assert grills_lib._is_truncated("f" * (2 * n - 2), js)  # one byte short
+
+
+def test_a_disconnected_probe_reads_none_not_minus_18_on_converting_boards():
+    """`ftoc(null)` returned -18 for a disconnected probe on the ftoc boards.
+
+    `convertTemperature` maps the 960 sentinel to null; ftoc guards
+    `undefined` and `960` but not `null`, so `Math.floor((null - 32) / 1.8)`
+    = -18 (JS coerces null to 0). A Celsius grill reported -18 C for every
+    unplugged probe instead of None.
+    """
+    sentinel_frame = "FE0C" + "090600" * 20 + "00"  # every field reads 960
+    for name in ("PBA", "LFS", "PBE", "PBL3", "PBM", "PBM2", "PBT", "PBV", "PBV2"):
+        cb = next(
+            g.control_board
+            for g in grills_lib.get_grills()
+            if g.control_board.name == name
+        )
+        out = cb.parse_temperatures(sentinel_frame)
+        assert out is not None and not out["isFahrenheit"]  # the Celsius path ran
+        assert -18 not in out.values(), (
+            f"{name}: {[k for k, v in out.items() if v == -18]}"
+        )
+
+
+def test_a_real_temperature_still_converts_after_the_sentinel_fix():
+    """The fix must touch only the sentinel, not real readings."""
+    cb = next(
+        g.control_board
+        for g in grills_lib.get_grills()
+        if g.control_board.name == "PBA"
+    )
+    # p1Temp at offset 8 reads 225 (F); the rest are the 960 sentinel.
+    frame = "FE0C" + "000000000000020205" + "090600" * 6 + "00"
+    out = cb.parse_temperatures(frame)
+    assert out is not None
+    assert out["p1Temp"] == 107  # 225 F -> 107 C, unchanged by the fix
+    assert out["p2Temp"] is None  # the sentinel, now None rather than -18


### PR DESCRIPTION
## What

On the 9 converting boards (~82 supported models), a disconnected probe reads **-18 °C** instead of `None` when the grill is in Celsius.

The chain: `convertTemperature` (in the JS template) maps the disconnected-probe sentinel `960` to `null`. The board's `ftoc` helper then runs on that value, and its guard is `typeof temp === "undefined" || temp === 960` — it does **not** cover `null`. So `ftoc(null)` falls through to `Math.floor((null - 32) / 1.8)`; JS coerces `null` to `0`, giving `Math.floor(-17.7)` = **-18**. Every unplugged probe, target, and unused temperature field on a Celsius grill reads -18 °C.

Reproduced on all 9 boards; against unpatched `main`, PBA's sentinel frame yields `{p1Target: -18, p2Target: -18, p1Temp: -18, ... grillTemp: -18}`. Surfaced through `get_probe_targets`, `get_probe_targets`'s own docstring ("absent rather than present as None") is violated — it invents a -18 °C target for probes that have none. (A live PBL grill — a *non*-converting board — reads `None` correctly, and confirmed the two upstream premises: real grills send the 960 sentinel and do run in Celsius.)

## Fix

`grills.json` is generated from the vendor API and must never be hand-edited (REVIEW.md). Every `=== 960` in the shipped routines is that `ftoc` guard — nothing else compares to the sentinel — so `_scrub_js` (which already rewrites this JS at load time) extends the guard to `null` as well: `temp === 960 || temp === null`. `ftoc` returns its argument unchanged for the guarded cases, so `ftoc(null)` now returns `null` → the field is `None`, the intended value.

**Lossless:** the fix touches only the sentinel path. A genuine reading still converts (verified: 225 °F → 107 °C, unchanged); only `null` becomes `None` instead of -18. Non-converting boards never call `ftoc` and are entirely unaffected.

## Tests

- `test_a_disconnected_probe_reads_none_not_minus_18_on_converting_boards` — all 9 boards, every sentinel field, no -18 in the result.
- `test_a_real_temperature_still_converts_after_the_sentinel_fix` — a real value still converts; only the sentinel is None.

Both fail against unpatched `main`, verified.

900 pass, `ruff check`, `ruff format --check` and `mypy .` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
