### PR TITLE
Dispatch subscribers through one routine

### DIFF
--- a/pytboss/api.py
+++ b/pytboss/api.py
@@ -4,7 +4,7 @@ import asyncio
 import inspect
 import json
 import logging
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Sequence
 from math import floor
 from time import monotonic
 from typing import Any
@@ -201,25 +201,13 @@ class PitBoss:
             return
 
         async with self._lock:
+            # Snapshotted here rather than inside `_dispatch`, because `_lock`
+            # is what guards the subscriber list -- and taken before dispatch
+            # begins, so a subscriber registered by another subscriber joins
+            # from the next update rather than part-way through this one.
             self._state.update(state)
             callbacks = list(self._state_callbacks)
-        # Dispatched outside `_lock`: a subscriber that calls back into the
-        # API (`get_state()` takes the same lock) would otherwise deadlock.
-        # The dedicated lock keeps one update's callbacks from interleaving
-        # with the next one's, which holding `_lock` used to guarantee.
-        async with self._callback_lock:
-            # TODO: Run callbacks concurrently
-            # TODO: Send copies of state so subscribers can't modify it
-            for callback in callbacks:
-                try:
-                    await _invoke(callback, self._state)
-                except Exception:
-                    # Isolated per subscriber: without this the first one to
-                    # raise skips every subscriber registered after it for
-                    # that update, and the exception escapes into the
-                    # transport's dispatch -- on BLE, an unhandled task
-                    # traceback in bleak's notification handler.
-                    _LOGGER.exception("Error in state subscriber")
+        await self._dispatch(callbacks, self._state, "state")
 
     async def _on_vdata_received(self, payload: str | dict):
         # Both, because the transports differ in what they can hand over.
@@ -240,15 +228,39 @@ class PitBoss:
         _LOGGER.debug("VData received: %s", vdata)
         async with self._lock:
             callbacks = list(self._vdata_callbacks)
+        await self._dispatch(callbacks, vdata, "vdata")
+
+    async def _dispatch(
+        self,
+        callbacks: Sequence[Callable[[Any], Awaitable[None] | None]],
+        payload: Any,
+        kind: str,
+    ) -> None:
+        """Hand one update to every subscriber that was registered for it.
+
+        `callbacks` is already a snapshot, taken by the caller under `_lock`
+        alongside whatever it was updating.
+
+        Called outside `_lock`: a subscriber that calls back into the API
+        (`get_state()` takes the same lock) would otherwise deadlock. The
+        dedicated `_callback_lock` keeps one update's callbacks from
+        interleaving with the next one's, which holding `_lock` used to
+        guarantee.
+
+        One failing subscriber must not cost the others their update: without
+        the isolation here, the first to raise skips every subscriber
+        registered after it, and the exception escapes into the transport's
+        dispatch -- on BLE, an unhandled task traceback inside bleak's
+        notification handler.
+        """
+        # TODO: Run callbacks concurrently
+        # TODO: Send copies of the payload so subscribers can't modify it
         async with self._callback_lock:
-            # TODO: Run callbacks concurrently
-            # TODO: Send copies of state so subscribers can't modify it
             for callback in callbacks:
                 try:
-                    await _invoke(callback, vdata)
+                    await _invoke(callback, payload)
                 except Exception:
-                    # Isolated per subscriber, as in `_on_state_received`.
-                    _LOGGER.exception("Error in vdata subscriber")
+                    _LOGGER.exception("Error in %s subscriber", kind)
 
     async def _authenticate(self, params: dict) -> dict:
         """Return `params` with the encoded password added.

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -654,6 +654,35 @@ async def test_state_callback_may_subscribe_another():
     assert late in pitboss._state_callbacks
 
 
+async def test_a_subscriber_added_mid_dispatch_waits_for_the_next_update():
+    """The subscriber list is snapshotted before dispatch begins.
+
+    Without that, appending to the list while it is being iterated hands the
+    in-flight update to a subscriber that was not registered when it landed
+    -- and on the vdata path, one that never saw the state it goes with.
+    """
+    conn = FakeTransport()
+    pitboss = api.PitBoss(conn, "PBV4PS2")
+    await pitboss.start()
+
+    seen: list[str] = []
+
+    async def late(state):
+        seen.append("late")
+
+    async def early(state):
+        seen.append("early")
+        if late not in pitboss._state_callbacks:
+            await pitboss.subscribe_state(late)
+
+    await pitboss.subscribe_state(early)
+    await asyncio.wait_for(conn.send_state(STATE_HEX), timeout=5)
+    assert seen == ["early"]
+
+    await asyncio.wait_for(conn.send_state(STATE_HEX), timeout=5)
+    assert seen == ["early", "early", "late"]
+
+
 async def test_state_subscriber_with_async_call_method():
     """`iscoroutinefunction` cannot see through an `async __call__`."""
 


### PR DESCRIPTION
`_on_state_received` and `_on_vdata_received` ended with the same block — take `_callback_lock`, iterate, isolate each subscriber's exceptions, log. Two consequences:

- The **four TODOs** in this file were two TODOs written twice.
- The comment explaining why dispatch happens outside `_lock` lived on only one of the two paths that depend on it. The vdata path had `# Isolated per subscriber, as in _on_state_received.` and nothing about the locking at all.

Extracted as `_dispatch`.

## Locking is unchanged

The callers keep their own snapshot rather than handing the list in, so the state update and the snapshot stay in one critical section:

```python
async with self._lock:
    self._state.update(state)
    callbacks = list(self._state_callbacks)
await self._dispatch(callbacks, self._state, "state")
```

Moving the snapshot into `_dispatch` would have meant releasing `_lock` and reacquiring it, which is a semantic change dressed up as a tidy-up. Not worth it for two lines.

## One property was load-bearing and untested

That snapshot guarantees a subscriber registered *by another subscriber* joins from the next update rather than part-way through the one in flight. Nothing checked it — `list(...)` could have been dropped and the whole suite still passed:

```
live-list mutation: CAUGHT
E   AssertionError: assert ['early', 'late'] == ['early']
```

`test_state_callback_may_subscribe_another` looks like it covers this and doesn't; it only asserts the late subscriber ends up registered.

## Verification

Broke each guarantee in turn and confirmed the suite fails:

```
per-subscriber isolation dropped               caught
dispatch moved back inside _lock (deadlock)    caught
state subscribers no longer dispatched         caught
vdata subscribers no longer dispatched         caught
awaits dropped: coroutines discarded           caught
snapshot replaced by the live list             caught   <- new test
```

One mutation survives — moving the snapshot outside the `async with` while leaving it before `_dispatch`. That is an equivalent mutant: the window it opens is only observable under real concurrency, and the half that is observable is the one the new test pins.

909 tests, `ruff check`, `ruff format --check` and `mypy .` clean. No behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)