### PR TITLE
Cover the uptime fallback and a malformed status frame

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -567,6 +567,26 @@ async def test_get_uptime_extrapolation_runs_ahead_not_behind():
         assert await pitboss.get_uptime() >= 100.0 + 5.0
 
 
+async def test_get_uptime_extrapolates_when_a_re_read_comes_back_unreadable(
+    pitboss: api.PitBoss, conn: FakeTransport
+):
+    """One unreadable reply must not throw away a good earlier one.
+
+    Falling back to 0.0 here would build `timed_key` from an uptime the
+    grill left behind long ago, and a password-protected grill rejects
+    every command signed with it. The clock has kept running, so the last
+    known uptime plus the elapsed time is a far better answer than nothing.
+    """
+    with freeze_time("2025-06-01 00:00:00") as ft:
+        first = await pitboss.get_uptime()
+        assert first > 0.0
+
+        # The cache goes stale, and the grill answers without a `time`.
+        ft.tick(api._UPTIME_TTL + 30.0)
+        with mock.patch.object(conn, "send_command", AsyncMock(return_value={})):
+            assert await pitboss.get_uptime() == first + api._UPTIME_TTL + 30.0
+
+
 async def test_get_uptime_is_re_read_once_the_cache_is_stale(pitboss: api.PitBoss):
     """The fake grill counts up per read, so a fresh read is far lower."""
     with freeze_time("2025-06-01 00:00:00") as ft:

--- a/tests/test_wss.py
+++ b/tests/test_wss.py
@@ -243,6 +243,26 @@ async def test_malformed_payload_does_not_kill_the_stream(
     state_callback.assert_awaited_once_with("state")
 
 
+async def test_a_frame_of_the_wrong_shape_does_not_kill_the_stream(
+    conn: wss.WebSocketConnection, state_payloads: Queue
+) -> None:
+    """Valid JSON, but `status` is not the list the firmware documents.
+
+    The malformed-payload guard above only covers text that will not parse.
+    This one parses and then blows up inside the handler -- `len()` on an
+    int -- which is a different `except`, and without it one odd push from
+    the relay would take the socket down until the next reconnect.
+    """
+    state_callback = MockCallback(1)
+    conn.set_state_callback(state_callback)
+    async with conn:
+        await state_payloads.put({"status": 5})
+        await state_payloads.put({"status": ["state"]})
+        async with timeout(5):
+            await state_callback.wait()
+    state_callback.assert_awaited_once_with("state")
+
+
 async def test_subscriber_exception_does_not_kill_the_stream(
     conn: wss.WebSocketConnection, state_payloads: Queue
 ) -> None:


### PR DESCRIPTION
Two recovery paths with no test. Both are reachable, and both matter on a live grill.

## `get_uptime` extrapolating from the last good reading

```python
if not isinstance(uptime, (int, float)):
    _LOGGER.debug("No uptime in the reply: %s", result)
    if self._last_uptime is None:
        return 0.0
    return self._last_uptime + (now - self._last_uptime_check)   # untested
```

Only the `None` arm was covered — by `test_get_uptime_does_not_cache_a_reply_it_cannot_read`, which asks before any successful read. Collapsing the whole block to `return 0.0` passed.

That is not a cosmetic difference. `timed_key` is built from the uptime, and on a password-protected grill the firmware accepts only the current 10-second bucket or the next one. An uptime of 0 signs every command with a key the grill left behind long ago, and it rejects all of them — for as long as the re-reads keep coming back unreadable.

## The websocket handler guard

```python
try:
    await self._handle_message(payload)
except Exception:
    _LOGGER.exception("Error handling payload: %s", payload)
```

Two nearby tests look like they cover this and do not:

- `test_malformed_payload_does_not_kill_the_stream` — text that will not parse, caught by the `except ValueError` around `msg.json()`, one level up.
- `test_subscriber_exception_does_not_kill_the_stream` — raised in the dispatcher, which is a separate task since the callback queue landed.

Neither reaches a payload that parses and then blows up *inside* the handler. `{"status": 5}` does it — `len()` on an int. `status` is documented as a list, but the firmware builds it conditionally, and the relay is not the firmware. Without the guard, one odd push takes the socket down until the next reconnect.

## Mutations

All three passed before, all three fail now:

```
uptime: give up instead of extrapolating       caught
uptime: extrapolate without the elapsed time   caught
wss: let a handler error kill the loop         caught
```

911 tests, 96% branch coverage. `ruff check`, `ruff format --check` and `mypy .` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)