### PR TITLE
Make four tests fail when the thing they name is broken

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1147,16 +1147,16 @@ async def test_on_vdata_received_accepts_a_decoded_object():
 
 
 @pytest.mark.parametrize(
-    "reply",
+    "reply,want",
     [
-        {},
-        {"sc_11": "", "sc_12": ""},
-        {"sc_11": STATE_HEX},
-        {"sc_12": TEMPS_HEX},
+        ({}, {}),
+        ({"sc_11": "", "sc_12": ""}, {}),
+        ({"sc_11": STATE_HEX}, STATE_DICT),
+        ({"sc_12": TEMPS_HEX}, TEMPS_DICT),
     ],
     ids=["empty", "blanked", "status_only", "temperatures_only"],
 )
-async def test_get_state_survives_a_partial_reply(reply):
+async def test_get_state_survives_a_partial_reply(reply, want):
     """The firmware blanks both frames while a command is in flight.
 
     `sendMCUCommand` clears `lastStatus.sc_11` and `sc_12` before it writes to
@@ -1168,7 +1168,10 @@ async def test_get_state_survives_a_partial_reply(reply):
     await pitboss.start()
     with mock.patch.object(conn, "send_command", AsyncMock(return_value=reply)):
         state = await pitboss.get_state()
-    assert isinstance(state, dict)
+    # The half that *is* present still parses. `isinstance(state, dict)` held
+    # even with both parse branches removed and an empty StateDict returned,
+    # so it proved only that nothing raised.
+    assert state == want
 
 
 async def test_get_uptime_does_not_cache_a_reply_it_cannot_read():

--- a/tests/test_grills.py
+++ b/tests/test_grills.py
@@ -174,12 +174,44 @@ def all_variants() -> list[grills_lib.Grill]:
 
 class TestGetGrills:
     def test_plain(self):
+        """The three things this does, rather than that it returned rows.
+
+        `assert len(grills) > 0` held whether or not any of them still
+        worked -- it is the shape REVIEW.md warns about, and it was the only
+        test for the library's main entry point.
+        """
         grills = list(grills_lib.get_grills())
         assert len(grills) > 0
 
+        # Models sold on two board generations appear once per board in the
+        # definitions; without a `control_board` each is yielded once, so a
+        # caller listing every supported model sees no duplicates.
+        names = [g.name for g in grills]
+        assert len(names) == len(set(names))
+
+        # Names the definitions carry but that cannot be driven.
+        for unsupported in grills_lib.UNSUPPORTED_MODELS:
+            assert unsupported not in names
+
+        # A board with no status-parsing routine cannot report anything, so
+        # its models are not offered at all.
+        assert all(g.control_board._status_js_func for g in grills)
+
     def test_with_control_board(self):
+        """That the filter filters, which is all this function does here.
+
+        The previous assertion -- that some grills came back -- passed with
+        the argument ignored entirely.
+        """
         grills = list(grills_lib.get_grills("PBL"))
         assert len(grills) > 0
+        assert {g.control_board.name for g in grills} == {"PBL"}
+
+        # And that it is a real narrowing rather than everything: another
+        # board's models are a different, non-empty set.
+        other = list(grills_lib.get_grills("PBM"))
+        assert other
+        assert {g.name for g in other}.isdisjoint({g.name for g in grills})
 
     @pytest.mark.parametrize("grill", all_variants(), ids=idfn)
     def test_js_commands(self, grill: grills_lib.Grill):

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -154,7 +154,13 @@ async def test_json_content_type_is_also_accepted(host, rpc):
     conn = HttpConnection(host)
     await conn.connect()
     try:
-        assert await conn.send_command("PB.GetState", {}) is not None
+        # The same literal the text/plain case asserts -- the claim is that
+        # the body decodes identically, which `is not None` would not have
+        # caught it failing to do.
+        assert await conn.send_command("PB.GetState", {}) == {
+            "sc_11": "FE0B",
+            "sc_12": "FE0C",
+        }
     finally:
         await conn.disconnect()
 

--- a/tests/test_ota.py
+++ b/tests/test_ota.py
@@ -109,6 +109,10 @@ async def test_get_boot_state_when_a_rollback_is_pending(mock_conn):
     }
     ota = OTA(mock_conn)
     result = await ota.get_boot_state()
+    # Without this the test is a tautology: `get_boot_state` passes the
+    # reply straight through, and the mock answers any method name -- so it
+    # passed with the RPC renamed to something that does not exist.
+    mock_conn.send_command.assert_awaited_once_with("OTA.GetBootState", {})
     assert result["is_committed"] is False
     assert result["commit_timeout"] == 300
 


### PR DESCRIPTION
Found by auditing the suite for assertions that hold whether or not the behaviour they are named for does. Each was confirmed by **breaking the library and watching the old assertion pass**.

## `TestGetGrills` — the case REVIEW.md warns about, still present

```py
def test_plain(self):
    assert len(grills) > 0

def test_with_control_board(self):
    assert len(grills) > 0
```

This is the only test for the library's main entry point.

`get_grills` does three things: skips boards with no status routine, skips `UNSUPPORTED_MODELS`, and de-duplicates models sold on two board generations. **None of the three was asserted.** Neither was the `control_board` filter — making the argument be ignored entirely left both tests green.

Now pinned: no duplicate names, no unsupported model present, every board has a status routine, the filter returns exactly that board, and another board's models are a different non-empty set.

## `test_get_state_survives_a_partial_reply`

```py
assert isinstance(state, dict)
```

The `status_only` and `temperatures_only` parameters exist to show the half that *is* present still parses. That assertion proved only that nothing raised — it passed with **both parse branches removed** and an empty `StateDict` returned. Each case now names the dict it expects.

## `test_get_boot_state_when_a_rollback_is_pending`

A tautology: `get_boot_state` passes the reply through unchanged and the mock answers any method name, so the test asserted values it had just set. Unlike its sibling it never pinned the call, and it passed with the RPC renamed to one that does not exist. There is no rollback-specific path in the library, so the name promised behaviour that was never there — pinning the call is what makes it worth keeping rather than deleting.

## `test_json_content_type_is_also_accepted`

`is not None`, where the claim is that a JSON body decodes the same as `text/plain`. An empty dict satisfied it. Now the same literal its sibling asserts.

## Verification

917 pass, `mypy .` clean, `ruff`/`ruff format` clean.

| Mutation | Old | New |
| --- | --- | --- |
| `get_grills` ignores the filter and the dedup | passed | 2 failed |
| `get_grills` stops skipping `UNSUPPORTED_MODELS` | passed | 5 failed |
| `get_state` drops both parse branches | passed | 2 failed |
| `get_boot_state` sends the wrong RPC | passed | 2 failed |

Companion to dknowles2/ha-pitboss#397.

🤖 Generated with [Claude Code](https://claude.com/claude-code)