### PR TITLE
Add ControlBoard.emits() for asking what a board reports

### DIFF
--- a/pytboss/grills.py
+++ b/pytboss/grills.py
@@ -438,6 +438,37 @@ class ControlBoard:
         """
         return "ftoc" in _live_code(self._status_js_func)
 
+    def emits(self, field: str) -> bool:
+        """Whether this board's routines can report `field`.
+
+        The boards do not all report the same state: PBM and PBM2 emit no
+        `erL`, most emit no `primeState`, and a few probe fields exist only
+        on some generations. A consumer creating an entity per field needs
+        to know which fields this board can ever produce, or the entity sits
+        permanently unknown.
+
+        True when live code in either parsing routine assigns the key in the
+        object it returns, and the field survives the post-parse drops
+        (`DROPPED_*_FIELDS`). Read off the routines rather than a list of
+        board names, like `converts_temperatures_to_celsius`: a definitions
+        refresh can add or remove a field, and only live code counts. The
+        key-assignment form matters too -- LFS comments `p1Target` out of
+        its status object literal but keeps a live
+        `status.p1Target = ftoc(status.p1Target)`, which converts undefined
+        and reports nothing.
+
+        "Can report", not "always reports": some fields are conditional,
+        like `grillSetTemp` appearing only while the grill holds a setpoint.
+        """
+        key = re.compile(rf"\b{re.escape(field)}\s*:")
+        if field not in DROPPED_STATUS_FIELDS.get(
+            self.name, frozenset()
+        ) and key.search(_live_code(self._status_js_func)):
+            return True
+        return field not in DROPPED_TEMPERATURE_FIELDS.get(
+            self.name, frozenset()
+        ) and bool(key.search(_live_code(self._temperatures_js_func)))
+
     def parse_status(self, message: str) -> StateDict | None:
         """Parses a status message.
 

--- a/tests/test_grills.py
+++ b/tests/test_grills.py
@@ -423,6 +423,53 @@ def test_converts_to_celsius_is_per_routine():
     assert board.converts_status_to_celsius is False
 
 
+def _board(name: str) -> grills_lib.ControlBoard:
+    return next(
+        g.control_board for g in grills_lib.get_grills() if g.control_board.name == name
+    )
+
+
+def test_emits_reads_the_routines():
+    """A field counts if either routine's live code assigns its key."""
+    board = grills_lib.ControlBoard(
+        "PBx", {}, "return {inStatus: 1};", "return {inTemps: 2};"
+    )
+    assert board.emits("inStatus") is True
+    assert board.emits("inTemps") is True
+    assert board.emits("neither") is False
+
+    commented = grills_lib.ControlBoard(
+        "PBx", {}, "return {/* gone: 1 */};", "// gone: 2"
+    )
+    assert commented.emits("gone") is False
+
+    # LFS's real shape: the literal is commented out, but a live assignment
+    # still names the field -- converting undefined reports nothing.
+    lfs_shape = grills_lib.ControlBoard(
+        "PBx", {}, "var s = {/* p1Target: x */}; s.p1Target = ftoc(s.p1Target);", ""
+    )
+    assert lfs_shape.emits("p1Target") is False
+
+
+def test_emits_on_the_real_boards():
+    """The board differences consumers actually gate on."""
+    assert _board("PBL").emits("erL") is True
+    for name in ("PBM", "PBM2"):  # no erL anywhere in their routines
+        assert _board(name).emits("erL") is False
+
+
+def test_emits_respects_the_dropped_fields():
+    """A field discarded after parsing is never reported, live code or not.
+
+    LBL's routines assign smokerActTemp in both replies, but both drops
+    discard it; grillTemp is dropped from status only and still arrives via
+    the temperatures reply.
+    """
+    board = _board("LBL")
+    assert board.emits("smokerActTemp") is False
+    assert board.emits("grillTemp") is True
+
+
 @contextmanager
 def _count_js_reads():
     """Count reads of dukpy's runtime `.js` assets."""


### PR DESCRIPTION
The boards do not all report the same state: PBM and PBM2 emit no `erL`, most boards no `primeState`, and a few probe fields exist only on some generations. A consumer creating an entity per field — ha-pitboss makes one binary sensor per error flag — needs to know which fields a board can ever produce, or the entity sits permanently unknown. Today the only way to ask is to parse a frame and see what comes back, which is exactly the wrong moment: entity creation happens before the first frame.

```py
>>> get_grill("PB1600PS1").control_board.emits("erL")
True
>>> get_grill("PB850CS2").control_board.emits("erL")   # PBM2
False
```

Design follows `converts_temperatures_to_celsius`: read off the routines' live code rather than maintaining a list of board names, so a definitions refresh keeps the answer current. Two refinements on top of plain substring membership, both borrowed from the test suite's `JSFunc.has_key`, where this predicate has been proven against every variant:

- **Key-assignment form** (`field:` in live code), not mere mention — LFS comments `p1Target` out of its status object literal but keeps a live `status.p1Target = ftoc(status.p1Target)`, which converts undefined and reports nothing.
- **Post-parse drops honored** — a field in `DROPPED_*_FIELDS` never reaches a consumer no matter what the routine assigns: LBL's `smokerActTemp` is assigned in both routines and reported by neither, while its `grillTemp` (dropped from status only) still arrives via the temperatures reply. Both are asserted in the tests.

Semantics are "can report", not "always reports" — `grillSetTemp` appears only while the grill holds a setpoint, and that's still `True`: the question consumers ask is whether the field is worth an entity.

Downstream in ha-pitboss this gates the "Startup error" binary sensor (and lets similar per-board gaps be handled without a hardcoded board list), keeping the board-knowledge boundary where REVIEW.md draws it: facts about boards live here, consumers just ask.

`uv run pytest` (916 passed), `ruff check`, `ruff format --check`, `mypy` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)