### PR TITLE
Add pytboss.testing for building realistic grill state

### DIFF
--- a/pytboss/testing.py
+++ b/pytboss/testing.py
@@ -1,0 +1,268 @@
+"""Build realistic grill state for tests.
+
+Consumers of this library otherwise test against hand-written state
+dictionaries. That is fast and precise about the consumer's own reasoning,
+and blind to this library: a renamed key, a dropped field, or a board that
+never reported one in the first place looks identical to everything working
+until a user says otherwise.
+
+The helpers here synthesize a wire frame for a specific grill and hand it to
+that board's own parsing routine, so the state that comes back is what the
+library would really produce -- the same vendor JavaScript, the same
+per-board field set, the same conversions. Nothing here fakes a parse.
+
+    >>> from pytboss import grills, testing
+    >>> grill = grills.get_grill("PBV4PS2")
+    >>> state = testing.build_state(grill, grillTemp=275, moduleIsOn=True)
+    >>> state["grillTemp"]
+    275
+
+Frames are synthesized, not captured: the field *values* are ours, the
+layout and the decoding are the board's. A board that reads a field at an
+offset the vendor got wrong will produce the wrong value here too, which is
+the point -- see `DROPPED_STATUS_FIELDS` for the ones where that is known
+and handled.
+
+This module is part of the public API and is safe to import from a test
+suite. It is not imported by the library at runtime.
+"""
+
+from __future__ import annotations
+
+import re
+
+from .grills import (
+    DROPPED_STATUS_FIELDS,
+    DROPPED_TEMPERATURE_FIELDS,
+    Grill,
+    StateDict,
+)
+
+__all__ = [
+    "build_state",
+    "encode_flag",
+    "encode_temperature",
+    "status_frame",
+    "temperatures_frame",
+]
+
+
+def encode_temperature(value: int) -> str:
+    """A temperature as the boards carry it: one decimal digit per byte.
+
+    161 becomes "010601". Three digits, so the range the wire can express is
+    0-999; 960 is the boards' own no-reading sentinel and decodes to None.
+    """
+    if not 0 <= value <= 999:
+        raise ValueError(f"temperature {value} does not fit in three digits")
+    return "".join(f"0{digit}" for digit in f"{value:03d}")
+
+
+def encode_flag(value: bool) -> str:
+    """A boolean as the boards carry it, in one byte."""
+    return "01" if value else "00"
+
+
+class _Frame:
+    """A hex payload assembled in field order.
+
+    Positional: the routines read fixed offsets, so a field skipped without
+    reserving its bytes shifts everything after it. Fields are therefore
+    added in the order the board expects, and only when that board's frame
+    carries them.
+    """
+
+    def __init__(self, prefix: str) -> None:
+        self._parts: list[str] = [prefix]
+        self._index: dict[str, int] = {}
+
+    def __str__(self) -> str:
+        return "".join(self._parts)
+
+    def __contains__(self, field: str) -> bool:
+        return field in self._index
+
+    def add(self, field: str, value: str) -> None:
+        if field in self._index:
+            raise KeyError(f"{field} is already in the frame")
+        self._index[field] = len(self._parts)
+        self._parts.append(value)
+
+
+def _carries(js: str | None, field: str) -> bool:
+    """Whether a routine's frame reserves bytes for `field`.
+
+    Deliberately asks the raw source rather than the live code. A field the
+    vendor commented out of the returned object is still *read* from the
+    frame, so its bytes are still there -- treating it as absent would build
+    a frame that is short, and every offset after it would be wrong.
+
+    `ControlBoard.emits` answers the other question, which is whether the
+    parsed result will contain the field. The two differ, and both are
+    needed: one to lay the frame out, the other to know what to expect back.
+    """
+    return bool(js) and field in js  # type: ignore[operator]
+
+
+def _live(js: str | None) -> str:
+    return re.sub(r"//.*", "", re.sub(r"/\*.*?\*/", "", js or "", flags=re.DOTALL))
+
+
+# Field order of the status (FE0B) frame, as `(field, default, conditional)`.
+# A bool default is a one-byte flag, an int a three-byte temperature, a str
+# raw bytes. Conditional fields are the ones some boards' routines do not
+# read at all, and whose bytes those frames therefore do not reserve.
+_STATUS_LAYOUT: tuple[tuple[str, object, bool], ...] = (
+    ("p1Target", 191, False),
+    ("p2Target", 192, True),
+    ("p1Temp", 161, False),
+    ("p2Temp", 162, False),
+    ("p3Temp", 163, False),
+    ("p4Temp", 164, True),
+    ("smokerActTemp", 200, True),
+    ("grillTemp", 225, False),
+    ("condGrillTemp", "01", False),
+    ("moduleIsOn", True, False),
+    ("err1", False, False),
+    ("err2", False, False),
+    ("err3", False, False),
+    ("highTempErr", False, False),
+    ("fanErr", False, False),
+    ("hotErr", False, False),
+    ("motorErr", False, False),
+    ("noPellets", False, False),
+    ("erL", False, True),
+    ("fanState", False, False),
+    ("hotState", False, False),
+    ("motorState", False, False),
+    ("lightState", False, False),
+    ("primeState", False, True),
+    ("isFahrenheit", True, False),
+    # One byte, not a three-digit temperature: the recipe clock
+    # follows it, and encoding it wide shifts all of it.
+    ("recipeStep", "01", False),
+)
+
+_TEMPERATURES_LAYOUT: tuple[tuple[str, object, bool], ...] = (
+    ("p1Target", 191, False),
+    ("p2Target", 192, True),
+    ("p1Temp", 161, False),
+    ("p2Temp", 162, False),
+    ("p3Temp", 163, False),
+    ("p4Temp", 164, True),
+    ("smokerActTemp", 210, True),
+    ("grillSetTemp", 225, False),
+    ("grillTemp", 215, False),
+    ("isFahrenheit", True, False),
+)
+
+
+def _encode(field: str, value: object) -> str:
+    if isinstance(value, bool):
+        return encode_flag(value)
+    if isinstance(value, int):
+        return encode_temperature(value)
+    if isinstance(value, str):
+        return value
+    raise TypeError(f"cannot encode {field}={value!r}")
+
+
+def _build(
+    js: str | None,
+    prefix: str,
+    layout: tuple[tuple[str, object, bool], ...],
+    dropped: frozenset[str],
+    values: dict[str, object],
+) -> str:
+    unknown = set(values) - {field for field, _, _ in layout}
+    if unknown:
+        raise ValueError(f"not fields of the {prefix} frame: {sorted(unknown)}")
+    # Which source answers "does the frame carry this" differs by reply, and
+    # getting it wrong shifts every offset after the field. The status frame
+    # reserves bytes for fields the vendor commented out of the returned
+    # object -- they are still read -- so it asks the raw routine. The
+    # temperatures frame does not, so it asks live code only.
+    source = js if prefix == "FE0B" else _live(js)
+    frame = _Frame(prefix)
+    for field, default, conditional in layout:
+        if conditional and not (
+            _carries(source, field)
+            # A field this board is known to read from bytes that do not hold
+            # it. The frame reserves none for it, which is what makes the
+            # rest of the reply line up.
+            and field not in dropped
+        ):
+            continue
+        frame.add(field, _encode(field, values.get(field, default)))
+    # The recipe clock is three separate bytes rather than a temperature.
+    if prefix == "FE0B":
+        for part, default in (("recipeHours", "04"), ("recipeMinutes", "0C")):
+            frame.add(part, default)
+        frame.add("recipeSeconds", "3B")
+    frame.add("suffix", "FF")
+    return str(frame)
+
+
+def status_frame(grill: Grill, **values: object) -> str:
+    """A status (FE0B) payload this grill's board would accept.
+
+    Values are given in the board's own terms: temperatures as integers,
+    flags as booleans. Fields this board's frame does not carry are left out
+    rather than zero-filled, because the routine reads by offset.
+    """
+    board = grill.control_board
+    return _build(
+        board._status_js_func,
+        "FE0B",
+        _STATUS_LAYOUT,
+        DROPPED_STATUS_FIELDS.get(board.name, frozenset()),
+        values,
+    )
+
+
+def temperatures_frame(grill: Grill, **values: object) -> str:
+    """A temperatures (FE0C) payload this grill's board would accept."""
+    board = grill.control_board
+    return _build(
+        board._temperatures_js_func,
+        "FE0C",
+        _TEMPERATURES_LAYOUT,
+        DROPPED_TEMPERATURE_FIELDS.get(board.name, frozenset()),
+        values,
+    )
+
+
+def build_state(grill: Grill, **values: object) -> StateDict:
+    """The state this grill would report, parsed by its own board routine.
+
+    Both frames are synthesized and both are parsed, then folded together
+    the way the API folds a poll -- the boards answer with two independent
+    replies and each carries only part of the picture.
+
+    Any field named in `values` is applied to whichever frames carry it, so
+    a caller can ask for `grillTemp=275` without knowing which reply their
+    board reports it in.
+    """
+    every_field = {f for f, _, _ in _STATUS_LAYOUT} | {
+        f for f, _, _ in _TEMPERATURES_LAYOUT
+    }
+    # Checked up front rather than per frame: a field only one reply carries
+    # is legitimate, so neither frame alone can tell a typo from a field the
+    # other one owns.
+    if unknown := set(values) - every_field:
+        raise ValueError(f"no frame carries: {sorted(unknown)}")
+
+    state = StateDict()
+    for build, parse, layout in (
+        (status_frame, grill.control_board.parse_status, _STATUS_LAYOUT),
+        (
+            temperatures_frame,
+            grill.control_board.parse_temperatures,
+            _TEMPERATURES_LAYOUT,
+        ),
+    ):
+        fields = {field for field, _, _ in layout}
+        frame = build(grill, **{k: v for k, v in values.items() if k in fields})
+        if parsed := parse(frame):
+            state.update(parsed)  # type: ignore[typeddict-item]
+    return state

