### PR TITLE
Compute the CalVer version for release drafts automatically

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -5,10 +5,53 @@ name: Release Drafter
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   update_release_draft:
     runs-on: ubuntu-latest
+    permissions:
+      # Release Drafter creates/updates the draft release.
+      contents: write
+      pull-requests: read
     steps:
+      # Tags are the input to the version calculation below, and a shallow
+      # clone does not carry them.
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      # Release Drafter resolves $RESOLVED_VERSION by semver-bumping the last
+      # tag, which has no notion of the calendar: on the first release of a new
+      # month it would draft 2026.8.7 rather than 2026.9.0. Compute the CalVer
+      # here and hand it to the action, which uses an explicit `version` input
+      # in preference to its own resolver.
+      #
+      # Dates are UTC, matching the runner, so a release cut late in the last
+      # evening of a month in a western timezone lands in the next month.
+      - name: Compute CalVer
+        id: calver
+        run: |
+          set -euo pipefail
+          prefix="$(date -u +%Y).$(date -u +%-m)"
+          # Tags are unpadded (2026.8.6, not 2026.08.06), so sort numerically
+          # on the patch field rather than lexically -- otherwise .10 would
+          # sort below .9.
+          patch="$(git tag --list "${prefix}.*" \
+            | awk -F. '$1 "." $2 == "'"${prefix}"'" {print $3}' \
+            | sort -n | tail -n1)"
+          if [ -z "${patch}" ]; then
+            # First release of this month: reset the patch field.
+            version="${prefix}.0"
+          else
+            version="${prefix}.$((patch + 1))"
+          fi
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          echo "Next version: ${version}"
+
       - uses: release-drafter/release-drafter@v7.7.0
+        with:
+          version: ${{ steps.calver.outputs.version }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Release Drafter resolves `$RESOLVED_VERSION` by semver-bumping the previous tag, which has no notion of the calendar. On the first release of a new month it drafted `2026.8.7` where the project's CalVer scheme calls for `2026.9.0`, so the version had to be corrected by hand whenever a month or year rolled over.

This computes the version in the workflow instead and passes it to the action, which prefers an explicit `version` input over its own resolver. The patch field resets to `0` when no tag exists for the current year and month, and otherwise continues from the highest existing patch.

Verified against the existing tag history:

| prefix | result |
| --- | --- |
| `2026.8` (has `.0`–`.6`) | `2026.8.7` |
| `2026.9` (none yet) | `2026.9.0` |
| `2027.1` (new year) | `2027.1.0` |
| `2024.10` (has `.0`–`.2`) | `2024.10.3` |

Notes:

- Tags are unpadded (`2026.8.6`, not `2026.08.06`), so patches are sorted numerically to keep `.10` above `.9`.
- The tag glob is guarded against prefix collisions, so `2024.1` does not absorb `2024.10.x`.
- Tags are the input to the calculation, so the checkout can no longer be shallow.
- Idempotent between publishes: a draft's tag is not created until the release is published, so re-running on every push to `main` recomputes the same version.
- Dates are UTC, matching the runner. A release cut late on the last evening of a month in a western timezone lands in the next month.
- Adds an explicit `permissions:` block; the workflow previously relied on the repository's default token scope.

No change is needed in `.github/release-drafter.yml` — `$RESOLVED_VERSION` in the name and tag templates picks up the injected version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)