### PR TITLE
Document the HTTP transport, and answer a stale TODO

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@ Python 3 library for interacting with Pitboss grills and smokers.
 
 ## Usage
 
-`pytboss` supports two ways of talking to a grill: a direct Bluetooth LE
-connection, or a WebSocket connection to the PitBoss cloud service. Both use
-the same `PitBoss` API once connected — only the `Transport` passed to it
-differs.
+`pytboss` supports three ways of talking to a grill: a direct Bluetooth LE
+connection, a WebSocket connection to the PitBoss cloud service, or an HTTP
+connection to the grill on your own network. All three use the same `PitBoss`
+API once connected — only the `Transport` passed to it differs.
 
 ### Bluetooth LE
 
@@ -82,6 +82,54 @@ async def main():
     await boss.start()
     while True:
         await asyncio.sleep(0.1)
+
+
+asyncio.run(main())
+```
+
+### HTTP (local network)
+
+Mongoose OS serves the same RPC interface at `http://<grill-ip>/rpc` that the
+Dansons relay forwards, so this transport talks to the grill directly, with
+the vendor's cloud out of the path.
+
+**Not every grill answers.** The ESP-IDF firmware line (versioned `16.x`, on
+the PBC2, PBD, PBE, PBL2 and PBT boards) links no HTTP server at all, and
+Mongoose grills serve the endpoint only when `http.enable` is set — per-unit
+configuration that no model or firmware version predicts. Nothing in this
+library turns it on; `connect()` simply fails. Check first over a transport
+that already works:
+
+```python
+from pytboss.exceptions import RPCError
+
+try:
+    http = await boss.config.get_config("http")
+except RPCError:
+    http = {}  # No such section: not a Mongoose grill.
+if http.get("enable"):
+    ...  # An HttpConnection will work against this grill.
+```
+
+**There is no push channel.** HTTP is strictly request/response, so unlike the
+other two transports this one never invokes the state or VData callbacks —
+`subscribe_state()` registers a callback that will not fire. Poll
+`get_state()` instead; it issues a live RPC and updates the same cache the
+rest of the API reads.
+
+```python
+import asyncio
+from pytboss import HttpConnection, PitBoss
+
+
+async def main():
+    host = "192.168.1.50"  # Your grill's address on the network.
+    model = "PBV4PS2"  # Or your model. See below.
+    boss = PitBoss(HttpConnection(host), model)
+    await boss.start()
+    while True:
+        print(await boss.get_state())
+        await asyncio.sleep(10)
 
 
 asyncio.run(main())

--- a/pytboss/__init__.py
+++ b/pytboss/__init__.py
@@ -1,4 +1,9 @@
-"""Client library for controlling PitBoss/Dansons grills over Bluetooth LE or WebSocket."""
+"""Client library for controlling PitBoss/Dansons grills.
+
+Three transports reach a grill: Bluetooth LE, the Dansons WebSocket relay,
+and -- on grills that serve it -- Mongoose OS's HTTP RPC endpoint on the
+local network. All three present the same `PitBoss` API once connected.
+"""
 
 from .api import PitBoss  # noqa: F401
 from .ble import BleConnection  # noqa: F401

--- a/pytboss/api.py
+++ b/pytboss/api.py
@@ -68,7 +68,12 @@ async def _invoke(callback: Callable[[Any], Awaitable[None] | None], arg: Any) -
 
 
 class PitBoss:
-    """API for interacting with PitBoss grills over Bluetooth LE."""
+    """API for interacting with PitBoss grills.
+
+    Transport-agnostic: the `Transport` passed to the constructor decides
+    whether the grill is reached over Bluetooth LE, the Dansons WebSocket
+    relay, or HTTP on the local network.
+    """
 
     fs: FileSystem
     """Filesystem operations."""

--- a/pytboss/ble.py
+++ b/pytboss/ble.py
@@ -333,7 +333,11 @@ class BleConnection(Transport):
                     temperatures_payload = payload
             await self._state_callback(status_payload, temperatures_payload)
         elif head == "<==PBD:" and self._vdata_callback:
-            # TODO: I think we want to decode this?
+            # Handed over as the text the firmware printed, not parsed. The
+            # websocket transport receives virtual data already decoded, as a
+            # member of a status frame, so `PitBoss._on_vdata_received` accepts
+            # both and parses only when it is handed a string. Decoding here
+            # too would leave that with nothing to distinguish the two.
             await self._vdata_callback(payload)
 
 

--- a/pytboss/grills.py
+++ b/pytboss/grills.py
@@ -275,6 +275,11 @@ def _convert_missed_fields(
     `fields` are the ones that block forgets. The arithmetic is `ftoc`'s:
     `floor((f - 32) / 1.8)`. The sentinel is already `None` by here, so only
     real readings are touched.
+
+    Unlike `_drop_fields`, this edits `state` in place and returns the same
+    object. Safe where it is called, because `_drop_fields` runs first and
+    hands over a dict nobody else holds -- but it is not safe to call on a
+    parse result directly.
     """
     if state is None or state.get("isFahrenheit") is not False:
         return state


### PR DESCRIPTION
## The third transport was invisible

`HttpConnection` is exported from `pytboss/__init__.py` and `http.py` carries a careful module docstring about which grills serve the endpoint. Nothing outside that module admitted it exists:

| Where | Said |
|---|---|
| `pytboss/__init__.py` | "over Bluetooth LE or WebSocket" |
| `PitBoss` class docstring | "API for interacting with PitBoss grills over Bluetooth LE" |
| `README.md` | "supports **two** ways of talking to a grill", two sections |

This matters more than usual right now: ha-pitboss#371 is built on this transport, and anyone who goes looking for how it works finds a README that says it isn't there.

The new README section carries the caveats that make it usable rather than just the constructor — the ESP-IDF line (`16.x`, on PBC2/PBD/PBE/PBL2/PBT) links no HTTP server, Mongoose grills serve the endpoint only when `http.enable` is set, and there is **no push channel**, so `subscribe_state()` registers a callback that never fires and state has to be polled. Every call in the examples was run against the real signatures.

## A TODO that was answered the other way

```python
elif head == "<==PBD:" and self._vdata_callback:
    # TODO: I think we want to decode this?
    await self._vdata_callback(payload)
```

It is answered, and acting on it would have broken the websocket path. `PitBoss._on_vdata_received` takes `str | dict` and parses **only when handed a string**, precisely because the two transports differ — `ble` reads virtual data off the debug log as printed text, `wss` receives it already decoded as a member of a status frame. Decoding in `ble` would leave that method unable to tell them apart. Replaced the TODO with the reason.

## One mutation worth naming

`_convert_missed_fields` edits its argument in place and returns the same object; its sibling `_drop_fields`, used in the same expression, returns a new dict. Neither docstring said which. It is safe as called — `_drop_fields` runs first and hands over a dict nobody else holds — so this is a comment, not a change. Reordering them would be a silent bug.

908 tests pass, `ruff check`, `ruff format --check` and `mypy .` clean. No behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)