--- a/tests/test_grills.py
+++ b/tests/test_grills.py
@@ -8,6 +8,7 @@ import pytest
 from dukpy import JSRuntimeError
 
 from pytboss import grills as grills_lib
+from pytboss import testing
 from pytboss.exceptions import InvalidGrill
 
 TEMPERATURE_FIELDS = (
@@ -231,31 +232,14 @@ class TestGetGrills:
     def test_parse_temperatures(self, grill: grills_lib.Grill):
         assert grill.control_board._temperatures_js_func is not None
         js = JSFunc(grill.control_board._temperatures_js_func)
-        msg = Message()
-        # A dropped field reads bytes that don't hold it, so the frame reserves
-        # none for it.
         dropped = grills_lib.DROPPED_TEMPERATURE_FIELDS.get(
             grill.control_board.name, frozenset()
         )
-
-        # WARNING! THE ORDER HERE MATTERS!
-        msg.add("prefix", "FE0C")
-        msg.add("p1Target", "010901")
-        if js.has_key("p2Target"):
-            msg.add("p2Target", "010902")
-        msg.add("p1Temp", "010601")
-        msg.add("p2Temp", "010602")
-        msg.add("p3Temp", "010603")
-        if js.has_key("p4Temp"):
-            msg.add("p4Temp", "010604")
-        if js.has_key("smokerActTemp") and "smokerActTemp" not in dropped:
-            msg.add("smokerActTemp", "020100")
-        msg.add("grillSetTemp", "020205")
-        msg.add("grillTemp", "020105")
-        msg.add("isFahrenheit", "01")
-        msg.add("suffix", "FF")
-
-        temps = grill.control_board.parse_temperatures(str(msg))
+        # The layout lives in `pytboss.testing` so there is one copy of it --
+        # the helper consumers build their own state with is the one proved
+        # right here. What to *expect* back stays this test's business.
+        frame = testing.temperatures_frame(grill)
+        temps = grill.control_board.parse_temperatures(frame)
         want = {
             "p1Temp": 161,
             "p2Temp": 162,
@@ -276,11 +260,12 @@ class TestGetGrills:
         with debug_js(js):
             assert temps == dict(want)
 
-            msg["isFahrenheit"] = "00"
-            status = grill.control_board.parse_temperatures(str(msg))
+            status = grill.control_board.parse_temperatures(
+                testing.temperatures_frame(grill, isFahrenheit=False)
+            )
             assert status is not None
             for key in TEMPERATURE_FIELDS:
-                if key not in msg or key not in want:
+                if key not in want:
                     continue
 
                 temp = want[key]
@@ -290,57 +275,12 @@ class TestGetGrills:
 
     @pytest.mark.parametrize("grill", all_variants(), ids=idfn)
     def test_parse_state(self, grill: grills_lib.Grill):
-        msg = Message()
         assert grill.control_board._status_js_func is not None
         js = JSFunc(grill.control_board._status_js_func)
-        # A dropped field reads bytes that don't hold it, so the frame reserves
-        # none for it.
-        dropped = grills_lib.DROPPED_STATUS_FIELDS.get(
-            grill.control_board.name, frozenset()
-        )
-
-        # WARNING! THE ORDER HERE MATTERS!
-        msg.add("prefix", "FE0B")
-        msg.add("p1Target", "010901")
-        if js.has_key("p2Target", ignore_comments=False):
-            msg.add("p2Target", "010902")
-        msg.add("p1Temp", "010601")
-        msg.add("p2Temp", "010602")
-        msg.add("p3Temp", "010603")
-        if js.has_key("p4Temp", ignore_comments=False):
-            msg.add("p4Temp", "010604")
-        if (
-            js.has_key("smokerActTemp", ignore_comments=False)
-            and "smokerActTemp" not in dropped
-        ):
-            msg.add("smokerActTemp", "020200")
-        msg.add("grillTemp", "020205")
-        msg.add("condGrillTemp", "01")
-        msg.add("moduleIsOn", "01")
-        msg.add("err1", "00")
-        msg.add("err2", "00")
-        msg.add("err3", "00")
-        msg.add("highTempErr", "00")
-        msg.add("fanErr", "00")
-        msg.add("hotErr", "00")
-        msg.add("motorErr", "00")
-        msg.add("noPellets", "00")
-        if js.has_key("erL", ignore_comments=False):
-            msg.add("erL", "00")
-        msg.add("fanState", "00")
-        msg.add("hotState", "00")
-        msg.add("motorState", "00")
-        msg.add("lightState", "00")
-        if js.has_key("primeState", ignore_comments=False):
-            msg.add("primeState", "00")
-        msg.add("isFahrenheit", "01")
-        msg.add("recipeStep", "01")
-        msg.add("recipeHours", "04")
-        msg.add("recipeMinutes", "0C")
-        msg.add("recipeSeconds", "3B")
-        msg.add("suffix", "FF")
-
-        status = grill.control_board.parse_status(str(msg))
+        # See `test_parse_temperatures`: one copy of the layout, in the
+        # helper consumers use, proved right by the expectations below.
+        frame = testing.status_frame(grill)
+        status = grill.control_board.parse_status(frame)
         want = {
             "moduleIsOn": True,
             "err1": False,
@@ -378,28 +318,31 @@ class TestGetGrills:
         with debug_js(js):
             assert status == dict(want)
 
-            msg["condGrillTemp"] = "02"
-            status = grill.control_board.parse_status(str(msg))
+            status = grill.control_board.parse_status(
+                testing.status_frame(grill, condGrillTemp="02")
+            )
             assert status is not None
             assert "grillSetTemp" not in status
 
             error_keys = ["err1", "err2", "err3"]
             error_keys += ["highTempErr", "fanErr", "hotErr", "motorErr"]
             error_keys += ["noPellets", "erL"]
-            for key in error_keys:
-                if key in msg:
-                    msg[key] = "01"
-            status = grill.control_board.parse_status(str(msg))
+            status = grill.control_board.parse_status(
+                testing.status_frame(
+                    grill, **{k: True for k in error_keys if js.has_key(k, False)}
+                )
+            )
             assert status is not None
             for key in error_keys:
-                if key in msg:
+                if key in status:
                     assert status[key]  # type: ignore[literal-required]
 
-            msg["isFahrenheit"] = "00"
-            status = grill.control_board.parse_status(str(msg))
+            status = grill.control_board.parse_status(
+                testing.status_frame(grill, isFahrenheit=False)
+            )
             assert status is not None
             for key in TEMPERATURE_FIELDS:
-                if key not in msg or key not in want:
+                if key not in want:
                     continue
                 temp = want[key]
                 if js.converts_to_celsius():

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -1,0 +1,113 @@
+"""The frame builders, checked against every board's own parsing routine.
+
+These assert concrete values rather than that a parse happened: a frame
+whose fields are one slot out of place still parses, and still returns a
+dict, so anything weaker would pass on exactly the bug this module is most
+likely to have.
+"""
+
+import pytest
+
+from pytboss import grills, testing
+
+
+def idfn(arg):
+    if isinstance(arg, grills.Grill):
+        return f"{arg.control_board.name} {arg.name}"
+    return None
+
+
+def all_grills() -> list[grills.Grill]:
+    return list(grills.get_grills())
+
+
+def test_encode_temperature_is_one_decimal_digit_per_byte():
+    assert testing.encode_temperature(161) == "010601"
+    assert testing.encode_temperature(0) == "000000"
+    assert testing.encode_temperature(999) == "090909"
+    # The boards' no-reading sentinel, which decodes back to None.
+    assert testing.encode_temperature(960) == "090600"
+
+
+def test_encode_temperature_rejects_what_the_wire_cannot_carry():
+    with pytest.raises(ValueError):
+        testing.encode_temperature(1000)
+    with pytest.raises(ValueError):
+        testing.encode_temperature(-1)
+
+
+def test_encode_flag():
+    assert testing.encode_flag(True) == "01"
+    assert testing.encode_flag(False) == "00"
+
+
+@pytest.mark.parametrize("grill", all_grills(), ids=idfn)
+def test_build_state_round_trips_the_values_it_was_given(grill: grills.Grill):
+    """Every board, in its own unit, reporting what it was asked to.
+
+    A shifted frame is the failure mode here -- a field added where the
+    board reserves no bytes, or left out where it does -- and it shows up as
+    one field reading another's value rather than as an error.
+    """
+    want = {
+        "grillTemp": 275,
+        "grillSetTemp": 250,
+        "p1Temp": 145,
+        "p2Temp": 146,
+        "moduleIsOn": True,
+    }
+    state = testing.build_state(grill, isFahrenheit=True, **want)
+    for field, value in want.items():
+        assert state.get(field) == value, (
+            f"{grill.name} on {grill.control_board.name}: {field} came back "
+            f"{state.get(field)!r}, wanted {value} -- a frame laid out wrong "
+            f"reads a neighbouring field"
+        )
+
+
+@pytest.mark.parametrize("grill", all_grills(), ids=idfn)
+def test_build_state_reports_only_what_the_board_can_report(grill: grills.Grill):
+    """The state matches `emits()`, which is the library's own answer.
+
+    Two independent routes to the same question: one reads the routine's
+    source, the other runs it. They disagreeing means one of them is wrong.
+    """
+    state = testing.build_state(grill)
+    board = grill.control_board
+    for field in state:
+        assert board.emits(field), (
+            f"{grill.name}: parsing produced {field}, which emits() denies"
+        )
+
+
+@pytest.mark.parametrize("grill", all_grills(), ids=idfn)
+def test_the_no_reading_sentinel_comes_back_as_none(grill: grills.Grill):
+    """960 is what an unplugged probe reads, and it must not become 960."""
+    state = testing.build_state(grill, p1Temp=960)
+    assert state.get("p1Temp") is None
+
+
+def test_a_field_no_frame_carries_is_an_error():
+    grill = grills.get_grill("PBV4PS2")
+    with pytest.raises(ValueError, match="no frame carries"):
+        testing.build_state(grill, notARealField=1)
+
+
+def test_boards_that_convert_hand_back_celsius():
+    """The split is real, so a caller cannot assume either unit.
+
+    Verified against the whole catalogue rather than one model, because
+    which boards convert is read off their routines and can change with a
+    definitions refresh.
+    """
+    converted = as_sent = 0
+    for grill in all_grills():
+        state = testing.build_state(grill, isFahrenheit=False, grillTemp=275)
+        if state.get("grillTemp") == 135:
+            converted += 1
+        elif state.get("grillTemp") == 275:
+            as_sent += 1
+        else:
+            pytest.fail(f"{grill.name} reported {state.get('grillTemp')!r}")
+    assert converted and as_sent
+    assert converted + as_sent == len(all_grills())


### PR DESCRIPTION
## Why

Consumers test against hand-written state dictionaries. The Home Assistant integration is the case in point: it mocks `PitBoss` entirely, so its 98% line coverage measures its reasoning about state **this library has never produced**. A renamed key, a dropped field, or a board that never reported one in the first place looks identical to everything working — until a user says otherwise. That is how dknowles2/ha-pitboss#391 was found.

## What

```py
>>> from pytboss import grills, testing
>>> grill = grills.get_grill("PBV4PS2")
>>> state = testing.build_state(grill, grillTemp=275, moduleIsOn=True)
>>> state["grillTemp"]
275
```

`build_state` synthesizes both wire frames for a specific grill and hands them to that board's own parsing routine. What comes back is what the library would really produce — same vendor JavaScript, same per-board field set, same conversions. The values are the caller's; the layout and the decoding are the board's. Nothing here fakes a parse.

Also public: `status_frame`, `temperatures_frame`, `encode_temperature`, `encode_flag`.

## One copy of the layout

The frame layout already existed, inline in `test_parse_state` and `test_parse_temperatures`. Those now build through the helper and keep their own expectations — so there is a single copy, it is the one consumers get, and it is proved right by the same 607 assertions as before across every model/board pairing.

That split is deliberate: `testing` owns *how to build a frame*, the tests own *what to expect back*. Converting the other way round — having the helper assert — would have made it circular.

## Two traps, both found during the conversion

Both shift every offset after the field, and both surface as one field silently reading another's value rather than as an error:

- **"Does the frame reserve bytes for this?" is a different question per reply.** The status frame reserves them for fields the vendor commented out of the returned object, because they are still *read*. The temperatures frame does not. Asking the raw source for both put three extra bytes into LBL and LFS temperature frames, and `grillTemp` came back reading `grillSetTemp` on nine models — 128/137 passing, which is exactly the kind of near-miss that reads as success.
- **`recipeStep` is one byte, not a three-digit temperature.** Encoding it wide shifted the recipe clock behind it (`recipeTime` 64 where 15179 was meant).

The existing assertions caught both during the conversion. That is the argument for doing it in this order rather than writing the helper and trusting it.

## Verification

1333 pass (was 917 — the new file adds 416, mostly the 137-way parametrizations), `mypy .` clean, `ruff`/`ruff format` clean.

`tests/test_testing.py` asserts concrete values rather than that a parse happened, since a frame one slot out of place still parses and still returns a dict. It also cross-checks the result against `ControlBoard.emits()` — two independent routes to "what does this board report", one reading the routine's source and one running it.

Across the catalogue: 82 boards convert 275 °F to 135 °C and 55 report as sent, which matches the Celsius split the integration ships against.

## Next

This is what lets ha-pitboss drive its entities from genuinely parsed state instead of hand-written dictionaries. That change goes up separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)