### PR TITLE
Record why Celsius probe targets read a degree low

### DIFF
--- a/pytboss/api.py
+++ b/pytboss/api.py
@@ -412,6 +412,26 @@ class PitBoss:
         actually working to.
 
         Probes with no target set are absent rather than present as `None`.
+
+        On a grill working in Celsius, a board-reported target can come back
+        one degree below what was asked for -- 63 set, 62 read -- and that is
+        correct rather than a rounding bug to fix here. The board stores
+        Fahrenheit whatever the panel is set to, and the vendor's own status
+        routine converts back with `floor((F - 32) / 1.8)`; pytboss runs that
+        routine verbatim rather than reimplementing it, so the value matches
+        what the vendor's app shows for the same grill. 46 of the 116 Celsius
+        targets between 5 and 120 land a degree low this way.
+
+        There is no lever on either side. The set command hands the board the
+        raw number -- the payload is byte-identical whichever unit the grill
+        is in, so the firmware does the conversion, not us -- and changing the
+        decode would mean disagreeing with the vendor's own reading of the
+        same frame.
+
+        The virtual data path above is lossless by comparison: `_to_fahrenheit`
+        and `_from_fahrenheit` both round, so a value written and read back
+        through the store survives. Probes 3 and 4 therefore do not drift on
+        any model, and probes 1 and 2 do wherever the board reports them.
         """
         fahrenheit = self._is_fahrenheit()
         targets: dict[int, int] = {}


### PR DESCRIPTION
Comment only, no behaviour change.

## Why

This keeps getting investigated. It came up in a session note here, it is behind the `floor` in ha-pitboss's `accepted_setpoints`, and it surfaced again as a parenthetical in dknowles2/ha-pitboss#394 ("63 → 62 is the board's own round trip"). Every pass reaches the same conclusion, and nothing in the tree says so.

It is also *systematic* enough to look like a rounding bug worth fixing, which is exactly why it keeps getting picked up:

```
Celsius targets 5-120: 46/116 come back changed
all drift is by: [1]
```

40% of the range, always by one degree, always downward.

## What is actually happening

The board stores Fahrenheit whatever the panel is set to. The vendor's own status routine converts back with `floor((F - 32) / 1.8)`, and pytboss runs that routine verbatim through `_evaljs` rather than reimplementing it — so 63 °C is stored as 145 °F and read back as `floor(62.77)` = 62.

## Why there is no lever

**Not on the write side.** The set command hands the board the raw number; the payload is byte-identical whichever unit the grill is in:

```
set-probe-1-temperature(63, fahrenheit=True)  -> FE0502000603FF
set-probe-1-temperature(63, fahrenheit=False) -> FE0502000603FF
```

So the firmware does the conversion, not us. There is no Fahrenheit value we could choose instead.

**Not on the read side.** Changing the decode means disagreeing with the vendor's own reading of the same frame — pytboss would report a number the vendor's app does not, for the same grill.

## The asymmetry worth knowing

The virtual data path is lossless: `_to_fahrenheit` and `_from_fahrenheit` both round, so 63 → 145 → 63 survives. That is why probes 3 and 4 never drift on any model, while probes 1 and 2 drift wherever the board reports `pNTarget` — which is every model for probe 1 and 26 of them for probe 2. The same grill can show both behaviours on different probes, which is the confusing part.

## Open, and needs hardware

I can show this matches the vendor's *app*, since that is the same JavaScript. Whether the grill's own **panel** also shows 62 is firmware, and I cannot check it. @dknowles2 — if the panel shows 63 while we show 62, this is worth reopening as a real disagreement with the appliance in front of the user. If it shows 62, we are exactly right and this comment stands as-is.

917 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)