### PR TITLE
Convert every temperature field a Celsius frame reports

### DIFF
--- a/pytboss/grills.py
+++ b/pytboss/grills.py
@@ -1,9 +1,10 @@
 """Routines for accessing grill metadata."""
 
 import json
+import math
 import re
 import threading
-from collections.abc import Container, Iterable
+from collections.abc import Collection, Container, Iterable
 from dataclasses import dataclass, field
 from functools import cache
 from importlib import resources
@@ -90,6 +91,19 @@ DROPPED_STATUS_FIELDS = {
 DROPPED_TEMPERATURE_FIELDS = {
     "LBL": frozenset({"smokerActTemp"}),
     "LFS": frozenset({"smokerActTemp"}),
+}
+
+# Fields these boards' temperature routine populates but forgets to run
+# through its `ftoc` helper, so they stay in Fahrenheit while every sibling
+# field is converted to the grill's Celsius unit -- two temperatures in one
+# reply in different units, with nothing marking which. Converted here to
+# match, but only when the frame reports Celsius. `grills.json` is generated
+# and must not be hand-edited (REVIEW.md); `DROPPED_*_FIELDS` uses this same
+# per-board shape for the same class of routine gap.
+UNCONVERTED_FAHRENHEIT_FIELDS = {
+    "PBA": frozenset({"p4Temp", "smokerActTemp"}),
+    "PBE": frozenset({"p4Temp", "smokerActTemp"}),
+    "PBT": frozenset({"p4Temp", "smokerActTemp"}),
 }
 
 # Typos in the vendor's command slugs, mapped to the canonical slug.
@@ -249,6 +263,26 @@ def _drop_fields(state: StateDict | None, fields: Container[str]) -> StateDict |
     if state is None:
         return None
     return cast(StateDict, {k: v for k, v in state.items() if k not in fields})
+
+
+def _convert_missed_fields(
+    state: StateDict | None, fields: Collection[str]
+) -> StateDict | None:
+    """Converts fields the routine left in Fahrenheit to the frame's unit.
+
+    Only when the reply reports Celsius (`isFahrenheit` false), mirroring the
+    board's own `if (!status.isFahrenheit)` conversion block -- the fields in
+    `fields` are the ones that block forgets. The arithmetic is `ftoc`'s:
+    `floor((f - 32) / 1.8)`. The sentinel is already `None` by here, so only
+    real readings are touched.
+    """
+    if state is None or state.get("isFahrenheit") is not False:
+        return state
+    for key in fields:
+        value = state.get(key)  # type: ignore[call-overload]
+        if isinstance(value, int) and not isinstance(value, bool):
+            state[key] = math.floor((value - 32) / 1.8)  # type: ignore[literal-required]
+    return state
 
 
 @dataclass
@@ -426,9 +460,12 @@ class ControlBoard:
             raise NotImplementedError
         if _is_truncated(message, self._temperatures_js_func):
             return None
-        return _drop_fields(
-            self._evaljs(self._temperatures_js_func, message),
-            DROPPED_TEMPERATURE_FIELDS.get(self.name, frozenset()),
+        return _convert_missed_fields(
+            _drop_fields(
+                self._evaljs(self._temperatures_js_func, message),
+                DROPPED_TEMPERATURE_FIELDS.get(self.name, frozenset()),
+            ),
+            UNCONVERTED_FAHRENHEIT_FIELDS.get(self.name, frozenset()),
         )
 
 

--- a/tests/test_grills.py
+++ b/tests/test_grills.py
@@ -605,3 +605,48 @@ def test_a_real_temperature_still_converts_after_the_sentinel_fix():
     assert out is not None
     assert out["p1Temp"] == 107  # 225 F -> 107 C, unchanged by the fix
     assert out["p2Temp"] is None  # the sentinel, now None rather than -18
+
+
+def _celsius_temps_frame() -> str:
+    """A 30-byte FE0C frame reading a real value at grill+smoker, in Celsius."""
+    parts = ["00"] * 30
+    parts[0], parts[1] = "FE", "0C"
+    for off in (20, 26):  # smokerActTemp, grillTemp
+        parts[off], parts[off + 1], parts[off + 2] = "02", "01", "02"  # 212 F
+    parts[29] = "00"  # isFahrenheit = false
+    return "".join(parts)
+
+
+def test_smoker_temp_is_converted_to_celsius_like_its_siblings():
+    """PBA/PBE/PBT convert every temp field except p4Temp and smokerActTemp.
+
+    Those two were left in Fahrenheit while the rest of the same reply was
+    converted -- two temperatures in one frame in different units. On a
+    Celsius grill smokerActTemp read ~2x too high.
+    """
+    frame = _celsius_temps_frame()
+    for name in ("PBA", "PBE", "PBT"):
+        cb = next(
+            g.control_board
+            for g in grills_lib.get_grills()
+            if g.control_board.name == name
+        )
+        out = cb.parse_temperatures(frame)
+        assert out is not None and out["isFahrenheit"] is False
+        # grillTemp (converted by the board) and smokerActTemp (converted here)
+        # must now agree -- both 212 F -> 100 C.
+        assert out["grillTemp"] == 100
+        assert out["smokerActTemp"] == 100
+
+
+def test_a_fahrenheit_frame_leaves_the_missed_fields_untouched():
+    """No double conversion: on a Fahrenheit grill the value is already right."""
+    frame = _celsius_temps_frame()[:-2] + "01"  # isFahrenheit = true
+    cb = next(
+        g.control_board
+        for g in grills_lib.get_grills()
+        if g.control_board.name == "PBA"
+    )
+    out = cb.parse_temperatures(frame)
+    assert out is not None and out["isFahrenheit"] is True
+    assert out["smokerActTemp"] == 212  # left in Fahrenheit, as it should be


### PR DESCRIPTION
## What

PBA/PBE/PBT run their temperature reply through an `ftoc` helper when the grill is in Celsius — but the list of fields they convert omits `p4Temp` and `smokerActTemp`. Those two stay in Fahrenheit while every sibling field is Celsius: **two temperatures in one frame in different units**, with nothing marking which. Reproduced — a Celsius frame reading 212 °F at both grill and smoker:

```
PBA Celsius: grillTemp=100  smokerActTemp=212   <- 100 C vs a raw Fahrenheit 212
```

On a real Celsius grill `smokerActTemp` reads about twice too high. (`p4Temp` is the moot half — all 22 models have 2 probes, so probe 4 reads the disconnected sentinel → `None`; `smokerActTemp` is the live chamber reading and the real problem.)

## Fix

`grills.json` is generated and must not be hand-edited (REVIEW.md), so a per-board field set — the same shape `DROPPED_*_FIELDS` already uses for this class of routine gap — lists the fields the routine leaves behind, and `_convert_missed_fields` converts them with `ftoc`'s own arithmetic (`floor((f - 32) / 1.8)`) **only when the reply reports Celsius**, mirroring the board's own `if (!status.isFahrenheit)` block.

Verified safe:
- A Fahrenheit frame is untouched — no double conversion (`smokerActTemp` stays 212).
- The disconnected-probe sentinel is already `None` by then, so only real readings are converted.
- The affected set is exactly PBA/PBE/PBT (round-2 JS sweep confirmed every other converting board converts all the fields it populates); no other board is touched.

Note this is distinct from the `DROPPED` of `smokerActTemp` on LBL/LFS — there the field reads no bytes of its own (an overlap), here it's a real distinct reading in the wrong unit, so it's converted rather than dropped.

## Tests

- `test_smoker_temp_is_converted_to_celsius_like_its_siblings` — on all three boards, `smokerActTemp` now agrees with `grillTemp` (both 212 °F → 100 °C). Fails against unpatched `main`, verified.
- `test_a_fahrenheit_frame_leaves_the_missed_fields_untouched` — no double conversion on a Fahrenheit grill.

900 pass, `ruff check`, `ruff format --check` and `mypy .` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
