### PR TITLE
Pin the truncation, not just the conversion

### DIFF
--- a/tests/test_grills.py
+++ b/tests/test_grills.py
@@ -607,24 +607,43 @@ def test_a_real_temperature_still_converts_after_the_sentinel_fix():
     assert out["p2Temp"] is None  # the sentinel, now None rather than -18
 
 
-def _celsius_temps_frame() -> str:
-    """A 30-byte FE0C frame reading a real value at grill+smoker, in Celsius."""
+def _celsius_temps_frame(fahrenheit: int = 212) -> str:
+    """A 30-byte FE0C frame reading `fahrenheit` at grill+smoker, in Celsius.
+
+    The reading is carried one decimal digit per byte, so only three-digit
+    values are expressible here -- which is every temperature these fields
+    report.
+    """
     parts = ["00"] * 30
     parts[0], parts[1] = "FE", "0C"
     for off in (20, 26):  # smokerActTemp, grillTemp
-        parts[off], parts[off + 1], parts[off + 2] = "02", "01", "02"  # 212 F
+        parts[off], parts[off + 1], parts[off + 2] = (
+            f"0{digit}" for digit in f"{fahrenheit:03d}"
+        )
     parts[29] = "00"  # isFahrenheit = false
     return "".join(parts)
 
 
-def test_smoker_temp_is_converted_to_celsius_like_its_siblings():
+@pytest.mark.parametrize(
+    "fahrenheit,celsius",
+    [
+        # Exactly divisible, so it cannot tell floor from round apart.
+        (212, 100),
+        # 181/1.8 = 100.55: the board's ftoc floors it to 100, `round` would
+        # give 101. Without this case the conversion could be reimplemented
+        # with `round` and the suite would not notice -- and smokerActTemp
+        # would sit one degree from the grillTemp it is supposed to match.
+        (213, 100),
+    ],
+)
+def test_smoker_temp_is_converted_to_celsius_like_its_siblings(fahrenheit, celsius):
     """PBA/PBE/PBT convert every temp field except p4Temp and smokerActTemp.
 
     Those two were left in Fahrenheit while the rest of the same reply was
     converted -- two temperatures in one frame in different units. On a
     Celsius grill smokerActTemp read ~2x too high.
     """
-    frame = _celsius_temps_frame()
+    frame = _celsius_temps_frame(fahrenheit)
     for name in ("PBA", "PBE", "PBT"):
         cb = next(
             g.control_board
@@ -635,8 +654,8 @@ def test_smoker_temp_is_converted_to_celsius_like_its_siblings():
         assert out is not None and out["isFahrenheit"] is False
         # grillTemp (converted by the board) and smokerActTemp (converted here)
         # must now agree -- both 212 F -> 100 C.
-        assert out["grillTemp"] == 100
-        assert out["smokerActTemp"] == 100
+        assert out["grillTemp"] == celsius
+        assert out["smokerActTemp"] == celsius
 
 
 def test_a_fahrenheit_frame_leaves_the_missed_fields_untouched():


### PR DESCRIPTION
Closes the gap I flagged when merging #593.

## What was uncovered

`test_smoker_temp_is_converted_to_celsius_like_its_siblings` used **212 °F, which is exactly 100 °C** — so `floor` and `round` agree on it, and the test could not tell the two implementations apart. Swapping `math.floor` for `round` in `_convert_missed_fields` passed the entire suite:

```
round instead of floor  ->  909 passed
```

## Why it is worth a test rather than a comment

The boards **truncate** where an obvious implementation rounds — the same finding as #327, and the reason `accepted_setpoints` derives its Celsius list with `floor((F - 32) / 1.8)`.

This particular conversion exists to make `smokerActTemp` agree with the `grillTemp` the board converted itself. Written with `round` it lands one degree away — reintroducing exactly the mismatch #593 removes, at a scale much harder to notice than the 2× version it started as. 89 of the 200 Fahrenheit values between 100 and 300 diverge, so it is not an edge case.

## The change

`_celsius_temps_frame` takes the reading as a parameter (it is carried one decimal digit per byte, so three-digit values), and the test is parametrized over two:

- **212 °F → 100 °C** — the original; exactly divisible, so both implementations agree
- **213 °F → 100 °C** — `181/1.8 = 100.55`, which `ftoc` floors to 100 and `round` would make 101

Both are asserted to equal `grillTemp`, which the board converts through its own `ftoc`, so the test compares our arithmetic against the board's rather than against a constant.

## Verified

```
round instead of floor  ->  FAILED ...test_smoker_temp_is_converted_to_celsius_like_its_siblings[213-100]
                            1 failed, 1 passed
```

The old case still passes under the mutation, which is the evidence that it was doing no work.

**909 tests**, `ruff check`, `ruff format --check`, `mypy .` clean. Tests only; no library code changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)