### PR TITLE
Publish to PyPI without a long-lived token

### DIFF
--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -10,20 +10,33 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    # Trusted publishing: PyPI mints a token good for fifteen minutes against
+    # this repository and this workflow file, so there is no long-lived
+    # credential in the repository secrets to leak or rotate. The environment
+    # is what the trusted publisher is keyed on, alongside the filename, and
+    # is where an approval gate would go if we ever want one.
+    environment:
+      name: pypi
+      url: https://pypi.org/p/pytboss
+
+    permissions:
+      # The only permission this needs, and the one that makes it work: it
+      # lets the job ask GitHub for the OIDC token it trades with PyPI.
+      id-token: write
+
     steps:
       - uses: actions/checkout@v7
       - name: Set up Python
         uses: actions/setup-python@v7
         with:
           python-version: '3.x'
-      - name: Install dependencies
+      - name: Build
         run: |
           python -m pip install --upgrade pip
-          pip install setuptools wheel twine build
-      - name: Build and publish
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
-        run: |
+          pip install build
           python -m build
-          twine upload dist/*
+      # Deliberately no `password:`. Passing one turns trusted publishing off
+      # and takes the attestations with it -- they are only generated for a
+      # secretless upload.
+      - name: Publish
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
> [!IMPORTANT]
> **Do not merge until the PyPI side is configured.** The first release after this lands will fail without it. Exact values below — it takes about a minute.

## Short answer to "should we update it"

Yes. Two concrete gains, not just fashion.

**No long-lived credential.** `PYPI_TOKEN` is the only long-lived *publishing* credential either repo still has. Trusted publishing has PyPI mint a token valid for fifteen minutes, keyed on this repository and this workflow filename. Nothing to leak, nothing to rotate.

**Provenance, which we currently get none of.** `pypa/gh-action-pypi-publish` generates and uploads PEP 740 attestations **by default** — but only for a secretless upload. Passing a password disables trusted publishing and takes the attestations with it. Released files get a Provenance badge linking to the run that built them, and the signing identity becomes queryable through PyPI's Integrity API.

Worth noting we are already half-way there as an org: ha-pitboss's `release.yml` asks for `id-token: write`, which is what produces the sigstore attestations on its release assets. This workflow is the one place left doing it the old way.

## What changed

```diff
+    environment:
+      name: pypi
+      url: https://pypi.org/p/pytboss
+    permissions:
+      id-token: write
...
-      - name: Build and publish
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
-        run: |
-          python -m build
-          twine upload dist/*
+      - name: Build
+        run: |
+          python -m pip install --upgrade pip
+          pip install build
+          python -m build
+      - name: Publish
+        uses: pypa/gh-action-pypi-publish@release/v1
```

`twine` and `setuptools`/`wheel` are no longer installed — the action handles the upload, and `build` brings its own backend.

**Checkout and setup are deliberately unchanged.** The version comes from the git tag via vcs-versioning; that resolves correctly today (2026.8.6 published as `2026.8.6`, not a `.devN`), and this is not the change to find out otherwise with.

## What you need to do, and it has to come first

At https://pypi.org/manage/project/pytboss/settings/publishing/ — add a GitHub publisher:

| Field | Value |
| --- | --- |
| Owner | `dknowles2` |
| Repository | `pytboss` |
| Workflow name | `publish-python.yml` |
| Environment | `pypi` |

The environment name has to match the workflow exactly or the OIDC exchange is rejected. GitHub creates the `pypi` environment on first use; if you want an approval gate before anything reaches PyPI, that is where it goes.

Once that exists, ping me and I will merge. `PYPI_TOKEN` can then be deleted from the repository secrets — worth doing rather than leaving a live token lying around unused.

## Verified

Workflow parses; `permissions`, `environment` and step order are as intended; no `secrets.` reference remains in the file.

I cannot test the OIDC exchange without publishing a real version, so the genuine proof is the next release. If it fails it fails loudly at the upload step with nothing published, which is the safe direction — and reverting this file restores the old path immediately.

## Sources

- [PyPI Trusted Publishers documentation](https://docs.pypi.org/trusted-publishers/)
- [pypa/gh-action-pypi-publish](https://github.com/pypa/gh-action-pypi-publish)
- [PyPI now supports digital attestations](https://blog.pypi.org/posts/2024-11-14-pypi-now-supports-digital-attestations/)
- [PEP 740](https://peps.python.org/pep-0740/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)