### PR TITLE
Drop PBVA's p4Temp, which reads the grill setpoint's bytes

### DIFF
--- a/pytboss/grills.py
+++ b/pytboss/grills.py
@@ -91,6 +91,14 @@ DROPPED_STATUS_FIELDS = {
 DROPPED_TEMPERATURE_FIELDS = {
     "LBL": frozenset({"smokerActTemp"}),
     "LFS": frozenset({"smokerActTemp"}),
+    # PBVA's p4Temp reads no bytes of its own either: it duplicates
+    # grillSetTemp's offset in the FE0C frame, on a board whose models carry
+    # two meat probes -- so it reports the grill setpoint as a probe reading.
+    # The routine's conversion block also skips it, so on a Celsius grill the
+    # bogus reading additionally stays in Fahrenheit. Its status routine
+    # already emits no p4Temp (the whole temperature block there is commented
+    # out).
+    "PBVA": frozenset({"p4Temp"}),
 }
 
 # Fields these boards' temperature routine populates but forgets to run

--- a/tests/test_grills.py
+++ b/tests/test_grills.py
@@ -254,13 +254,7 @@ class TestGetGrills:
                 temp = want[key]
                 if js.converts_to_celsius():
                     temp = f_to_c(want[key])
-                try:
-                    assert status[key] == temp, f"{key}: {status[key]} != {temp}"  # type: ignore[literal-required]
-                except AssertionError:
-                    if key in ("p4Temp", "smokerActTemp"):
-                        # Some grills don't convert these fields for some reason.
-                        continue
-                    raise
+                assert status[key] == temp, f"{key}: {status[key]} != {temp}"  # type: ignore[literal-required]
 
     @pytest.mark.parametrize("grill", all_variants(), ids=idfn)
     def test_parse_state(self, grill: grills_lib.Grill):
@@ -378,13 +372,7 @@ class TestGetGrills:
                 temp = want[key]
                 if js.converts_to_celsius():
                     temp = f_to_c(want[key])
-                try:
-                    assert status[key] == temp, f"{key}: {status[key]} != {temp}"  # type: ignore[literal-required]
-                except AssertionError:
-                    if key in ("p4Temp", "smokerActTemp"):
-                        # Some grills don't convert these fields for some reason.
-                        continue
-                    raise
+                assert status[key] == temp, f"{key}: {status[key]} != {temp}"  # type: ignore[literal-required]
 
 
 class TestGetGrill:
@@ -656,6 +644,31 @@ def test_smoker_temp_is_converted_to_celsius_like_its_siblings(fahrenheit, celsi
         # must now agree -- both 212 F -> 100 C.
         assert out["grillTemp"] == celsius
         assert out["smokerActTemp"] == celsius
+
+
+def test_pbva_does_not_report_the_setpoint_as_probe_4():
+    """PBVA's p4Temp duplicates grillSetTemp's offset; the board has two probes.
+
+    The routine reads both fields from bytes 14-16 of the FE0C frame, so
+    p4Temp reported the grill setpoint as a probe reading -- and since the
+    conversion block also skips it, on a Celsius grill the bogus reading
+    stayed in Fahrenheit next to a converted grillSetTemp. PBVA's models are
+    in `UNSUPPORTED_MODELS`, so the exhaustive per-variant tests never visit
+    this board; only `get_grill` reaches it.
+    """
+    cb = grills_lib.get_grill("PBV30DS").control_board
+    # Digit-per-byte: setpoint 250 F at 14-16, grill 225 F at 17-19,
+    # isFahrenheit at 20.
+    frame = "FE0C" + "00" * 12 + "020500" + "020205" + "01" + "FF"
+    out = cb.parse_temperatures(frame)
+    assert out is not None
+    assert "p4Temp" not in out
+    assert out["grillSetTemp"] == 250
+
+    celsius = cb.parse_temperatures(frame[:-4] + "00" + "FF")
+    assert celsius is not None
+    assert "p4Temp" not in celsius
+    assert celsius["grillSetTemp"] == 120  # 250 F, via the board's own table
 
 
 def test_a_fahrenheit_frame_leaves_the_missed_fields_untouched():


### PR DESCRIPTION
PBVA's temperature routine reads `p4Temp` and `grillSetTemp` from the same offset — bytes 14–16 of the FE0C frame:

```js
p4Temp: convertTemperature(parts, 14),
grillSetTemp: convertTemperature(parts, 14),
```

and the board's models (PBV30DS/PBV30DX) carry two meat probes, so `p4Temp` is not a probe at all: it reports the grill setpoint as a probe reading. The routine's Celsius conversion block also skips it, so on a Celsius grill the bogus value additionally stays in Fahrenheit next to a converted `grillSetTemp` — #593's class of gap, on a field that shouldn't exist in the first place.

The fix drops the field after parsing via `DROPPED_TEMPERATURE_FIELDS`, the same way LBL/LFS handle their aliased `smokerActTemp`, keeping the vendor routine byte-identical to `grills.json`. The status routine needs nothing: its whole temperature block is commented out, so it already emits no `p4Temp`.

Found by sweeping every board's routines with synthesized frames rather than the three boards named in the original report. Two reasons it survived #593:

- PBVA's models are in `UNSUPPORTED_MODELS`, so `all_variants()` never visits this board — no exhaustive test ever parsed its frames.
- The per-variant temperature tests carried a `p4Temp`/`smokerActTemp` tolerance ("Some grills don't convert these fields for some reason") that skipped exactly this class of mismatch. Every board those tests visit now converts correctly, so this PR also removes the tolerance in both tests — it's what kept the gap invisible.

The regression test goes through `get_grill("PBV30DS")`, the only path that reaches an unsupported board, and asserts the field is gone in both units while `grillSetTemp` still converts through the board's own `ftocSet` table (250 °F → 120 °C).

`uv run pytest` (914 passed), `ruff check`, `ruff format --check`, `mypy` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)